### PR TITLE
Add resume command copy shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Dispatch reads your local Copilot CLI session store and presents every past sess
 - **Time range filtering** (`1`–`4`) — 1 hour, 1 day, 7 days, all
 - **Preview panel** (`p`) — metadata, chat-style conversation bubbles, checkpoints (up to 5), files (up to 5), refs (up to 5), scroll indicators. Toggle conversation sort order with `o`. Click the session ID row to copy it to clipboard
 - **Copy session ID** (`c`) — copy the selected session's ID to the system clipboard. Also available by clicking the ID row in the preview pane
+- **Copy resume command** (`Y`) — copy the selected session's full resume command to the system clipboard
 - **Open working directory** (`O`) — open the selected session's working directory in the system file manager (Explorer on Windows, Finder on macOS, the default file manager on Linux)
 - **Four launch modes** (`Enter` / `t` / `w` / `e`) — in-place, new tab, new window, split pane (Windows Terminal) with per-session overrides
 - **Multi-session open** (`Space` / `L` / `a` / `d`) — select multiple sessions with Space, launch all at once with L, select/deselect all with a/d. Shift+↑/↓ for range selection, Ctrl+click and Shift+click for mouse selection
@@ -217,6 +218,7 @@ Add `--json` (`dispatch doctor --json`) to print the same checks as a single JSO
 | `o` | Toggle conversation sort order (oldest/newest first) |
 | `c` | Copy session ID to clipboard |
 | `O` | Open session working directory in file manager |
+| `Y` | Copy resume command to clipboard |
 | `PgUp` / `PgDn` | Scroll preview |
 | `r` | Refresh session store |
 | `,` | Open settings panel |

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -190,6 +190,13 @@
      - Behavior: Cycles preview pane position: right → bottom → left → top → right. Persisted in config.
      - Condition: In session list view
 
+20e. **Y** (Shift+Y) → Copy Resume Command
+     - File: internal\tui\keys.go
+     - Code: key.NewBinding(key.WithKeys("Y"), key.WithHelp("Y", "copy resume cmd"))
+     - Handler: internal\tui\model.go
+     - Behavior: Copies the selected session's resume command to the system clipboard using the same launch settings as Dispatch.
+     - Condition: Only when a session is selected
+
 21. **PgUp (Page Up)** → Preview Panel Scroll Up
     - File: internal\tui\keys.go (line 85)
     - Code: key.NewBinding(key.WithKeys("pgup"))

--- a/internal/platform/shell.go
+++ b/internal/platform/shell.go
@@ -225,6 +225,14 @@ func buildResumeCommandString(sessionID string, cfg ResumeConfig) (string, error
 	return quote(binary) + " " + strings.Join(quoted, " "), nil
 }
 
+// BuildResumeCommandString returns the shell command Dispatch uses to start or
+// resume a Copilot CLI session, including configured flags and custom command
+// templates. It is exported for UI and diagnostics code that need to display or
+// copy the same command used by the launcher.
+func BuildResumeCommandString(sessionID string, cfg ResumeConfig) (string, error) {
+	return buildResumeCommandString(sessionID, cfg)
+}
+
 // shellQuote wraps s in POSIX single quotes if it contains whitespace or
 // shell metacharacters. Single quotes suppress all shell interpretation;
 // embedded single quotes are escaped with the POSIX end-escape-reopen idiom (end quote,

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -47,6 +47,7 @@ type keyMap struct {
 	ViewPlan          key.Binding
 	CopyID            key.Binding
 	CopyPath          key.Binding
+	CopyResumeCommand key.Binding
 	CopyPreview       key.Binding
 	ExpandCollapseAll key.Binding
 	ScanWorkStatus    key.Binding
@@ -64,7 +65,7 @@ type keyMap struct {
 
 // ShortHelp returns a compact set of key bindings for the mini help bar.
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Enter, k.LaunchWindow, k.LaunchTab, k.LaunchPane, k.LaunchAll, k.Search, k.Filter, k.Sort, k.Preview, k.ViewPlan, k.Timeline, k.Compare, k.Hide, k.Star, k.Note, k.CopyID, k.CopyPath, k.CopyPreview, k.Export, k.OpenFile, k.OpenDir, k.JumpNextAttention, k.FilterAttention, k.ResumeInterrupted, k.ScanWorkStatus, k.ExpandCollapseAll, k.ViewSwitch, k.CmdPalette, k.Config, k.Help, k.Quit}
+	return []key.Binding{k.Enter, k.LaunchWindow, k.LaunchTab, k.LaunchPane, k.LaunchAll, k.Search, k.Filter, k.Sort, k.Preview, k.ViewPlan, k.Timeline, k.Compare, k.Hide, k.Star, k.Note, k.CopyID, k.CopyPath, k.CopyResumeCommand, k.CopyPreview, k.Export, k.OpenFile, k.OpenDir, k.JumpNextAttention, k.FilterAttention, k.ResumeInterrupted, k.ScanWorkStatus, k.ExpandCollapseAll, k.ViewSwitch, k.CmdPalette, k.Config, k.Help, k.Quit}
 }
 
 // FullHelp returns grouped key bindings for the expanded help view.
