### PR TITLE
deps: update all dependencies to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,8 +36,8 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260622092850-f39628c8a989 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
-	github.com/charmbracelet/x/exp/golden v0.0.0-20260622092256-25656177ba8e // indirect
-	github.com/charmbracelet/x/exp/slice v0.0.0-20260622092256-25656177ba8e // indirect
+	github.com/charmbracelet/x/exp/golden v0.0.0-20260628005914-6eb80f72a239 // indirect
+	github.com/charmbracelet/x/exp/slice v0.0.0-20260628005914-6eb80f72a239 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,10 +34,10 @@ github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dA
 github.com/charmbracelet/x/ansi v0.11.7/go.mod h1:9qGpnAVYz+8ACONkZBUWPtL7lulP9No6p1epAihUZwQ=
 github.com/charmbracelet/x/cellbuf v0.0.15 h1:ur3pZy0o6z/R7EylET877CBxaiE1Sp1GMxoFPAIztPI=
 github.com/charmbracelet/x/cellbuf v0.0.15/go.mod h1:J1YVbR7MUuEGIFPCaaZ96KDl5NoS0DAWkskup+mOY+Q=
-github.com/charmbracelet/x/exp/golden v0.0.0-20260622092256-25656177ba8e h1:x7pKVbisrybuOyTq7CS0zQoKNrckmfBPXAgKK/Hkg1I=
-github.com/charmbracelet/x/exp/golden v0.0.0-20260622092256-25656177ba8e/go.mod h1:6fMpcW6iwN/kX+xJ52eqVWsDiBTe0UJD24JLoHFe+P0=
-github.com/charmbracelet/x/exp/slice v0.0.0-20260622092256-25656177ba8e h1:TerxTCW/3BrnpqKxeouW0cWSjZb7PsVAmtNftRAAFRE=
-github.com/charmbracelet/x/exp/slice v0.0.0-20260622092256-25656177ba8e/go.mod h1:vqEfX6xzqW1pKKZUUiFOKg0OQ7bCh54Q2vR/tserrRA=
+github.com/charmbracelet/x/exp/golden v0.0.0-20260628005914-6eb80f72a239 h1:ZkqtDjeyqKAvk07Hpj7aTa1YbiEx7Az9ksnjOs1k1rI=
+github.com/charmbracelet/x/exp/golden v0.0.0-20260628005914-6eb80f72a239/go.mod h1:6fMpcW6iwN/kX+xJ52eqVWsDiBTe0UJD24JLoHFe+P0=
+github.com/charmbracelet/x/exp/slice v0.0.0-20260628005914-6eb80f72a239 h1:4PUb+uaFuVH5lmhZRPEoo49HqC0r1ZqSJ+wOKgw8svE=
+github.com/charmbracelet/x/exp/slice v0.0.0-20260628005914-6eb80f72a239/go.mod h1:vqEfX6xzqW1pKKZUUiFOKg0OQ7bCh54Q2vR/tserrRA=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
 github.com/charmbracelet/x/term v0.2.2/go.mod h1:kF8CY5RddLWrsgVwpw4kAa6TESp6EB5y3uxGLeCqzAI=
 github.com/charmbracelet/x/termios v0.1.1 h1:o3Q2bT8eqzGnGPOYheoYS8eEleT5ZVNYNy8JawjaNZY=


### PR DESCRIPTION
## Summary
- Updated Go module dependencies to latest tidy-selected versions.
- Bumped github.com/charmbracelet/x/exp/golden and github.com/charmbracelet/x/exp/slice to 20260628005914-6eb80f72a239.
- npm workspace was already current; package.json/package-lock.json unchanged and npm audit found 0 vulnerabilities.

## Validation
- go build ./...
- go test ./...
- golangci-lint run --allow-parallel-runners (0 issues)
- mage build, mage test, mage vet, mage fmt
- npm test (astro check && astro build)

## Notes
- go mod tidy pruned unused/phantom Go deps.
- depcheck flags expected Astro/tooling false positives (script and .astro usage); no Node deps removed.