### PR TITLE
Add open command to resume a session by ID

### DIFF
--- a/cmd/dispatch/cli.go
+++ b/cmd/dispatch/cli.go
@@ -69,6 +69,13 @@ func handleArgs(args []string, origStderr io.Writer, updateCh <-chan *update.Upd
 			showUpdateNotification(origStderr, updateCh)
 			return true, cleanup, nil
 
+		case "open":
+			if oErr := runOpen(os.Stdout, args); oErr != nil {
+				fmt.Fprintf(os.Stderr, "open: %v\n", oErr)
+				return true, cleanup, oErr
+			}
+			return true, cleanup, nil
+
 		case "--demo":
 			c, demoErr := setupDemo()
 			if demoErr != nil {
@@ -138,7 +145,7 @@ func runCompletion(w io.Writer, shell string) error {
 const bashCompletionScript = `# bash completion for dispatch
 _dispatch_completion() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
-  local commands="help version update completion"
+  local commands="help version open doctor update completion"
   local flags="-h --help -v --version --demo --clear-cache --reindex"
 
   if [[ "${COMP_CWORD}" -eq 1 ]]; then
@@ -157,7 +164,7 @@ complete -F _dispatch_completion dispatch disp
 const zshCompletionScript = `#compdef dispatch disp
 _dispatch_completion() {
   local -a commands shells flags
-  commands=(help version update completion)
+  commands=(help version open doctor update completion)
   shells=(bash zsh powershell)
   flags=(-h --help -v --version --demo --clear-cache --reindex)
 
@@ -175,7 +182,7 @@ _dispatch_completion "$@"
 `
 
 const powershellCompletionScript = `# PowerShell completion for dispatch
-$script:DispatchCommands = @('help', 'version', 'update', 'completion')
+$script:DispatchCommands = @('help', 'version', 'open', 'doctor', 'update', 'completion')
 $script:DispatchFlags = @('-h', '--help', '-v', '--version', '--demo', '--clear-cache', '--reindex')
 $script:DispatchShells = @('bash', 'zsh', 'powershell')
 

--- a/cmd/dispatch/main.go
+++ b/cmd/dispatch/main.go
@@ -90,6 +90,7 @@ Usage:
 Commands:
   help                    Show this help message
   version                 Print the version
+  open <id> [--mode M]    Resume a session by ID (M: inplace, tab, window, pane)
   completion <shell>      Print shell completion (bash, zsh, powershell)
   doctor                  Print environment diagnostics
   update                  Update dispatch to the latest release

--- a/cmd/dispatch/open.go
+++ b/cmd/dispatch/open.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/jongio/dispatch/internal/config"
+	"github.com/jongio/dispatch/internal/data"
+	"github.com/jongio/dispatch/internal/platform"
+)
+
+// Function variables allow test substitution of external calls, matching the
+// pattern used elsewhere in this package (see cli.go).
+var (
+	openLoadConfigFn = config.Load
+	openGetSessionFn = defaultOpenGetSession
+	openLaunchFn     = defaultOpenLaunch
+)
+
+// runOpen resumes the session with the given ID using the same launch path
+// the TUI uses. args is the full argument slice with args[0] == "open".
+func runOpen(w io.Writer, args []string) error {
+	if w == nil {
+		w = io.Discard
+	}
+
+	id, modeFlag, err := parseOpenArgs(args)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := openLoadConfigFn()
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	mode := resolveOpenMode(modeFlag, cfg)
+
+	sess, err := openGetSessionFn(id)
+	if err != nil {
+		return err
+	}
+	if sess == nil {
+		return fmt.Errorf("session %q not found", id)
+	}
+
+	return openLaunchFn(w, cfg, sess, mode)
+}
+
+// parseOpenArgs extracts the session ID and optional launch mode from the
+// "open" subcommand arguments. args[0] is expected to be "open".
+func parseOpenArgs(args []string) (id, mode string, err error) {
+	rest := args
+	if len(rest) > 0 {
+		rest = rest[1:] // drop the "open" token
+	}
+
+	var positionals []string
+	for i := 0; i < len(rest); i++ {
+		arg := rest[i]
+		switch {
+		case arg == "--mode" || arg == "-m":
+			if i+1 >= len(rest) {
+				return "", "", errors.New("--mode requires a value: inplace, tab, window, or pane")
+			}
+			mode = rest[i+1]
+			i++
+		case strings.HasPrefix(arg, "--mode="):
+			mode = strings.TrimPrefix(arg, "--mode=")
+		case strings.HasPrefix(arg, "-"):
+			return "", "", fmt.Errorf("unknown flag: %s", arg)
+		default:
+			positionals = append(positionals, arg)
+		}
+	}
+
+	switch len(positionals) {
+	case 0:
+		return "", "", errors.New("open requires a session ID")
+	case 1:
+		id = positionals[0]
+	default:
+		return "", "", fmt.Errorf("open accepts a single session ID, got %d arguments", len(positionals))
+	}
+
+	if mode != "" {
+		if _, mErr := normalizeLaunchMode(mode); mErr != nil {
+			return "", "", mErr
+		}
+	}
+	return id, mode, nil
+}
+
+// normalizeLaunchMode maps a user-facing mode string to a config launch mode.
+func normalizeLaunchMode(mode string) (string, error) {
+	switch strings.ToLower(mode) {
+	case "inplace", "in-place":
+		return config.LaunchModeInPlace, nil
+	case "tab":
+		return config.LaunchModeTab, nil
+	case "window":
+		return config.LaunchModeWindow, nil
+	case "pane":
+		return config.LaunchModePane, nil
+	default:
+		return "", fmt.Errorf("invalid mode %q (want inplace, tab, window, or pane)", mode)
+	}
+}
+
+// resolveOpenMode returns the launch mode to use: the flag when set (already
+// validated), otherwise the configured default.
+func resolveOpenMode(modeFlag string, cfg *config.Config) string {
+	if modeFlag != "" {
+		m, _ := normalizeLaunchMode(modeFlag)
+		return m
+	}
+	return cfg.EffectiveLaunchMode()
+}
+
+// defaultOpenGetSession loads a session by ID from the default session store.
+// It returns (nil, nil) when no session with that ID exists.
+func defaultOpenGetSession(id string) (*data.Session, error) {
+	store, err := data.Open()
+	if err != nil {
+		return nil, fmt.Errorf("opening session store: %w", err)
+	}
+	defer store.Close() //nolint:errcheck // read-only, best-effort close
+
+	detail, err := store.GetSession(context.Background(), id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if detail == nil {
+		return nil, nil
+	}
+	return &detail.Session, nil
+}
+
+// defaultOpenLaunch resumes the session using the resolved launch mode. For
+// in-place mode it runs the Copilot CLI in the current terminal and waits for
+// it to exit. For tab, window, and pane modes it delegates to the platform
+// launcher, matching the behavior of launching from the TUI.
+func defaultOpenLaunch(w io.Writer, cfg *config.Config, sess *data.Session, mode string) error {
+	if mode == config.LaunchModeInPlace {
+		rc := platform.ResumeConfig{
+			YoloMode:      cfg.YoloMode,
+			Agent:         cfg.Agent,
+			Model:         cfg.Model,
+			CustomCommand: cfg.CustomCommand,
+			Cwd:           sess.Cwd,
+		}
+		cmd, err := platform.NewResumeCmd(sess.ID, rc)
+		if err != nil {
+			return err
+		}
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	}
+
+	shell := resolveOpenShell(cfg)
+	if shell.Path == "" {
+		return errors.New("no shell detected on this system")
+	}
+	rc := platform.ResumeConfig{
+		YoloMode:      cfg.YoloMode,
+		Agent:         cfg.Agent,
+		Model:         cfg.Model,
+		Terminal:      cfg.DefaultTerminal,
+		CustomCommand: cfg.CustomCommand,
+		Cwd:           sess.Cwd,
+		LaunchStyle:   launchStyleForOpenMode(mode),
+		PaneDirection: cfg.EffectivePaneDirection(),
+	}
+	if err := platform.LaunchSession(shell, sess.ID, rc); err != nil {
+		return err
+	}
+	fmt.Fprintf(w, "Launched session %s\n", sess.ID)
+	return nil
+}
+
+// resolveOpenShell picks the configured shell by name, falling back to the
+// platform default. Mirrors the direct (non-picker) resolution used by the TUI
+// for batch launches.
+func resolveOpenShell(cfg *config.Config) platform.ShellInfo {
+	if cfg.DefaultShell != "" {
+		for _, sh := range platform.DetectShells() {
+			if sh.Name == cfg.DefaultShell {
+				return sh
+			}
+		}
+	}
+	return platform.DefaultShell()
+}
+
+// launchStyleForOpenMode maps a config launch mode to a platform launch style.
+func launchStyleForOpenMode(mode string) string {
+	switch mode {
+	case config.LaunchModeWindow:
+		return platform.LaunchStyleWindow
+	case config.LaunchModePane:
+		return platform.LaunchStylePane
+	default:
+		return platform.LaunchStyleTab
+	}
+}

--- a/cmd/dispatch/open_test.go
+++ b/cmd/dispatch/open_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/jongio/dispatch/internal/config"
+	"github.com/jongio/dispatch/internal/data"
+	"github.com/jongio/dispatch/internal/update"
+)
+
+func TestParseOpenArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantID   string
+		wantMode string
+		wantErr  bool
+	}{
+		{name: "id only", args: []string{"open", "abc123"}, wantID: "abc123"},
+		{name: "mode space", args: []string{"open", "abc", "--mode", "window"}, wantID: "abc", wantMode: "window"},
+		{name: "mode equals", args: []string{"open", "abc", "--mode=pane"}, wantID: "abc", wantMode: "pane"},
+		{name: "short mode", args: []string{"open", "-m", "tab", "abc"}, wantID: "abc", wantMode: "tab"},
+		{name: "mode before id", args: []string{"open", "--mode", "inplace", "xyz"}, wantID: "xyz", wantMode: "inplace"},
+		{name: "missing id", args: []string{"open"}, wantErr: true},
+		{name: "missing id with mode", args: []string{"open", "--mode", "tab"}, wantErr: true},
+		{name: "two ids", args: []string{"open", "a", "b"}, wantErr: true},
+		{name: "unknown flag", args: []string{"open", "--nope", "a"}, wantErr: true},
+		{name: "mode without value", args: []string{"open", "a", "--mode"}, wantErr: true},
+		{name: "invalid mode", args: []string{"open", "a", "--mode", "sideways"}, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			id, mode, err := parseOpenArgs(tc.args)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got id=%q mode=%q", id, mode)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if id != tc.wantID {
+				t.Errorf("id = %q, want %q", id, tc.wantID)
+			}
+			if mode != tc.wantMode {
+				t.Errorf("mode = %q, want %q", mode, tc.wantMode)
+			}
+		})
+	}
+}
+
+func TestNormalizeLaunchMode(t *testing.T) {
+	valid := map[string]string{
+		"inplace":  config.LaunchModeInPlace,
+		"in-place": config.LaunchModeInPlace,
+		"TAB":      config.LaunchModeTab,
+		"Window":   config.LaunchModeWindow,
+		"pane":     config.LaunchModePane,
+	}
+	for in, want := range valid {
+		got, err := normalizeLaunchMode(in)
+		if err != nil {
+			t.Errorf("normalizeLaunchMode(%q) unexpected error: %v", in, err)
+		}
+		if got != want {
+			t.Errorf("normalizeLaunchMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+	if _, err := normalizeLaunchMode("bogus"); err == nil {
+		t.Error("expected error for invalid mode")
+	}
+}
+
+func TestResolveOpenMode(t *testing.T) {
+	cfg := config.Default()
+	cfg.LaunchMode = config.LaunchModeWindow
+
+	if got := resolveOpenMode("pane", cfg); got != config.LaunchModePane {
+		t.Errorf("flag override = %q, want %q", got, config.LaunchModePane)
+	}
+	if got := resolveOpenMode("", cfg); got != config.LaunchModeWindow {
+		t.Errorf("default = %q, want %q", got, config.LaunchModeWindow)
+	}
+}
+
+func TestLaunchStyleForOpenMode(t *testing.T) {
+	cases := map[string]string{
+		config.LaunchModeWindow:  "window",
+		config.LaunchModePane:    "pane",
+		config.LaunchModeTab:     "",
+		config.LaunchModeInPlace: "",
+	}
+	for mode, want := range cases {
+		if got := launchStyleForOpenMode(mode); got != want {
+			t.Errorf("launchStyleForOpenMode(%q) = %q, want %q", mode, got, want)
+		}
+	}
+}
+
+// withOpenStubs swaps the package test seams and returns a restore func.
+func withOpenStubs(t *testing.T, cfg *config.Config, sess *data.Session, getErr error) *openCapture {
+	t.Helper()
+	cap := &openCapture{}
+	origCfg, origGet, origLaunch := openLoadConfigFn, openGetSessionFn, openLaunchFn
+	openLoadConfigFn = func() (*config.Config, error) { return cfg, nil }
+	openGetSessionFn = func(id string) (*data.Session, error) {
+		cap.gotID = id
+		return sess, getErr
+	}
+	openLaunchFn = func(_ io.Writer, c *config.Config, s *data.Session, mode string) error {
+		cap.launched = true
+		cap.mode = mode
+		cap.session = s
+		return nil
+	}
+	t.Cleanup(func() {
+		openLoadConfigFn, openGetSessionFn, openLaunchFn = origCfg, origGet, origLaunch
+	})
+	return cap
+}
+
+type openCapture struct {
+	gotID    string
+	launched bool
+	mode     string
+	session  *data.Session
+}
+
+func TestRunOpen_HappyPath(t *testing.T) {
+	cfg := config.Default()
+	cfg.LaunchMode = config.LaunchModeTab
+	sess := &data.Session{ID: "sess-1", Cwd: "/tmp/project"}
+	cap := withOpenStubs(t, cfg, sess, nil)
+
+	if err := runOpen(io.Discard, []string{"open", "sess-1", "--mode", "window"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cap.gotID != "sess-1" {
+		t.Errorf("looked up id %q, want sess-1", cap.gotID)
+	}
+	if !cap.launched {
+		t.Fatal("expected launch to be invoked")
+	}
+	if cap.mode != config.LaunchModeWindow {
+		t.Errorf("launched mode = %q, want %q", cap.mode, config.LaunchModeWindow)
+	}
+}
+
+func TestRunOpen_NotFound(t *testing.T) {
+	withOpenStubs(t, config.Default(), nil, nil)
+	err := runOpen(io.Discard, []string{"open", "missing"})
+	if err == nil {
+		t.Fatal("expected error for missing session")
+	}
+}
+
+func TestRunOpen_LookupError(t *testing.T) {
+	withOpenStubs(t, config.Default(), nil, errors.New("boom"))
+	if err := runOpen(io.Discard, []string{"open", "x"}); err == nil {
+		t.Fatal("expected lookup error to propagate")
+	}
+}
+
+func TestRunOpen_BadArgs(t *testing.T) {
+	if err := runOpen(io.Discard, []string{"open"}); err == nil {
+		t.Fatal("expected error for missing id")
+	}
+}
+
+func TestHandleArgs_OpenMissingID(t *testing.T) {
+	ch := make(chan *update.UpdateInfo, 1)
+	ch <- nil
+	// parseOpenArgs fails before touching config or the store, so this is safe.
+	done, _, err := handleArgs([]string{"open"}, io.Discard, ch)
+	if !done {
+		t.Error("expected done=true for open")
+	}
+	if err == nil {
+		t.Error("expected error for open with no session ID")
+	}
+}

--- a/cmd/dispatch/open_test.go
+++ b/cmd/dispatch/open_test.go
@@ -103,23 +103,23 @@ func TestLaunchStyleForOpenMode(t *testing.T) {
 // withOpenStubs swaps the package test seams and returns a restore func.
 func withOpenStubs(t *testing.T, cfg *config.Config, sess *data.Session, getErr error) *openCapture {
 	t.Helper()
-	cap := &openCapture{}
+	capture := &openCapture{}
 	origCfg, origGet, origLaunch := openLoadConfigFn, openGetSessionFn, openLaunchFn
 	openLoadConfigFn = func() (*config.Config, error) { return cfg, nil }
 	openGetSessionFn = func(id string) (*data.Session, error) {
-		cap.gotID = id
+		capture.gotID = id
 		return sess, getErr
 	}
 	openLaunchFn = func(_ io.Writer, c *config.Config, s *data.Session, mode string) error {
-		cap.launched = true
-		cap.mode = mode
-		cap.session = s
+		capture.launched = true
+		capture.mode = mode
+		capture.session = s
 		return nil
 	}
 	t.Cleanup(func() {
 		openLoadConfigFn, openGetSessionFn, openLaunchFn = origCfg, origGet, origLaunch
 	})
-	return cap
+	return capture
 }
 
 type openCapture struct {
@@ -133,19 +133,19 @@ func TestRunOpen_HappyPath(t *testing.T) {
 	cfg := config.Default()
 	cfg.LaunchMode = config.LaunchModeTab
 	sess := &data.Session{ID: "sess-1", Cwd: "/tmp/project"}
-	cap := withOpenStubs(t, cfg, sess, nil)
+	capture := withOpenStubs(t, cfg, sess, nil)
 
 	if err := runOpen(io.Discard, []string{"open", "sess-1", "--mode", "window"}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cap.gotID != "sess-1" {
-		t.Errorf("looked up id %q, want sess-1", cap.gotID)
+	if capture.gotID != "sess-1" {
+		t.Errorf("looked up id %q, want sess-1", capture.gotID)
 	}
-	if !cap.launched {
+	if !capture.launched {
 		t.Fatal("expected launch to be invoked")
 	}
-	if cap.mode != config.LaunchModeWindow {
-		t.Errorf("launched mode = %q, want %q", cap.mode, config.LaunchModeWindow)
+	if capture.mode != config.LaunchModeWindow {
+		t.Errorf("launched mode = %q, want %q", capture.mode, config.LaunchModeWindow)
 	}
 }
 


### PR DESCRIPTION
Adds a non-interactive `dispatch open <id>` subcommand so you can resume a stored session straight from the shell without opening the TUI first.

## What it does
- `dispatch open <id>` resumes the session with that ID using the same launch path the TUI uses.
- `--mode` (or `-m`) selects how it launches: `inplace`, `tab`, `window`, or `pane`. When omitted it uses the configured default launch mode.
- `inplace` runs the Copilot CLI in the current terminal and waits for it to exit. The other modes delegate to the platform launcher, matching TUI launch behavior.

## Why
Scripts, shell aliases, and editor tasks often know the exact session ID already. Today the only way to resume is to open the TUI, search, and press enter. A headless command makes those flows one step.

## Notes
- Wired into `handleArgs` alongside the other early-exit subcommands, and added to the usage text and the bash, zsh, and powershell completion lists.
- Errors clearly when the ID is missing, unknown, or when more than one positional argument is passed.
- Tests cover argument parsing, mode normalization, mode resolution, launch-style mapping, and the not-found and lookup-error paths.

Closes #189