@@ -74,7 +75,7 @@ func (k keyMap) FullHelp() [][]key.Binding {
 		{k.Space, k.LaunchAll, k.SelectAll, k.DeselectAll, k.ShiftUp, k.ShiftDown},
 		{k.Search, k.Escape, k.Filter},
 		{k.Sort, k.SortOrder, k.Pivot, k.PivotOrder, k.ExpandCollapseAll},
-		{k.Preview, k.PreviewPosition, k.PreviewScrollUp, k.PreviewScrollDown, k.ConversationSort, k.ViewPlan, k.Timeline, k.Compare, k.CopyID, k.CopyPath, k.CopyPreview, k.Export, k.OpenFile, k.OpenDir, k.Reindex, k.ScanWorkStatus, k.ViewSwitch, k.Config},
+		{k.Preview, k.PreviewPosition, k.PreviewScrollUp, k.PreviewScrollDown, k.ConversationSort, k.ViewPlan, k.Timeline, k.Compare, k.CopyID, k.CopyPath, k.CopyResumeCommand, k.CopyPreview, k.Export, k.OpenFile, k.OpenDir, k.Reindex, k.ScanWorkStatus, k.ViewSwitch, k.Config},
 		{k.Hide, k.ToggleHidden, k.Star, k.Note, k.JumpNextAttention, k.FilterAttention, k.ResumeInterrupted},
 		{k.TimeRange1, k.TimeRange2, k.TimeRange3, k.TimeRange4},
 		{k.Help, k.CmdPalette, k.Quit},
@@ -124,6 +125,7 @@ var keys = keyMap{
 	ViewPlan:          key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "view plan")),
 	CopyID:            key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "copy session ID")),
 	CopyPath:          key.NewBinding(key.WithKeys("C"), key.WithHelp("C", "copy path")),
+	CopyResumeCommand: key.NewBinding(key.WithKeys("Y"), key.WithHelp("Y", "copy resume cmd")),
 	CopyPreview:       key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "copy preview")),
 	ExpandCollapseAll: key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "expand/collapse all")),
 	ScanWorkStatus:    key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "scan work status")),

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -60,6 +60,10 @@ const (
 	// working directory path is copied to the clipboard.
 	statusCopiedPath = "Copied path ✓"
 
+	// statusCopiedResumeCommand is the status message shown when a session's
+	// resume command is copied to the clipboard.
+	statusCopiedResumeCommand = "Copied resume command ✓"
+
 	// statusCopiedPreview is the status message shown when preview content
 	// is copied to the clipboard via the y key.
 	statusCopiedPreview = "Copied to clipboard ✓"
@@ -1406,6 +1410,9 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, keys.Export):
 		return m.handleExport()
 
+	case key.Matches(msg, keys.CopyResumeCommand):
+		return m.handleCopyResumeCommand()
+
 	case key.Matches(msg, keys.JumpNextAttention):
 		return m.handleJumpNextAttention()
 
