### PR TITLE
fix: quality sweep — code review, security, and docs fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Dispatch reads your local Copilot CLI session store and presents every past sess
 - **Refresh** (`r`) — reload the session store without restarting
 - **Demo mode** — `dispatch --demo` with synthetic data for experimentation
 - **Self-update** — `dispatch update` checks GitHub Releases and upgrades in-place; background update check notifies on new versions
-- **Maintenance** — `--rebuild-index` (manual rebuild of the session index via Copilot CLI PTY — repair action only), `--clear-cache` (reset config)
+- **Maintenance** — `--reindex` (manual rebuild of the session index via Copilot CLI PTY — repair action only), `--clear-cache` (reset config)
 - **Cross-platform** — Windows (amd64/arm64), macOS (amd64/arm64), Linux (amd64/arm64)
 
 ### Feature Highlights

--- a/internal/data/chronicle.go
+++ b/internal/data/chronicle.go
@@ -99,7 +99,11 @@ func ChronicleReindex(ctx context.Context, onLine func(line string)) error {
 		for {
 			n, rErr := ptty.Read(buf)
 			if n > 0 {
-				outCh <- string(buf[:n])
+				select {
+				case outCh <- string(buf[:n]):
+				case <-ctx.Done():
+					return
+				}
 			}
 			if rErr != nil {
 				return

--- a/internal/data/dbwatch.go
+++ b/internal/data/dbwatch.go
@@ -111,7 +111,15 @@ func (w *DBWatcher) loop() {
 				continue
 			}
 			if w.Poll() && w.onChange != nil {
-				w.onChange()
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							// Swallow panic so the watcher loop survives.
+							_ = r
+						}
+					}()
+					w.onChange()
+				}()
 			}
 		}
 	}

--- a/internal/data/plans.go
+++ b/internal/data/plans.go
@@ -147,7 +147,7 @@ func WriteContinuationPlan(sessionID string, remaining []string, summary string)
 	// Ensure the session directory exists (it may not if the session-state
 	// was created by the store but never had a plan written).
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("creating session dir: %w", err)
 	}
 

--- a/internal/data/store.go
+++ b/internal/data/store.go
@@ -784,6 +784,7 @@ func (s *Store) searchRefs(ctx context.Context, query string, limit int) []Searc
 
 	rows, err := s.db.QueryContext(ctx, q, args...)
 	if err != nil {
+		slog.Debug("searchRefs query failed", "error", err)
 		return nil
 	}
 	defer rows.Close() //nolint:errcheck // rows read-only
@@ -792,6 +793,7 @@ func (s *Store) searchRefs(ctx context.Context, query string, limit int) []Searc
 	for rows.Next() {
 		var r SearchResult
 		if err := rows.Scan(&r.Content, &r.SessionID, &r.SourceType, &r.SourceID); err != nil {
+			slog.Debug("searchRefs scan failed", "error", err)
 			continue
 		}
 		r.Rank = -100 // boost ref matches to top

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -619,6 +619,7 @@ func copyFile(src, dst string) error {
 
 	if _, err := io.Copy(out, in); err != nil {
 		_ = out.Close()
+		_ = os.Remove(dst)
 		return err
 	}
 


### PR DESCRIPTION
## Summary

Max-quality sweep across the entire codebase. All gates pass clean (build, test, vet, lint, gofumpt, govulncheck, deadcode).

### Changes

**Code fixes**:
- **chronicle.go**: Prevent goroutine blocking by respecting ctx.Done in PTY reader
- **dbwatch.go**: Recover panics in onChange callback so watcher loop survives
- **plans.go**: Tighten session-state dir permissions from 0755 to 0700
- **store.go**: Log searchRefs DB errors instead of silently swallowing them
- **update.go**: Clean up partial file on copyFile write failure

**Docs**:
- **README.md**: Fix stale --rebuild-index flag name to --reindex

### Verification

All pass: go build, go test (13 packages), go vet, golangci-lint, gofumpt, govulncheck, mage install