### PR TITLE
perf: improve session refresh with PRAGMA data_version and simplify reindex

### DIFF
--- a/internal/data/chronicle.go
+++ b/internal/data/chronicle.go
@@ -26,9 +26,6 @@ const (
 	// threshold is reached, giving the CLI time to fully settle.
 	startupGracePeriod = 2 * time.Second
 
-	// chronicleExpWait is how long to wait after sending /experimental on.
-	chronicleExpWait = 5 * time.Second
-
 	// chronicleReindexTimeout is the maximum time to wait for the reindex
 	// ETL to complete. Large session stores may take a while.
 	chronicleReindexTimeout = 120 * time.Second
@@ -213,19 +210,9 @@ func ChronicleReindex(ctx context.Context, onLine func(line string)) error {
 		return err
 	}
 
-	status("⏳ Enabling experimental features...")
-
-	// 2. Enable experimental mode (required for /chronicle commands).
-	if _, err := ptty.Write([]byte("/experimental on\r\n")); err != nil {
-		return fmt.Errorf("sending /experimental on: %w", err)
-	}
-	if err := collect(chronicleExpWait, 0); err != nil {
-		return err
-	}
-
 	status("⏳ Starting chronicle reindex...")
 
-	// 3. Send /chronicle reindex.
+	// 2. Send /chronicle reindex (no longer requires /experimental on).
 	if _, err := ptty.Write([]byte("/chronicle reindex\r\n")); err != nil {
 		return fmt.Errorf("sending /chronicle reindex: %w", err)
 	}
@@ -233,7 +220,7 @@ func ChronicleReindex(ctx context.Context, onLine func(line string)) error {
 		return err
 	}
 
-	// 4. Send /exit to shut down cleanly.
+	// 3. Send /exit to shut down cleanly.
 	ptty.Write([]byte("/exit\r\n")) //nolint:errcheck
 	if err := collect(chronicleExitWait, 0); err != nil {
 		return err

--- a/internal/data/dbwatch.go
+++ b/internal/data/dbwatch.go
@@ -1,6 +1,8 @@
 package data
 
 import (
+	"context"
+	"database/sql"
 	"os"
 	"sync"
 	"time"
@@ -8,19 +10,23 @@ import (
 	"github.com/jongio/dispatch/internal/platform"
 )
 
-// DBWatcher monitors the session store database for changes by checking
-// the WAL file modification time. It only polls when active (TUI focused)
-// to minimize resource usage.
+// DBWatcher monitors the session store database for changes. It uses
+// SQLite's PRAGMA data_version as the primary signal (increments on each
+// external commit) and falls back to WAL file modification time when the
+// database connection is unavailable. It only polls when active (TUI
+// focused) to minimize resource usage.
 type DBWatcher struct {
-	mu       sync.Mutex
-	active   bool
-	lastMod  time.Time
-	path     string // path to session-store.db
-	interval time.Duration
-	stop     chan struct{}
-	stopOnce sync.Once
-	onChange func() // callback fired when change detected
-	started  bool
+	mu          sync.Mutex
+	active      bool
+	lastMod     time.Time
+	lastDataVer int64  // last observed PRAGMA data_version value
+	path        string // path to session-store.db
+	interval    time.Duration
+	stop        chan struct{}
+	stopOnce    sync.Once
+	onChange    func() // callback fired when change detected
+	started     bool
+	db          *sql.DB // pinned read-only connection for data_version
 }
 
 // NewDBWatcher creates a watcher for the session store. The onChange callback
@@ -51,45 +57,130 @@ func (w *DBWatcher) SetActive(active bool) {
 // Stop permanently stops the watcher. It is safe to call multiple times.
 func (w *DBWatcher) Stop() {
 	w.stopOnce.Do(func() { close(w.stop) })
+	w.mu.Lock()
+	db := w.db
+	w.db = nil
+	w.mu.Unlock()
+	if db != nil {
+		_ = db.Close()
+	}
 }
 
-// ResetBaseline updates the last-known modification time to now so the
-// next poll cycle won't fire a spurious change notification. Use this
-// after a manual reload (e.g. rebuild index) to avoid duplicate refreshes.
+// ResetBaseline updates the last-known state so the next poll cycle won't
+// fire a spurious change notification. Use this after a manual reload
+// (e.g. rebuild index) to avoid duplicate refreshes.
 func (w *DBWatcher) ResetBaseline() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.lastMod = time.Now()
+	// Re-query data_version so the next poll sees the current value.
+	if w.db != nil {
+		var ver int64
+		if err := w.db.QueryRowContext(context.Background(), "PRAGMA data_version").Scan(&ver); err == nil {
+			w.lastDataVer = ver
+		}
+	}
 }
 
-// Poll checks the WAL file for changes and returns true if it has been
+// Poll checks the database for changes and returns true if it has been
 // modified since the last check. This is also called internally by the
 // loop but can be called manually for immediate checks.
 func (w *DBWatcher) Poll() bool {
 	if w.path == "" {
 		return false
 	}
-	// Check WAL first — active writes go there before checkpoint.
-	walPath := w.path + "-wal"
-	info, err := os.Stat(walPath)
-	if err != nil {
-		// No WAL — check main db file.
-		info, err = os.Stat(w.path)
-		if err != nil {
-			return false
+
+	// Primary: PRAGMA data_version (reliable, semantic change detection).
+	changed, ok := w.pollDataVersion()
+	if ok {
+		// data_version query succeeded — it is the authoritative signal.
+		return changed
+	}
+
+	// Fallback: WAL/DB file mtime (catches changes when DB connection
+	// isn't open yet or query fails).
+	return w.pollMtime()
+}
+
+// pollDataVersion uses PRAGMA data_version to detect committed changes
+// from other connections. Returns (changed, ok) where ok indicates whether
+// the query succeeded. When ok is false, the caller should fall back to mtime.
+func (w *DBWatcher) pollDataVersion() (changed bool, ok bool) {
+	w.mu.Lock()
+	db := w.db
+	w.mu.Unlock()
+
+	// Lazily open the connection on first poll when the file exists.
+	if db == nil {
+		if _, err := os.Stat(w.path); err != nil {
+			return false, false
 		}
+		var err error
+		db, err = sql.Open("sqlite", w.path+"?mode=ro")
+		if err != nil {
+			return false, false
+		}
+		// Pin to a single physical connection so data_version values
+		// are comparable across polls (SQLite requirement).
+		db.SetMaxOpenConns(1)
+		db.SetMaxIdleConns(1)
+		db.SetConnMaxLifetime(0)
+
+		w.mu.Lock()
+		w.db = db
+		w.mu.Unlock()
+	}
+
+	var ver int64
+	if err := db.QueryRowContext(context.Background(), "PRAGMA data_version").Scan(&ver); err != nil {
+		// Query failed — close connection and fall through to mtime.
+		w.mu.Lock()
+		w.db = nil
+		w.mu.Unlock()
+		_ = db.Close()
+		return false, false
 	}
 
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	mod := info.ModTime()
+	if w.lastDataVer == 0 {
+		w.lastDataVer = ver
+		return false, true // first check, establish baseline
+	}
+	if ver != w.lastDataVer {
+		w.lastDataVer = ver
+		return true, true
+	}
+	return false, true
+}
+
+// pollMtime checks WAL and DB file modification times as a fallback.
+func (w *DBWatcher) pollMtime() bool {
+	// Check both WAL and main DB, use the latest mtime.
+	var latest time.Time
+	walPath := w.path + "-wal"
+	if info, err := os.Stat(walPath); err == nil {
+		latest = info.ModTime()
+	}
+	if info, err := os.Stat(w.path); err == nil {
+		if mod := info.ModTime(); mod.After(latest) {
+			latest = mod
+		}
+	}
+	if latest.IsZero() {
+		return false
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
 	if w.lastMod.IsZero() {
-		w.lastMod = mod
+		w.lastMod = latest
 		return false // first check, establish baseline
 	}
-	if mod.After(w.lastMod) {
-		w.lastMod = mod
+	if latest.After(w.lastMod) {
+		w.lastMod = latest
 		return true
 	}
 	return false

--- a/internal/data/dbwatch_test.go
+++ b/internal/data/dbwatch_test.go
@@ -1,10 +1,14 @@
 package data
 
 import (
+	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	_ "modernc.org/sqlite"
 )
 
 func TestNewDBWatcher_DoesNotStart(t *testing.T) {
@@ -45,7 +49,7 @@ func TestSetActive_FalseSkipsPolling(t *testing.T) {
 	}
 }
 
-func TestPoll_BaselineThenChange(t *testing.T) {
+func TestPollMtime_BaselineThenChange(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "session-store.db")
 	walPath := dbPath + "-wal"
@@ -84,7 +88,7 @@ func TestPoll_BaselineThenChange(t *testing.T) {
 	}
 }
 
-func TestPoll_FallsBackToMainDB(t *testing.T) {
+func TestPollMtime_FallsBackToMainDB(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "session-store.db")
 
@@ -116,6 +120,47 @@ func TestPoll_FallsBackToMainDB(t *testing.T) {
 	}
 }
 
+func TestPollMtime_UsesMaxOfWalAndDb(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "session-store.db")
+	walPath := dbPath + "-wal"
+
+	// Create both files with past mtime.
+	past := time.Now().Add(-10 * time.Second)
+	if err := os.WriteFile(dbPath, []byte("db"), 0o644); err != nil {
+		t.Fatalf("creating db: %v", err)
+	}
+	if err := os.WriteFile(walPath, []byte("wal"), 0o644); err != nil {
+		t.Fatalf("creating wal: %v", err)
+	}
+	if err := os.Chtimes(dbPath, past, past); err != nil {
+		t.Fatalf("setting db mtime: %v", err)
+	}
+	if err := os.Chtimes(walPath, past, past); err != nil {
+		t.Fatalf("setting wal mtime: %v", err)
+	}
+
+	w := &DBWatcher{
+		path:     dbPath,
+		interval: time.Hour,
+		stop:     make(chan struct{}),
+	}
+	defer w.Stop()
+
+	// Baseline.
+	w.Poll()
+
+	// Modify only main DB (WAL stays old) — should still detect.
+	future := time.Now().Add(5 * time.Second)
+	if err := os.Chtimes(dbPath, future, future); err != nil {
+		t.Fatalf("touching db: %v", err)
+	}
+
+	if !w.Poll() {
+		t.Fatal("expected Poll to detect main DB change even when WAL is older")
+	}
+}
+
 func TestPoll_EmptyPath(t *testing.T) {
 	w := &DBWatcher{
 		path:     "",
@@ -126,6 +171,54 @@ func TestPoll_EmptyPath(t *testing.T) {
 
 	if w.Poll() {
 		t.Fatal("expected Poll to return false for empty path")
+	}
+}
+
+func TestPollDataVersion_DetectsCommit(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	// Create a real SQLite database with WAL mode.
+	writer, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("opening writer db: %v", err)
+	}
+	defer writer.Close()
+	writer.SetMaxOpenConns(1)
+
+	if _, err := writer.ExecContext(context.Background(), "PRAGMA journal_mode = WAL"); err != nil {
+		t.Fatalf("setting WAL mode: %v", err)
+	}
+	if _, err := writer.ExecContext(context.Background(), "CREATE TABLE t (id INTEGER PRIMARY KEY)"); err != nil {
+		t.Fatalf("creating table: %v", err)
+	}
+
+	w := &DBWatcher{
+		path:     dbPath,
+		interval: time.Hour,
+		stop:     make(chan struct{}),
+	}
+	defer w.Stop()
+
+	// First poll establishes data_version baseline.
+	if w.Poll() {
+		t.Fatal("expected first Poll to return false (baseline)")
+	}
+
+	// Write from external connection — this should increment data_version
+	// visible to the watcher's reader connection.
+	if _, err := writer.ExecContext(context.Background(), "INSERT INTO t (id) VALUES (1)"); err != nil {
+		t.Fatalf("inserting row: %v", err)
+	}
+
+	// Poll should detect the external commit.
+	if !w.Poll() {
+		t.Fatal("expected Poll to return true after external commit")
+	}
+
+	// Subsequent poll without changes returns false.
+	if w.Poll() {
+		t.Fatal("expected Poll to return false when no new commits")
 	}
 }
 
@@ -182,6 +275,59 @@ func TestResetBaseline(t *testing.T) {
 	}
 }
 
+func TestResetBaseline_ResetsDataVersion(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	// Create a real SQLite database.
+	writer, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("opening writer db: %v", err)
+	}
+	defer writer.Close()
+	writer.SetMaxOpenConns(1)
+
+	if _, err := writer.ExecContext(context.Background(), "PRAGMA journal_mode = WAL"); err != nil {
+		t.Fatalf("setting WAL mode: %v", err)
+	}
+	if _, err := writer.ExecContext(context.Background(), "CREATE TABLE t (id INTEGER PRIMARY KEY)"); err != nil {
+		t.Fatalf("creating table: %v", err)
+	}
+
+	w := &DBWatcher{
+		path:     dbPath,
+		interval: time.Hour,
+		stop:     make(chan struct{}),
+	}
+	defer w.Stop()
+
+	// Establish baseline.
+	w.Poll()
+
+	// External write.
+	if _, err := writer.ExecContext(context.Background(), "INSERT INTO t (id) VALUES (1)"); err != nil {
+		t.Fatalf("inserting row: %v", err)
+	}
+
+	// Detect change.
+	if !w.Poll() {
+		t.Fatal("expected change detection")
+	}
+
+	// Another write.
+	if _, err := writer.ExecContext(context.Background(), "INSERT INTO t (id) VALUES (2)"); err != nil {
+		t.Fatalf("inserting row: %v", err)
+	}
+
+	// ResetBaseline should update data_version baseline too.
+	w.ResetBaseline()
+
+	// Poll should NOT fire for the write that happened before reset.
+	if w.Poll() {
+		t.Fatal("expected Poll to return false after ResetBaseline")
+	}
+}
+
 func TestStop_TerminatesLoop(t *testing.T) {
 	w := &DBWatcher{
 		path:     "nonexistent",
@@ -199,4 +345,47 @@ func TestStop_TerminatesLoop(t *testing.T) {
 
 	// Give the goroutine time to exit.
 	time.Sleep(30 * time.Millisecond)
+}
+
+func TestStop_ClosesDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	// Create a real SQLite database so the watcher opens a connection.
+	writer, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("opening db: %v", err)
+	}
+	if _, err := writer.ExecContext(context.Background(), "CREATE TABLE t (id INTEGER)"); err != nil {
+		t.Fatalf("creating table: %v", err)
+	}
+	writer.Close()
+
+	w := &DBWatcher{
+		path:     dbPath,
+		interval: time.Hour,
+		stop:     make(chan struct{}),
+	}
+
+	// Poll to trigger lazy DB open.
+	w.Poll()
+
+	w.mu.Lock()
+	hasDB := w.db != nil
+	w.mu.Unlock()
+
+	if !hasDB {
+		t.Fatal("expected watcher to have opened DB connection")
+	}
+
+	// Stop should close the connection.
+	w.Stop()
+
+	w.mu.Lock()
+	hasDB = w.db != nil
+	w.mu.Unlock()
+
+	if hasDB {
+		t.Fatal("expected watcher DB to be nil after Stop")
+	}
 }


### PR DESCRIPTION
## Summary

Improves dispatch's session store change detection reliability and simplifies the chronicle reindex flow.

## Changes

### DBWatcher: PRAGMA data_version (primary change detection)

The watcher now uses SQLite's \PRAGMA data_version\ as the primary mechanism to detect external commits to the session store. This integer increments on every committed write from another connection, which is far more reliable than polling WAL file modification times (those can be stale after checkpoints or misleading across platforms).

Key improvements:
- Pinned single-connection pool ensures data_version values are comparable across polls (SQLite requirement)
- Falls back to mtime (using max of WAL and main DB) when the DB connection isn't available yet
- \Stop()\ properly closes the watcher DB connection
- \ResetBaseline()\ resets both data_version and mtime baselines

### Chronicle reindex: remove /experimental on

\/chronicle reindex\ no longer requires experimental mode. Removing that step saves ~5-7s per reindex and eliminates a fragile PTY interaction that could fail if the CLI's gating changed.

### Tests

- \TestPollDataVersion_DetectsCommit\: verifies real SQLite writer/reader pair
- \TestPollMtime_UsesMaxOfWalAndDb\: verifies both WAL and DB file are checked
- \TestResetBaseline_ResetsDataVersion\: ensures reset covers data_version
- \TestStop_ClosesDB\: verifies resource cleanup on shutdown