### PR TITLE
Add stats command for session totals and breakdowns

### DIFF
--- a/cmd/dispatch/cli.go
+++ b/cmd/dispatch/cli.go
@@ -69,6 +69,13 @@ func handleArgs(args []string, origStderr io.Writer, updateCh <-chan *update.Upd
 			showUpdateNotification(origStderr, updateCh)
 			return true, cleanup, nil
 
+		case "stats":
+			if sErr := runStats(os.Stdout, args); sErr != nil {
+				fmt.Fprintf(os.Stderr, "stats: %v\n", sErr)
+				return true, cleanup, sErr
+			}
+			return true, cleanup, nil
+
 		case "--demo":
 			c, demoErr := setupDemo()
 			if demoErr != nil {
@@ -138,7 +145,7 @@ func runCompletion(w io.Writer, shell string) error {
 const bashCompletionScript = `# bash completion for dispatch
 _dispatch_completion() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
-  local commands="help version update completion"
+  local commands="help version update completion doctor stats"
   local flags="-h --help -v --version --demo --clear-cache --reindex"
 
   if [[ "${COMP_CWORD}" -eq 1 ]]; then
@@ -157,7 +164,7 @@ complete -F _dispatch_completion dispatch disp
 const zshCompletionScript = `#compdef dispatch disp
 _dispatch_completion() {
   local -a commands shells flags
-  commands=(help version update completion)
+  commands=(help version update completion doctor stats)
   shells=(bash zsh powershell)
   flags=(-h --help -v --version --demo --clear-cache --reindex)
 
@@ -175,7 +182,7 @@ _dispatch_completion "$@"
 `
 
 const powershellCompletionScript = `# PowerShell completion for dispatch
-$script:DispatchCommands = @('help', 'version', 'update', 'completion')
+$script:DispatchCommands = @('help', 'version', 'update', 'completion', 'doctor', 'stats')
 $script:DispatchFlags = @('-h', '--help', '-v', '--version', '--demo', '--clear-cache', '--reindex')
 $script:DispatchShells = @('bash', 'zsh', 'powershell')
 

--- a/cmd/dispatch/main.go
+++ b/cmd/dispatch/main.go
@@ -92,7 +92,16 @@ Commands:
   version                 Print the version
   completion <shell>      Print shell completion (bash, zsh, powershell)
   doctor                  Print environment diagnostics
+  stats [flags]           Print session totals and breakdowns
   update                  Update dispatch to the latest release
+
+Stats flags:
+  --json                  Print the summary as JSON
+  --repo <name>           Only count sessions for a repository
+  --branch <name>         Only count sessions on a branch
+  --folder <path>         Only count sessions under a folder
+  --since <date>          Only count sessions created on or after a date
+  --until <date>          Only count sessions created on or before a date
 
 Flags:
   -h, --help              Show this help message

--- a/cmd/dispatch/stats.go
+++ b/cmd/dispatch/stats.go
@@ -1,0 +1,332 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jongio/dispatch/internal/data"
+)
+
+// statsListSessionsFn loads sessions for the stats command. It is a package
+// variable so tests can substitute a fixed set of sessions, matching the seam
+// pattern used elsewhere in this package (see cli.go).
+var statsListSessionsFn = defaultStatsListSessions
+
+// statsQueryLimit is a high ceiling used so the summary covers every stored
+// session rather than the smaller default page size used by the TUI.
+const statsQueryLimit = 100_000
+
+// statsOptions holds the parsed flags for the stats command.
+type statsOptions struct {
+	filter data.FilterOptions
+	json   bool
+}
+
+// countEntry is one label and count pair in a grouped breakdown.
+type countEntry struct {
+	Label string `json:"label"`
+	Count int    `json:"count"`
+}
+
+// statsReport is the aggregate summary produced by the stats command.
+type statsReport struct {
+	TotalSessions int          `json:"total_sessions"`
+	TotalTurns    int          `json:"total_turns"`
+	TotalFiles    int          `json:"total_files"`
+	Earliest      string       `json:"earliest,omitempty"`
+	Latest        string       `json:"latest,omitempty"`
+	ByRepository  []countEntry `json:"by_repository"`
+	ByBranch      []countEntry `json:"by_branch"`
+	ByHostType    []countEntry `json:"by_host_type"`
+}
+
+// runStats prints aggregate counts for the stored sessions. args is the full
+// argument slice with args[0] == "stats".
+func runStats(w io.Writer, args []string) error {
+	if w == nil {
+		w = io.Discard
+	}
+
+	opts, err := parseStatsArgs(args)
+	if err != nil {
+		return err
+	}
+
+	sessions, err := statsListSessionsFn(opts.filter)
+	if err != nil {
+		return err
+	}
+
+	report := buildStatsReport(sessions)
+	if opts.json {
+		return writeStatsJSON(w, report)
+	}
+	writeStatsText(w, report)
+	return nil
+}
+
+// parseStatsArgs reads the stats subcommand flags. args[0] is expected to be
+// "stats". It rejects positional arguments and unknown flags.
+func parseStatsArgs(args []string) (statsOptions, error) {
+	var opts statsOptions
+
+	rest := args
+	if len(rest) > 0 {
+		rest = rest[1:] // drop the "stats" token
+	}
+
+	takeValue := func(i int, name, inline string) (string, int, error) {
+		if inline != "" {
+			return inline, i, nil
+		}
+		if i+1 >= len(rest) {
+			return "", i, fmt.Errorf("%s requires a value", name)
+		}
+		return rest[i+1], i + 1, nil
+	}
+
+	for i := 0; i < len(rest); i++ {
+		arg := rest[i]
+		name, inline, hasInline := splitFlag(arg)
+
+		switch {
+		case name == "--json":
+			opts.json = true
+		case name == "--repo" || name == "--repository":
+			v, ni, err := takeValue(i, "--repo", inlineOrEmpty(inline, hasInline))
+			if err != nil {
+				return statsOptions{}, err
+			}
+			opts.filter.Repository = v
+			i = ni
+		case name == "--branch":
+			v, ni, err := takeValue(i, "--branch", inlineOrEmpty(inline, hasInline))
+			if err != nil {
+				return statsOptions{}, err
+			}
+			opts.filter.Branch = v
+			i = ni
+		case name == "--folder":
+			v, ni, err := takeValue(i, "--folder", inlineOrEmpty(inline, hasInline))
+			if err != nil {
+				return statsOptions{}, err
+			}
+			opts.filter.Folder = v
+			i = ni
+		case name == "--since":
+			v, ni, err := takeValue(i, "--since", inlineOrEmpty(inline, hasInline))
+			if err != nil {
+				return statsOptions{}, err
+			}
+			t, ok := parseStatsTime(v)
+			if !ok {
+				return statsOptions{}, fmt.Errorf("invalid --since value %q (want YYYY-MM-DD or RFC3339)", v)
+			}
+			opts.filter.Since = &t
+			i = ni
+		case name == "--until":
+			v, ni, err := takeValue(i, "--until", inlineOrEmpty(inline, hasInline))
+			if err != nil {
+				return statsOptions{}, err
+			}
+			t, ok := parseStatsTime(v)
+			if !ok {
+				return statsOptions{}, fmt.Errorf("invalid --until value %q (want YYYY-MM-DD or RFC3339)", v)
+			}
+			opts.filter.Until = &t
+			i = ni
+		case strings.HasPrefix(arg, "-"):
+			return statsOptions{}, fmt.Errorf("unknown flag: %s", arg)
+		default:
+			return statsOptions{}, fmt.Errorf("stats does not take positional arguments, got %q", arg)
+		}
+	}
+
+	return opts, nil
+}
+
+// splitFlag separates a flag token into its name and optional inline value,
+// e.g. "--repo=foo" becomes ("--repo", "foo", true).
+func splitFlag(arg string) (name, value string, hasValue bool) {
+	if eq := strings.IndexByte(arg, '='); eq >= 0 {
+		return arg[:eq], arg[eq+1:], true
+	}
+	return arg, "", false
+}
+
+// inlineOrEmpty returns the inline value only when one was present, so that a
+// bare flag falls through to consuming the next argument.
+func inlineOrEmpty(value string, hasValue bool) string {
+	if hasValue {
+		return value
+	}
+	return ""
+}
+
+// parseStatsTime parses a timestamp in RFC3339 or common date-only forms.
+func parseStatsTime(s string) (time.Time, bool) {
+	layouts := []string{
+		time.RFC3339,
+		"2006-01-02T15:04:05.000Z",
+		"2006-01-02T15:04:05",
+		"2006-01-02",
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// buildStatsReport aggregates the given sessions into a summary.
+func buildStatsReport(sessions []data.Session) statsReport {
+	report := statsReport{
+		ByRepository: []countEntry{},
+		ByBranch:     []countEntry{},
+		ByHostType:   []countEntry{},
+	}
+
+	repoCounts := map[string]int{}
+	branchCounts := map[string]int{}
+	hostCounts := map[string]int{}
+
+	var earliest, latest time.Time
+
+	for _, s := range sessions {
+		report.TotalSessions++
+		report.TotalTurns += s.TurnCount
+		report.TotalFiles += s.FileCount
+
+		repoCounts[labelOr(s.Repository, "(none)")]++
+		branchCounts[labelOr(s.Branch, "(none)")]++
+		hostCounts[labelOr(s.HostType, "(unknown)")]++
+
+		if t, ok := parseStatsTime(s.CreatedAt); ok {
+			if earliest.IsZero() || t.Before(earliest) {
+				earliest = t
+			}
+		}
+		if t, ok := latestTime(s); ok {
+			if latest.IsZero() || t.After(latest) {
+				latest = t
+			}
+		}
+	}
+
+	if !earliest.IsZero() {
+		report.Earliest = earliest.UTC().Format("2006-01-02")
+	}
+	if !latest.IsZero() {
+		report.Latest = latest.UTC().Format("2006-01-02")
+	}
+
+	report.ByRepository = sortedCounts(repoCounts)
+	report.ByBranch = sortedCounts(branchCounts)
+	report.ByHostType = sortedCounts(hostCounts)
+	return report
+}
+
+// latestTime returns the most recent timestamp for a session, preferring
+// LastActiveAt and falling back to UpdatedAt then CreatedAt.
+func latestTime(s data.Session) (time.Time, bool) {
+	for _, ts := range []string{s.LastActiveAt, s.UpdatedAt, s.CreatedAt} {
+		if t, ok := parseStatsTime(ts); ok {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// labelOr returns value, or fallback when value is empty.
+func labelOr(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}
+
+// sortedCounts converts a label/count map into a slice ordered by count
+// descending, then label ascending for stable output.
+func sortedCounts(counts map[string]int) []countEntry {
+	entries := make([]countEntry, 0, len(counts))
+	for label, count := range counts {
+		entries = append(entries, countEntry{Label: label, Count: count})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Count != entries[j].Count {
+			return entries[i].Count > entries[j].Count
+		}
+		return entries[i].Label < entries[j].Label
+	})
+	return entries
+}
+
+// writeStatsJSON prints the report as a single JSON object.
+func writeStatsJSON(w io.Writer, report statsReport) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(report)
+}
+
+// writeStatsText prints the report in a plain, human-readable layout.
+func writeStatsText(w io.Writer, report statsReport) {
+	fmt.Fprintln(w, "Dispatch stats")
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Sessions: %d\n", report.TotalSessions)
+	fmt.Fprintf(w, "Turns:    %d\n", report.TotalTurns)
+	fmt.Fprintf(w, "Files:    %d\n", report.TotalFiles)
+	if report.Earliest != "" && report.Latest != "" {
+		fmt.Fprintf(w, "Range:    %s to %s\n", report.Earliest, report.Latest)
+	}
+
+	if report.TotalSessions == 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "No sessions found.")
+		return
+	}
+
+	writeCountSection(w, "By repository", report.ByRepository)
+	writeCountSection(w, "By branch", report.ByBranch)
+	writeCountSection(w, "By host type", report.ByHostType)
+}
+
+// writeCountSection prints a titled breakdown with aligned counts.
+func writeCountSection(w io.Writer, title string, entries []countEntry) {
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, title)
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "  (no data)")
+		return
+	}
+	width := 0
+	for _, e := range entries {
+		if len(e.Label) > width {
+			width = len(e.Label)
+		}
+	}
+	for _, e := range entries {
+		fmt.Fprintf(w, "  %-*s  %d\n", width, e.Label, e.Count)
+	}
+}
+
+// defaultStatsListSessions loads every stored session matching the filter.
+func defaultStatsListSessions(filter data.FilterOptions) ([]data.Session, error) {
+	store, err := data.Open()
+	if err != nil {
+		return nil, fmt.Errorf("opening session store: %w", err)
+	}
+	defer store.Close() //nolint:errcheck // read-only, best-effort close
+
+	sortOpts := data.SortOptions{Field: data.SortByCreated, Order: data.Ascending}
+	sessions, err := store.ListSessions(context.Background(), filter, sortOpts, statsQueryLimit)
+	if err != nil {
+		return nil, fmt.Errorf("listing sessions: %w", err)
+	}
+	return sessions, nil
+}

--- a/cmd/dispatch/stats_test.go
+++ b/cmd/dispatch/stats_test.go
@@ -1,0 +1,219 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jongio/dispatch/internal/data"
+)
+
+func withStatsList(t *testing.T, fn func(data.FilterOptions) ([]data.Session, error)) {
+	t.Helper()
+	prev := statsListSessionsFn
+	statsListSessionsFn = fn
+	t.Cleanup(func() { statsListSessionsFn = prev })
+}
+
+func sampleSessions() []data.Session {
+	return []data.Session{
+		{
+			ID:           "a",
+			Repository:   "jongio/dispatch",
+			Branch:       "main",
+			HostType:     "github",
+			CreatedAt:    "2026-01-05T10:00:00Z",
+			LastActiveAt: "2026-01-06T10:00:00Z",
+			TurnCount:    5,
+			FileCount:    3,
+		},
+		{
+			ID:           "b",
+			Repository:   "jongio/dispatch",
+			Branch:       "feature",
+			HostType:     "github",
+			CreatedAt:    "2026-02-01T10:00:00Z",
+			LastActiveAt: "2026-07-01T10:00:00Z",
+			TurnCount:    10,
+			FileCount:    2,
+		},
+		{
+			ID:         "c",
+			Repository: "",
+			Branch:     "",
+			HostType:   "",
+			CreatedAt:  "2026-03-01T10:00:00Z",
+			UpdatedAt:  "2026-03-02T10:00:00Z",
+			TurnCount:  1,
+			FileCount:  0,
+		},
+	}
+}
+
+func TestBuildStatsReportTotals(t *testing.T) {
+	report := buildStatsReport(sampleSessions())
+
+	if report.TotalSessions != 3 {
+		t.Errorf("TotalSessions = %d, want 3", report.TotalSessions)
+	}
+	if report.TotalTurns != 16 {
+		t.Errorf("TotalTurns = %d, want 16", report.TotalTurns)
+	}
+	if report.TotalFiles != 5 {
+		t.Errorf("TotalFiles = %d, want 5", report.TotalFiles)
+	}
+	if report.Earliest != "2026-01-05" {
+		t.Errorf("Earliest = %q, want 2026-01-05", report.Earliest)
+	}
+	if report.Latest != "2026-07-01" {
+		t.Errorf("Latest = %q, want 2026-07-01", report.Latest)
+	}
+}
+
+func TestBuildStatsReportGrouping(t *testing.T) {
+	report := buildStatsReport(sampleSessions())
+
+	if len(report.ByRepository) != 2 {
+		t.Fatalf("ByRepository len = %d, want 2", len(report.ByRepository))
+	}
+	// Highest count first.
+	if report.ByRepository[0].Label != "jongio/dispatch" || report.ByRepository[0].Count != 2 {
+		t.Errorf("ByRepository[0] = %+v, want jongio/dispatch=2", report.ByRepository[0])
+	}
+	if report.ByRepository[1].Label != "(none)" || report.ByRepository[1].Count != 1 {
+		t.Errorf("ByRepository[1] = %+v, want (none)=1", report.ByRepository[1])
+	}
+
+	var host string
+	for _, e := range report.ByHostType {
+		if e.Label == "(unknown)" {
+			host = e.Label
+		}
+	}
+	if host == "" {
+		t.Errorf("expected an (unknown) host type bucket, got %+v", report.ByHostType)
+	}
+}
+
+func TestBuildStatsReportEmpty(t *testing.T) {
+	report := buildStatsReport(nil)
+	if report.TotalSessions != 0 {
+		t.Errorf("TotalSessions = %d, want 0", report.TotalSessions)
+	}
+	if report.Earliest != "" || report.Latest != "" {
+		t.Errorf("expected empty range, got %q..%q", report.Earliest, report.Latest)
+	}
+	if report.ByRepository == nil || report.ByBranch == nil || report.ByHostType == nil {
+		t.Errorf("group slices should be non-nil for JSON output")
+	}
+}
+
+func TestParseStatsArgs(t *testing.T) {
+	opts, err := parseStatsArgs([]string{"stats", "--json", "--repo", "jongio/dispatch", "--branch=main", "--since", "2026-01-01", "--until=2026-07-01"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !opts.json {
+		t.Error("expected json=true")
+	}
+	if opts.filter.Repository != "jongio/dispatch" {
+		t.Errorf("Repository = %q", opts.filter.Repository)
+	}
+	if opts.filter.Branch != "main" {
+		t.Errorf("Branch = %q", opts.filter.Branch)
+	}
+	if opts.filter.Since == nil || opts.filter.Until == nil {
+		t.Fatal("expected Since and Until to be set")
+	}
+	if opts.filter.Since.Format("2006-01-02") != "2026-01-01" {
+		t.Errorf("Since = %v", opts.filter.Since)
+	}
+}
+
+func TestParseStatsArgsErrors(t *testing.T) {
+	cases := [][]string{
+		{"stats", "--repo"},              // missing value
+		{"stats", "--since", "not-date"}, // bad date
+		{"stats", "--bogus"},             // unknown flag
+		{"stats", "extra"},               // positional
+	}
+	for _, args := range cases {
+		if _, err := parseStatsArgs(args); err == nil {
+			t.Errorf("parseStatsArgs(%v) expected error, got nil", args)
+		}
+	}
+}
+
+func TestRunStatsText(t *testing.T) {
+	withStatsList(t, func(data.FilterOptions) ([]data.Session, error) {
+		return sampleSessions(), nil
+	})
+
+	var buf bytes.Buffer
+	if err := runStats(&buf, []string{"stats"}); err != nil {
+		t.Fatalf("runStats: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"Sessions: 3", "Turns:    16", "Files:    5", "By repository", "jongio/dispatch", "By host type"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestRunStatsJSON(t *testing.T) {
+	withStatsList(t, func(data.FilterOptions) ([]data.Session, error) {
+		return sampleSessions(), nil
+	})
+
+	var buf bytes.Buffer
+	if err := runStats(&buf, []string{"stats", "--json"}); err != nil {
+		t.Fatalf("runStats: %v", err)
+	}
+	var report statsReport
+	if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, buf.String())
+	}
+	if report.TotalSessions != 3 || report.TotalTurns != 16 {
+		t.Errorf("unexpected report: %+v", report)
+	}
+}
+
+func TestRunStatsPassesFilter(t *testing.T) {
+	var got data.FilterOptions
+	withStatsList(t, func(f data.FilterOptions) ([]data.Session, error) {
+		got = f
+		return nil, nil
+	})
+
+	if err := runStats(&bytes.Buffer{}, []string{"stats", "--repo", "jongio/dispatch"}); err != nil {
+		t.Fatalf("runStats: %v", err)
+	}
+	if got.Repository != "jongio/dispatch" {
+		t.Errorf("filter.Repository = %q, want jongio/dispatch", got.Repository)
+	}
+}
+
+func TestRunStatsListError(t *testing.T) {
+	withStatsList(t, func(data.FilterOptions) ([]data.Session, error) {
+		return nil, errors.New("boom")
+	})
+	if err := runStats(&bytes.Buffer{}, []string{"stats"}); err == nil {
+		t.Error("expected error from list failure")
+	}
+}
+
+func TestHandleArgsStats(t *testing.T) {
+	withStatsList(t, func(data.FilterOptions) ([]data.Session, error) {
+		return sampleSessions(), nil
+	})
+	done, _, err := handleArgs([]string{"stats", "--json"}, &bytes.Buffer{}, nil)
+	if !done {
+		t.Error("expected done=true for stats")
+	}
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
Adds a non-interactive `dispatch stats` subcommand that summarizes the session store without opening the TUI. Useful for a shell status line, a daily report, or a quick sanity check.

## What it does
- Prints totals: session count, turn count, file count, and the date range covered.
- Prints counts grouped by repository, by branch, and by host type, sorted by count.
- `--json` prints the same data as a single JSON object for scripts.
- `--repo`, `--branch`, `--folder`, `--since`, and `--until` reuse the existing data filters so the numbers match what the TUI shows. Dates accept `YYYY-MM-DD` or RFC3339.

## Behavior
- An empty store prints zero counts and exits 0.
- An unreadable store exits non-zero with the error on stderr.
- Help text and the bash, zsh, and powershell completion lists include the new command.

## Notes
- Follows the same early-exit subcommand pattern as `doctor` in `cmd/dispatch/cli.go` and reads through `internal/data` `ListSessions` with `FilterOptions`.
- Tests cover argument parsing, filter passing, aggregation, empty input, JSON output, and the list-error path.

Closes #188