@@ -1597,6 +1604,27 @@ func (m Model) handleCopyPath() (tea.Model, tea.Cmd) {
 		return m, clearStatusAfter(2 * time.Second)
 	}
 	m.statusInfo = statusCopiedPath
+	return m, clearStatusAfter(2 * time.Second)
+}
+
+// handleCopyResumeCommand copies the selected session's resume command to the
+// system clipboard. It mirrors the same launch options used by Dispatch when
+// opening sessions so copied commands match the configured workflow.
+func (m Model) handleCopyResumeCommand() (tea.Model, tea.Cmd) {
+	sess, ok := m.sessionList.Selected()
+	if !ok {
+		return m, nil
+	}
+	cmd, err := platform.BuildResumeCommandString(sess.ID, m.resumeConfigForSession(sess.Cwd))
+	if err != nil {
+		m.statusErr = "resume command: " + err.Error()
+		return m, clearStatusAfter(2 * time.Second)
+	}
+	if err := clipboardWrite(cmd); err != nil {
+		m.statusErr = "clipboard: " + err.Error()
+		return m, clearStatusAfter(2 * time.Second)
+	}
+	m.statusInfo = statusCopiedResumeCommand
 	return m, clearStatusAfter(2 * time.Second)
 }
 
@@ -3276,13 +3304,7 @@ func (m *Model) resolveShellAndLaunchDirect(sessionID, cwd, mode string) tea.Cmd
 // runs the Copilot CLI session resume in the current terminal, and quits
 // the TUI when the session ends.
 func (m *Model) launchInPlace(sessionID, cwd string) tea.Cmd {
-	cfg := platform.ResumeConfig{
-		YoloMode:      m.cfg.YoloMode,
-		Agent:         m.cfg.Agent,
-		Model:         m.cfg.Model,
-		CustomCommand: m.cfg.CustomCommand,
-		Cwd:           cwd,
-	}
+	cfg := m.resumeConfigForSession(cwd)
 	cmd, err := platform.NewResumeCmd(sessionID, cfg)
 	if err != nil {
 		m.statusErr = err.Error()
@@ -3307,16 +3329,8 @@ func launchStyleForMode(mode string) string {
 
 // launchExternal opens the session in a new tab, window, or pane depending on launchStyle.
 func (m *Model) launchExternal(shell platform.ShellInfo, sessionID, cwd, launchStyle string) tea.Cmd {
-	cfg := platform.ResumeConfig{
-		YoloMode:      m.cfg.YoloMode,
-		Agent:         m.cfg.Agent,
-		Model:         m.cfg.Model,
-		Terminal:      m.cfg.DefaultTerminal,
-		CustomCommand: m.cfg.CustomCommand,
-		Cwd:           cwd,
-		LaunchStyle:   launchStyle,
-		PaneDirection: m.cfg.EffectivePaneDirection(),
-	}
+	cfg := m.resumeConfigForSession(cwd)
+	cfg.LaunchStyle = launchStyle
 	return func() tea.Msg {
 		if err := platform.LaunchSession(shell, sessionID, cfg); err != nil {
 			detail := fmt.Sprintf("launch failed: %v (shell=%s, terminal=%s)",
@@ -3324,6 +3338,18 @@ func (m *Model) launchExternal(shell platform.ShellInfo, sessionID, cwd, launchS
 			return dataErrorMsg{err: errors.New(detail)}
 		}
 		return nil
+	}
+}
+
+func (m Model) resumeConfigForSession(cwd string) platform.ResumeConfig {
+	return platform.ResumeConfig{
+		YoloMode:      m.cfg.YoloMode,
+		Agent:         m.cfg.Agent,
+		Model:         m.cfg.Model,
+		Terminal:      m.cfg.DefaultTerminal,
+		CustomCommand: m.cfg.CustomCommand,
+		Cwd:           cwd,
+		PaneDirection: m.cfg.EffectivePaneDirection(),
 	}
 }
 

--- a/internal/tui/model_update_test.go
+++ b/internal/tui/model_update_test.go
@@ -2127,6 +2127,93 @@ func TestHandleKey_CopyID_Error(t *testing.T) {
 	}
 }
 
+func TestHandleKey_CopyResumeCommand_Success(t *testing.T) {
+	var copied string
+	orig := clipboardWrite
+	clipboardWrite = func(text string) error {
+		copied = text
+		return nil
+	}
+	t.Cleanup(func() { clipboardWrite = orig })
+
+	m := newTestModel()
+	m.cfg.CustomCommand = "copilot --resume {sessionId} --agent test-agent"
+	m.sessionList.SetSessions([]data.Session{{ID: "abc-123", Cwd: "/a"}})
+
+	result, cmd := m.Update(runeKeyMsg('Y'))
+	rm := result.(Model)
+	if copied != "copilot --resume abc-123 --agent test-agent" {
+		t.Errorf("clipboard text = %q", copied)
+	}
+	if rm.statusInfo != statusCopiedResumeCommand {
+		t.Errorf("statusInfo = %q, want %q", rm.statusInfo, statusCopiedResumeCommand)
+	}
+	if rm.statusErr != "" {
+		t.Errorf("statusErr = %q, want empty", rm.statusErr)
+	}
+	if cmd == nil {
+		t.Error("CopyResumeCommand success should return clearStatusAfter cmd")
+	}
+}
+
+func TestHandleKey_CopyResumeCommand_NoSession(t *testing.T) {
+	m := newTestModel()
+	result, cmd := m.Update(runeKeyMsg('Y'))
+	rm := result.(Model)
+	if rm.statusInfo != "" || rm.statusErr != "" {
+		t.Errorf("status = (%q, %q), want empty", rm.statusInfo, rm.statusErr)
+	}
+	if cmd != nil {
+		t.Error("CopyResumeCommand with no session should return nil cmd")
+	}
+}
+
+func TestHandleKey_CopyResumeCommand_BuildError(t *testing.T) {
+	orig := clipboardWrite
+	clipboardWrite = func(string) error {
+		t.Fatal("clipboard should not be called when command build fails")
+		return nil
+	}
+	t.Cleanup(func() { clipboardWrite = orig })
+
+	m := newTestModel()
+	m.cfg.CustomCommand = "bad\ncommand {sessionId}"
+	m.sessionList.SetSessions([]data.Session{{ID: "abc-123", Cwd: "/a"}})
+
+	result, cmd := m.Update(runeKeyMsg('Y'))
+	rm := result.(Model)
+	if !strings.Contains(rm.statusErr, "resume command:") {
+		t.Errorf("statusErr = %q, want resume command error", rm.statusErr)
+	}
+	if cmd == nil {
+		t.Error("CopyResumeCommand build error should return clearStatusAfter cmd")
+	}
+}
+
+func TestHandleKey_CopyResumeCommand_ClipboardError(t *testing.T) {
+	orig := clipboardWrite
+	clipboardWrite = func(string) error {
+		return errors.New("no display")
+	}
+	t.Cleanup(func() { clipboardWrite = orig })
+
+	m := newTestModel()
+	m.cfg.CustomCommand = "copilot --resume {sessionId}"
+	m.sessionList.SetSessions([]data.Session{{ID: "abc-123", Cwd: "/a"}})
+
+	result, cmd := m.Update(runeKeyMsg('Y'))
+	rm := result.(Model)
+	if !strings.Contains(rm.statusErr, "clipboard:") {
+		t.Errorf("statusErr = %q, want clipboard error", rm.statusErr)
+	}
+	if rm.statusInfo != "" {
+		t.Errorf("statusInfo = %q, want empty", rm.statusInfo)
+	}
+	if cmd == nil {
+		t.Error("CopyResumeCommand clipboard error should return clearStatusAfter cmd")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // CopyPreview (y key)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #162

Adds a `C` shortcut that copies the selected session's resume command using the same launch settings Dispatch uses for session resume. Includes docs and tests.

Verification:
- go build ./...
- go test ./...