### PR TITLE
perf+quality: optimize session queries and improve test quality

### DIFF
--- a/internal/data/mq_coverage_test.go
+++ b/internal/data/mq_coverage_test.go
@@ -86,41 +86,26 @@ func TestLastReindexTime_NoStore(t *testing.T) {
 }
 
 func TestLastReindexTime_WithDBFile(t *testing.T) {
-	// Create a fake session store file structure.
+	// Use DISPATCH_DB to point SessionStorePath at our temp file.
 	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
-	t.Setenv("USERPROFILE", tmp)
-	localAppData := filepath.Join(tmp, "AppData", "Local")
-	t.Setenv("LOCALAPPDATA", localAppData)
-
-	// Create the session store path structure for Windows.
-	storeDir := filepath.Join(localAppData, "github-copilot", "github-copilot-cli")
-	if err := os.MkdirAll(storeDir, 0o755); err != nil {
-		t.Fatalf("creating store dir: %v", err)
-	}
-	storePath := filepath.Join(storeDir, "sessions.db")
+	storePath := filepath.Join(tmp, "session-store.db")
 	if err := os.WriteFile(storePath, []byte("fake"), 0o644); err != nil {
 		t.Fatalf("writing fake store: %v", err)
 	}
+	t.Setenv("DISPATCH_DB", storePath)
 
 	got := LastReindexTime()
-	// The function should return the mtime of the file, or zero if path
-	// resolution fails. We verify it doesn't panic.
-	_ = got
+	if got.IsZero() {
+		t.Error("LastReindexTime() returned zero time, want DB file mtime")
+	}
+	if time.Since(got) > 5*time.Second {
+		t.Errorf("LastReindexTime() = %v, expected within last 5s", got)
+	}
 }
 
 func TestLastReindexTime_WithWALFile(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
-	t.Setenv("USERPROFILE", tmp)
-	localAppData := filepath.Join(tmp, "AppData", "Local")
-	t.Setenv("LOCALAPPDATA", localAppData)
-
-	storeDir := filepath.Join(localAppData, "github-copilot", "github-copilot-cli")
-	if err := os.MkdirAll(storeDir, 0o755); err != nil {
-		t.Fatalf("creating store dir: %v", err)
-	}
-	storePath := filepath.Join(storeDir, "sessions.db")
+	storePath := filepath.Join(tmp, "session-store.db")
 	if err := os.WriteFile(storePath, []byte("fake"), 0o644); err != nil {
 		t.Fatalf("writing fake store: %v", err)
 	}
@@ -130,24 +115,20 @@ func TestLastReindexTime_WithWALFile(t *testing.T) {
 	if err := os.WriteFile(walPath, []byte("wal-data"), 0o644); err != nil {
 		t.Fatalf("writing fake WAL: %v", err)
 	}
+	t.Setenv("DISPATCH_DB", storePath)
 
 	got := LastReindexTime()
-	// Should return WAL mtime since WAL exists with size > 0.
-	_ = got
+	if got.IsZero() {
+		t.Error("LastReindexTime() returned zero time, want WAL file mtime")
+	}
+	if time.Since(got) > 5*time.Second {
+		t.Errorf("LastReindexTime() = %v, expected within last 5s", got)
+	}
 }
 
 func TestLastReindexTime_EmptyWAL(t *testing.T) {
 	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
-	t.Setenv("USERPROFILE", tmp)
-	localAppData := filepath.Join(tmp, "AppData", "Local")
-	t.Setenv("LOCALAPPDATA", localAppData)
-
-	storeDir := filepath.Join(localAppData, "github-copilot", "github-copilot-cli")
-	if err := os.MkdirAll(storeDir, 0o755); err != nil {
-		t.Fatalf("creating store dir: %v", err)
-	}
-	storePath := filepath.Join(storeDir, "sessions.db")
+	storePath := filepath.Join(tmp, "session-store.db")
 	if err := os.WriteFile(storePath, []byte("fake"), 0o644); err != nil {
 		t.Fatalf("writing fake store: %v", err)
 	}
@@ -157,9 +138,15 @@ func TestLastReindexTime_EmptyWAL(t *testing.T) {
 	if err := os.WriteFile(walPath, []byte{}, 0o644); err != nil {
 		t.Fatalf("writing empty WAL: %v", err)
 	}
+	t.Setenv("DISPATCH_DB", storePath)
 
 	got := LastReindexTime()
-	_ = got
+	if got.IsZero() {
+		t.Error("LastReindexTime() returned zero time, want DB file mtime (empty WAL fallback)")
+	}
+	if time.Since(got) > 5*time.Second {
+		t.Errorf("LastReindexTime() = %v, expected within last 5s", got)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -340,11 +327,13 @@ func TestChronicleReindex_NoBinary(t *testing.T) {
 	// Also ensure copilot/ghcs are not in PATH.
 	t.Setenv("PATH", t.TempDir())
 
-	// This test may or may not return ErrCopilotNotFound depending on
-	// whether the system actually has Copilot CLI installed. We just
-	// verify it doesn't panic and returns a deterministic error type
-	// when the binary is genuinely not found.
-	_ = time.Now() // use time to avoid unused import
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := ChronicleReindex(ctx, nil)
+	if !errors.Is(err, ErrCopilotNotFound) {
+		t.Errorf("ChronicleReindex() = %v, want ErrCopilotNotFound", err)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/data/store.go
+++ b/internal/data/store.go
@@ -244,7 +244,7 @@ func escapeLIKE(s string) string {
 // Each value is COALESCE'd to empty-string so that SQLite's multi-arg MAX()
 // never sees NULL (which would poison the result to NULL).
 const lastActiveExpr = `MAX(
-	COALESCE((SELECT MAX(t.timestamp) FROM turns t WHERE t.session_id = s.id), ''),
+	COALESCE(tc.last_turn_at, ''),
 	COALESCE(s.updated_at, ''),
 	COALESCE(s.created_at, '')
 )`
@@ -261,8 +261,8 @@ func (fb *filterBuilder) apply(f FilterOptions) {
 	// Sessions with activity in any of these tables are kept even if turns
 	// haven't been recorded (e.g. MCP / sub-agent work).
 	fb.wheres = append(fb.wheres,
-		`(EXISTS (SELECT 1 FROM turns t WHERE t.session_id = s.id)`+
-			` OR EXISTS (SELECT 1 FROM session_files sf3 WHERE sf3.session_id = s.id)`+
+		`(COALESCE(tc.turn_count, 0) > 0`+
+			` OR COALESCE(fc.file_count, 0) > 0`+
 			` OR EXISTS (SELECT 1 FROM checkpoints cp2 WHERE cp2.session_id = s.id)`+
 			` OR EXISTS (SELECT 1 FROM session_refs sr3 WHERE sr3.session_id = s.id))`)
 
@@ -382,7 +382,7 @@ var sessionColumnsSuffix = lastActiveExpr + ` AS last_active_at,
 
 // countJoins provides the LEFT JOINs for pre-aggregated turn and file counts.
 // Every query that uses sessionColumnsSuffix must include these joins.
-const countJoins = ` LEFT JOIN (SELECT session_id, COUNT(*) AS turn_count FROM turns GROUP BY session_id) tc ON tc.session_id = s.id` +
+const countJoins = ` LEFT JOIN (SELECT session_id, COUNT(*) AS turn_count, MAX(timestamp) AS last_turn_at FROM turns GROUP BY session_id) tc ON tc.session_id = s.id` +
 	` LEFT JOIN (SELECT session_id, COUNT(DISTINCT file_path) AS file_count FROM session_files GROUP BY session_id) fc ON fc.session_id = s.id`
 
 // sessionColumns returns the full SELECT column list, including host_type

--- a/internal/data/workstatus.go
+++ b/internal/data/workstatus.go
@@ -145,10 +145,10 @@ func ScanWorkStatus(sessionIDs []string, progressFn func(completed, total int)) 
 			result[id] = r
 			completed++
 			c := int(completed)
-			mu.Unlock()
 			if progressFn != nil {
 				progressFn(c, n)
 			}
+			mu.Unlock()
 			return nil
 		})
 	}

--- a/internal/data/workstatus.go
+++ b/internal/data/workstatus.go
@@ -6,7 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // Section name constants for plan.md header-based task parsing.
@@ -124,14 +128,31 @@ func ScanWorkStatusQuick(planMap map[string]bool) map[string]WorkStatusResult {
 func ScanWorkStatus(sessionIDs []string, progressFn func(completed, total int)) map[string]WorkStatusResult {
 	n := len(sessionIDs)
 	result := make(map[string]WorkStatusResult, n)
-
-	for i, id := range sessionIDs {
-		result[id] = analyseSession(id)
-
-		if progressFn != nil {
-			progressFn(i+1, n)
-		}
+	if n == 0 {
+		return result
 	}
+
+	var mu sync.Mutex
+	var completed int64
+
+	var g errgroup.Group
+	g.SetLimit(runtime.NumCPU())
+
+	for _, id := range sessionIDs {
+		g.Go(func() error {
+			r := analyseSession(id)
+			mu.Lock()
+			result[id] = r
+			completed++
+			c := int(completed)
+			mu.Unlock()
+			if progressFn != nil {
+				progressFn(c, n)
+			}
+			return nil
+		})
+	}
+	_ = g.Wait()
 	return result
 }
 

--- a/internal/platform/coverage_test.go
+++ b/internal/platform/coverage_test.go
@@ -102,47 +102,6 @@ func TestBuildResumeArgs_EmptySessionIDWithFlags(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// ResumeConfig fields
-// ---------------------------------------------------------------------------
-
-func TestResumeConfigFields(t *testing.T) {
-	cfg := ResumeConfig{
-		YoloMode:      true,
-		Agent:         "test-agent",
-		Model:         "test-model",
-		Terminal:      "test-terminal",
-		CustomCommand: "test-command",
-		Cwd:           "/tmp",
-		LaunchStyle:   LaunchStyleWindow,
-		PaneDirection: "down",
-	}
-	if !cfg.YoloMode {
-		t.Error("YoloMode should be true")
-	}
-	if cfg.Agent != "test-agent" {
-		t.Errorf("Agent = %q, want 'test-agent'", cfg.Agent)
-	}
-	if cfg.Model != "test-model" {
-		t.Errorf("Model = %q, want 'test-model'", cfg.Model)
-	}
-	if cfg.Terminal != "test-terminal" {
-		t.Errorf("Terminal = %q, want 'test-terminal'", cfg.Terminal)
-	}
-	if cfg.CustomCommand != "test-command" {
-		t.Errorf("CustomCommand = %q, want 'test-command'", cfg.CustomCommand)
-	}
-	if cfg.Cwd != "/tmp" {
-		t.Errorf("Cwd = %q, want '/tmp'", cfg.Cwd)
-	}
-	if cfg.LaunchStyle != LaunchStyleWindow {
-		t.Errorf("LaunchStyle = %q, want %q", cfg.LaunchStyle, LaunchStyleWindow)
-	}
-	if cfg.PaneDirection != "down" {
-		t.Errorf("PaneDirection = %q, want 'down'", cfg.PaneDirection)
-	}
-}
-
 func TestLaunchStyleConstants(t *testing.T) {
 	if LaunchStyleTab != "" {
 		t.Errorf("LaunchStyleTab = %q, want empty", LaunchStyleTab)

--- a/internal/platform/mq_coverage_test.go
+++ b/internal/platform/mq_coverage_test.go
@@ -160,4 +160,3 @@ func TestDefaultTerminal_Windows(t *testing.T) {
 		t.Errorf("DefaultTerminal() = %q, want %q or %q", terminal, termWindowsTerminal, termConhost)
 	}
 }
-

--- a/internal/platform/mq_coverage_test.go
+++ b/internal/platform/mq_coverage_test.go
@@ -3,6 +3,7 @@
 package platform
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -36,15 +37,15 @@ func TestBuildStartCmdLine_PowerShell(t *testing.T) {
 		t.Fatal("buildStartCmdLine returned empty string")
 	}
 	// Should include the shell path.
-	if !containsStr(got, shell.Path) {
+	if !strings.Contains(got, shell.Path) {
 		t.Errorf("cmd line should contain shell path %q", shell.Path)
 	}
 	// Should use -Command for PowerShell.
-	if !containsStr(got, "-Command") {
+	if !strings.Contains(got, "-Command") {
 		t.Error("cmd line should use -Command for PowerShell")
 	}
 	// Should include -NoLogo from shell.Args.
-	if !containsStr(got, "-NoLogo") {
+	if !strings.Contains(got, "-NoLogo") {
 		t.Error("cmd line should include -NoLogo from shell.Args")
 	}
 }
@@ -55,7 +56,7 @@ func TestBuildStartCmdLine_Cmd(t *testing.T) {
 
 	got := buildStartCmdLine(shell, resumeCmd)
 
-	if !containsStr(got, "/k") {
+	if !strings.Contains(got, "/k") {
 		t.Error("cmd line should use /k for cmd.exe")
 	}
 }
@@ -66,24 +67,24 @@ func TestBuildStartCmdLine_Bash(t *testing.T) {
 
 	got := buildStartCmdLine(shell, resumeCmd)
 
-	if !containsStr(got, "-c") {
+	if !strings.Contains(got, "-c") {
 		t.Error("cmd line should use -c for bash")
 	}
-	if !containsStr(got, "--login") {
+	if !strings.Contains(got, "--login") {
 		t.Error("cmd line should include --login from shell.Args")
 	}
 	// Backslashes should be converted to forward slashes for Git Bash,
 	// and double quotes should become single quotes for bash literal quoting.
-	if containsStr(got, `C:\Users`) {
+	if strings.Contains(got, `C:\Users`) {
 		t.Error("cmd line should convert backslashes to forward slashes for Git Bash")
 	}
-	if !containsStr(got, `C:/Users`) {
+	if !strings.Contains(got, `C:/Users`) {
 		t.Error("cmd line should contain forward-slash paths for Git Bash")
 	}
-	if containsStr(got, `"C:/Users`) {
+	if strings.Contains(got, `"C:/Users`) {
 		t.Error("cmd line should use single quotes (not double) for bash path quoting")
 	}
-	if !containsStr(got, `'C:/Users`) {
+	if !strings.Contains(got, `'C:/Users`) {
 		t.Error("cmd line should contain single-quoted paths for Git Bash")
 	}
 }
@@ -160,15 +161,3 @@ func TestDefaultTerminal_Windows(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// containsStr helper (avoid importing strings in test file)
-// ---------------------------------------------------------------------------
-
-func containsStr(haystack, needle string) bool {
-	for i := 0; i <= len(haystack)-len(needle); i++ {
-		if haystack[i:i+len(needle)] == needle {
-			return true
-		}
-	}
-	return false
-}


### PR DESCRIPTION
## Summary

Swarm session resolving **#109** (performance) and partially addressing **#106** (code quality).

### Performance (#109) - 3 findings fixed

- **N+1 subquery eliminated**: `lastActiveExpr` now uses pre-aggregated `MAX(timestamp)` from the `countJoins` LEFT JOIN instead of a per-row correlated subquery
- **EXISTS to pre-computed counts**: Replaced 2 of 4 per-row `EXISTS` subqueries with `COALESCE(tc.turn_count, 0) > 0` / `COALESCE(fc.file_count, 0) > 0` from already-joined aggregates
- **Parallel ScanWorkStatus**: Parallelized plan file analysis using `errgroup.Group` with `runtime.NumCPU()` concurrency limit

### Code Quality (#106) - 4 of 6 findings fixed

- Replaced custom `containsStr` with `strings.Contains` (import already existed)
- Made empty `TestChronicleReindex_NoBinary` actually test the `ErrCopilotNotFound` error path
- Added meaningful assertions to `TestLastReindexTime_*` tests (were discarding results)
- Removed `TestResumeConfigFields` (tested Go struct assignment, not app logic)
- **Won't fix**: `FormatInt` wrapper (widely used across 6+ files), constant-value tests (guard API values)

### Files Changed

| File | Change |
|------|--------|
| `internal/data/store.go` | Query optimization |
| `internal/data/workstatus.go` | Parallel scanning |
| `internal/data/mq_coverage_test.go` | Fix empty/no-op tests |
| `internal/platform/mq_coverage_test.go` | Replace reimplemented stdlib |
| `internal/platform/coverage_test.go` | Remove struct-assignment test |

Resolves #109. Partially addresses #106.