### PR TITLE
Add host-type pivot to session grouping

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,7 +52,7 @@ type NamedView struct {
 	// SortOrder is the sort direction ("asc" or "desc").
 	SortOrder string `json:"sort_order,omitempty"`
 
-	// Pivot is the grouping mode (e.g. "none", "folder", "repo", "branch", "date").
+	// Pivot is the grouping mode (e.g. "none", "folder", "repo", "branch", "date", "host").
 	Pivot string `json:"pivot,omitempty"`
 
 	// FavoritesOnly restricts the list to favorited sessions.
@@ -93,7 +93,7 @@ func (v *NamedView) Validate() error {
 	}
 	if v.Pivot != "" {
 		switch v.Pivot {
-		case PivotNone, PivotFolder, PivotRepo, PivotBranch, PivotDate:
+		case PivotNone, PivotFolder, PivotRepo, PivotBranch, PivotDate, PivotHost:
 		default:
 			return fmt.Errorf("named view %q: invalid pivot %q", v.Name, v.Pivot)
 		}
@@ -128,7 +128,7 @@ type Config struct {
 	DefaultSortOrder string `json:"default_sort_order,omitempty"`
 
 	// DefaultPivot is the default grouping applied to session lists.
-	// Valid values: "none", "folder", "repo", "branch", "date".
+	// Valid values: "none", "folder", "repo", "branch", "date", "host".
 	DefaultPivot string `json:"default_pivot"`
 
 	// ShowPreview controls whether the detail/preview panel is visible.
@@ -331,6 +331,7 @@ const (
 	PivotRepo   = "repo"
 	PivotBranch = "branch"
 	PivotDate   = "date"
+	PivotHost   = "host"
 )
 
 // EffectivePaneDirection returns the configured pane direction, defaulting

--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -269,6 +269,9 @@ const (
 	PivotByBranch PivotField = "branch"
 	// PivotByDate groups sessions by date (YYYY-MM-DD).
 	PivotByDate PivotField = "date"
+	// PivotByHost groups sessions by host type (the provider that created
+	// the session, e.g. "github" or "ado").
+	PivotByHost PivotField = "host_type"
 )
 
 // SessionGroup holds a set of sessions that share a common pivot label.

--- a/internal/data/store.go
+++ b/internal/data/store.go
@@ -431,6 +431,8 @@ func pivotExpr(p PivotField) string {
 		return "COALESCE(s.branch, '')"
 	case PivotByDate:
 		return lastActiveExpr
+	case PivotByHost:
+		return "COALESCE(s.host_type, '')"
 	default: // PivotByFolder and any unknown value
 		return coalesceCwd
 	}
@@ -1004,6 +1006,11 @@ func (s *Store) GroupSessions(ctx context.Context, pivot PivotField, filter Filt
 	fb.apply(s.withAutoExclusions(filter))
 
 	expr := pivotExpr(pivot)
+	// Older schemas (pre-v3) have no host_type column. Fall back to a single
+	// empty-label group rather than issuing a query that would error.
+	if pivot == PivotByHost && !s.hasHostType {
+		expr = "''"
+	}
 	q := fmt.Sprintf("SELECT %s AS pivot_label, %s FROM sessions s%s%s%s ORDER BY pivot_label, %s %s",
 		expr, s.sessionColumns(), countJoins, fb.joinSQL(), fb.whereSQL(), sortColumn(sort.Field), sortDir(sort.Order))
 

--- a/internal/data/store_coverage_test.go
+++ b/internal/data/store_coverage_test.go
@@ -304,6 +304,7 @@ func TestCovPivotExpr_AllFields(t *testing.T) {
 		{PivotByRepo, "COALESCE(s.repository, '')"},
 		{PivotByBranch, "COALESCE(s.branch, '')"},
 		{PivotByDate, lastActiveExpr},
+		{PivotByHost, "COALESCE(s.host_type, '')"},
 		{PivotByFolder, "COALESCE(s.cwd, '')"},
 		{"unknown", "COALESCE(s.cwd, '')"},
 	}
@@ -372,7 +373,7 @@ func TestCovGroupSessions_AllPivots(t *testing.T) {
 	defer func() { _ = s.Close() }()
 	populateTestData(t, s)
 
-	pivots := []PivotField{PivotByFolder, PivotByRepo, PivotByBranch, PivotByDate}
+	pivots := []PivotField{PivotByFolder, PivotByRepo, PivotByBranch, PivotByDate, PivotByHost}
 	for _, p := range pivots {
 		t.Run(string(p), func(t *testing.T) {
 			groups, err := s.GroupSessions(context.Background(), p, FilterOptions{}, SortOptions{Field: SortByUpdated, Order: Descending}, 100)

--- a/internal/data/store_test.go
+++ b/internal/data/store_test.go
@@ -1675,6 +1675,7 @@ func TestPivotExpr(t *testing.T) {
 		{PivotByRepo, "COALESCE(s.repository, '')"},
 		{PivotByBranch, "COALESCE(s.branch, '')"},
 		{PivotByDate, lastActiveExpr},
+		{PivotByHost, "COALESCE(s.host_type, '')"},
 		{PivotField("unknown"), "COALESCE(s.cwd, '')"}, // defaults to folder
 	}
 	for _, tt := range tests {

--- a/internal/tui/components/sessionlist.go
+++ b/internal/tui/components/sessionlist.go
@@ -107,7 +107,7 @@ func (s *SessionList) SetGroups(groups []data.SessionGroup) {
 }
 
 // SetPivotField stores the current pivot mode so that group header icons
-// reflect the active grouping dimension (folder, repo, branch, date).
+// reflect the active grouping dimension (folder, repo, branch, date, host).
 func (s *SessionList) SetPivotField(pivot string) {
 	s.pivotField = pivot
 }
@@ -697,6 +697,9 @@ func (s SessionList) renderFolderRow(item displayItem, selected bool) string {
 	}
 
 	folder := AbbrevHome(item.folderPath)
+	if s.pivotField == "host" {
+		folder = hostGroupLabel(item.folderPath)
+	}
 	count := strconv.Itoa(item.count)
 
 	prefix := " " + arrow + " "
@@ -714,6 +717,21 @@ func (s SessionList) renderFolderRow(item displayItem, selected bool) string {
 		return styles.SelectedStyle.Render(PadToWidth(line, s.width))
 	}
 	return styles.GroupHeaderStyle.Render(PadToWidth(line, s.width))
+}
+
+// hostGroupLabel maps a raw host type value to a readable group label for the
+// host pivot. Empty values fall into a single clearly named group.
+func hostGroupLabel(hostType string) string {
+	switch hostType {
+	case "github":
+		return "GitHub"
+	case "ado":
+		return "Azure DevOps"
+	case "":
+		return "No host"
+	default:
+		return hostType
+	}
 }
 
 func (s SessionList) renderSessionRow(sess data.Session, selected bool, hidden bool, aiFound bool, favorited bool) string {

--- a/internal/tui/components/sessionlist_hostpivot_test.go
+++ b/internal/tui/components/sessionlist_hostpivot_test.go
@@ -1,0 +1,48 @@
+package components
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jongio/dispatch/internal/data"
+)
+
+func TestHostGroupLabel(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"github", "GitHub"},
+		{"ado", "Azure DevOps"},
+		{"", "No host"},
+		{"other", "other"},
+	}
+	for _, tt := range tests {
+		if got := hostGroupLabel(tt.in); got != tt.want {
+			t.Errorf("hostGroupLabel(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestHostPivotRendersFriendlyLabels(t *testing.T) {
+	sl := NewSessionList()
+	sl.SetPivotField("host")
+	sl.SetGroups([]data.SessionGroup{
+		{Label: "github", Count: 2, Sessions: []data.Session{
+			{ID: "1", HostType: "github"},
+			{ID: "2", HostType: "github"},
+		}},
+		{Label: "", Count: 1, Sessions: []data.Session{
+			{ID: "3"},
+		}},
+	})
+	sl.SetSize(80, 20)
+
+	view := sl.View()
+	if !strings.Contains(view, "GitHub") {
+		t.Errorf("expected view to contain friendly host label 'GitHub'\n%s", view)
+	}
+	if !strings.Contains(view, "No host") {
+		t.Errorf("expected view to contain 'No host' for empty host type\n%s", view)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -136,6 +136,7 @@ const (
 	pivotRepo   = "repo"
 	pivotBranch = "branch"
 	pivotDate   = "date"
+	pivotHost   = "host"
 )
 
 // ---------------------------------------------------------------------------
@@ -198,7 +199,7 @@ type Model struct {
 	filter     data.FilterOptions
 	sort       data.SortOptions
 	timeRange  string         // "1h", "1d", "7d", "all"
-	pivot      string         // "none", "folder", "repo", "branch", "date"
+	pivot      string         // "none", "folder", "repo", "branch", "date", "host"
 	pivotOrder data.SortOrder // group header sort direction
 
 	// Loaded data.
@@ -2823,7 +2824,7 @@ func (m *Model) toggleSortOrder() {
 	m.saveConfig()
 }
 
-var pivotModes = []string{pivotNone, pivotFolder, pivotRepo, pivotBranch, pivotDate}
+var pivotModes = []string{pivotNone, pivotFolder, pivotRepo, pivotBranch, pivotDate, pivotHost}
 
 func (m *Model) cyclePivot() {
 	for i, p := range pivotModes {
@@ -3977,6 +3978,8 @@ func pivotFieldFromString(s string) data.PivotField {
 		return data.PivotByBranch
 	case pivotDate:
 		return data.PivotByDate
+	case pivotHost:
+		return data.PivotByHost
 	default:
 		return data.PivotByFolder
 	}

--- a/internal/tui/model_coverage_test.go
+++ b/internal/tui/model_coverage_test.go
@@ -497,8 +497,8 @@ func TestCovCyclePivotFullCycle(t *testing.T) {
 	m := newTestModel()
 	m.pivot = pivotNone
 
-	// pivotModes = [none, folder, repo, branch, date]
-	expected := []string{pivotFolder, pivotRepo, pivotBranch, pivotDate, pivotNone}
+	// pivotModes = [none, folder, repo, branch, date, host]
+	expected := []string{pivotFolder, pivotRepo, pivotBranch, pivotDate, pivotHost, pivotNone}
 	for _, exp := range expected {
 		m.cyclePivot()
 		if m.pivot != exp {

--- a/internal/tui/model_helpers_test.go
+++ b/internal/tui/model_helpers_test.go
@@ -56,6 +56,7 @@ func TestPivotFieldFromString(t *testing.T) {
 		{"repo", data.PivotByRepo},
 		{"branch", data.PivotByBranch},
 		{"date", data.PivotByDate},
+		{"host", data.PivotByHost},
 		{"none", data.PivotByFolder}, // unknown → folder
 		{"", data.PivotByFolder},
 		{"unknown", data.PivotByFolder},
@@ -755,7 +756,7 @@ func TestCyclePivot(t *testing.T) {
 	m := newTestModel()
 	m.pivot = pivotNone
 
-	expected := []string{pivotFolder, pivotRepo, pivotBranch, pivotDate, pivotNone}
+	expected := []string{pivotFolder, pivotRepo, pivotBranch, pivotDate, pivotHost, pivotNone}
 	for _, exp := range expected {
 		m.cyclePivot()
 		if m.pivot != exp {

--- a/internal/tui/styles/icons.go
+++ b/internal/tui/styles/icons.go
@@ -62,6 +62,7 @@ const (
 	// Host type icons — distinguish session origin (GitHub, Azure DevOps).
 	nfGitHub = "\uf09b" //  nf-fa-github
 	nfADO    = "\uf0c2" //  nf-fa-cloud (Azure DevOps)
+	nfHost   = "\uf233" //  nf-fa-server (host type pivot group)
 	nfPencil = "\uf040" //  nf-fa-pencil
 )
 
@@ -93,6 +94,7 @@ const (
 
 	fbGitHub = "⊙"
 	fbADO    = "☁"
+	fbHost   = "⛁"
 	fbPencil = "✎"
 )
 
@@ -163,6 +165,12 @@ func IconBranch() string { return icon(nfGitBranch+" ", fbBranch) }
 
 // IconBranchOpen returns the expanded git branch icon ("" or "⎇").
 func IconBranchOpen() string { return icon(nfGitBranch+" ", fbBranch) }
+
+// IconHost returns the collapsed host type icon ("" or "⛁").
+func IconHost() string { return icon(nfHost+" ", fbHost) }
+
+// IconHostOpen returns the expanded host type icon ("" or "⛁").
+func IconHostOpen() string { return icon(nfHost+" ", fbHost) }
 
 // ---------------------------------------------------------------------------
 // Attention status dot icons
@@ -252,7 +260,8 @@ func IconGitMissing() string { return icon("\uf00d", "✗") } // nf-fa-times
 
 // PivotGroupIcons returns the (collapsed, expanded) icons for a pivot field.
 // The pivot string matches data.PivotField values ("cwd", "repository",
-// "branch", "date") or the TUI pivot mode constants ("folder", "repo", etc).
+// "branch", "date", "host_type") or the TUI pivot mode constants ("folder",
+// "repo", "host", etc).
 func PivotGroupIcons(pivot string) (collapsed, expanded string) {
 	switch pivot {
 	case "repository", "repo":
@@ -261,6 +270,8 @@ func PivotGroupIcons(pivot string) (collapsed, expanded string) {
 		return IconBranch(), IconBranchOpen()
 	case "date":
 		return IconCalendar(), IconCalendarOpen()
+	case "host", "host_type":
+		return IconHost(), IconHostOpen()
 	default: // "cwd", "folder", or anything else
 		return IconFolder(), IconFolderOpen()
 	}

--- a/internal/tui/styles/icons_test.go
+++ b/internal/tui/styles/icons_test.go
@@ -254,6 +254,8 @@ func TestPivotGroupIcons(t *testing.T) {
 		{"repository", IconRepo(), IconRepoOpen()},
 		{"branch", IconBranch(), IconBranchOpen()},
 		{"date", IconCalendar(), IconCalendarOpen()},
+		{"host", IconHost(), IconHostOpen()},
+		{"host_type", IconHost(), IconHostOpen()},
 		{"unknown", IconFolder(), IconFolderOpen()},
 		{"", IconFolder(), IconFolderOpen()},
 	}


### PR DESCRIPTION
## Problem

The pivot (grouping) modes cover folder, repo, branch, and date, but not where a session came from. People who mix GitHub and Azure DevOps sessions cannot group the list by origin.

## Proposed solution

Add a host type pivot mode to the existing Tab cycle. Sessions group by their host type with readable labels (GitHub, Azure DevOps) and per group counts like the other pivots. Sessions with no recorded host type fall into a single `No host` group.

## What changed

- Added `PivotByHost` to the data layer, mapping to the `host_type` column, with a schema guard for stores that predate the column.
- Added `host` to the TUI pivot cycle and `pivotFieldFromString` mapping.
- Added a dedicated host icon and wired it into `PivotGroupIcons`.
- Friendly group labels are applied at render time (GitHub, Azure DevOps, No host) while the raw value stays the expand/collapse key.

## Acceptance criteria

- [x] Tab cycles through a new host pivot in addition to folder, repo, branch, and date.
- [x] Sessions group by host type with readable labels and per group counts.
- [x] Sessions with no recorded host type fall into a single clearly labeled group.
- [x] The new mode reuses existing group rendering, expand and collapse, and sort behavior.

Closes #190