### PR TITLE
Add search query history recall

### DIFF
--- a/internal/tui/components/help.go
+++ b/internal/tui/components/help.go
@@ -90,6 +90,8 @@ func (h HelpOverlay) View() string {
 	sb.WriteByte('\n')
 	sb.WriteString(shortcutRow("/", "Search", "Esc", "Clear"))
 	sb.WriteByte('\n')
+	sb.WriteString(shortcutRow("↑/↓", "Search history", "", ""))
+	sb.WriteByte('\n')
 	sb.WriteString(shortcutRow("f", "Filter dirs", "Space", "Toggle item"))
 
 	// Multi-Select

--- a/internal/tui/components/searchbar.go
+++ b/internal/tui/components/searchbar.go
@@ -64,6 +64,11 @@ func (s *SearchBar) SetValue(v string) {
 	s.input.SetValue(v)
 }
 
+// CursorEnd moves the input cursor to the end of the current value.
+func (s *SearchBar) CursorEnd() {
+	s.input.CursorEnd()
+}
+
 // SetResultCount updates the displayed result count.
 func (s *SearchBar) SetResultCount(n int) {
 	s.resultCount = n

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -151,6 +151,98 @@ type searchState struct {
 	copilotSearchCancel  context.CancelFunc  // cancels the in-flight SDK search
 	aiSessionIDs         map[string]struct{} // session IDs found by SDK search
 	lastRawInput         string              // last raw search bar text (for change detection)
+	history              []string            // committed search queries, oldest last (for up/down recall)
+	historyIdx           int                 // recall cursor into history; == len(history) means not navigating
+}
+
+// maxSearchHistory caps how many recent queries are retained for up/down recall.
+const maxSearchHistory = 20
+
+// pushHistory records a committed query for later recall. Blank queries are
+// ignored. Duplicates are collapsed so the same query never appears twice, and
+// the most recent entry is kept at the end. The recall cursor is reset to the
+// end (not navigating) after every push.
+func (s *searchState) pushHistory(q string) {
+	q = strings.TrimSpace(q)
+	if q == "" {
+		s.historyIdx = len(s.history)
+		return
+	}
+	// Drop any earlier identical entry so recall order stays useful.
+	for i, h := range s.history {
+		if h == q {
+			s.history = append(s.history[:i], s.history[i+1:]...)
+			break
+		}
+	}
+	s.history = append(s.history, q)
+	if len(s.history) > maxSearchHistory {
+		s.history = s.history[len(s.history)-maxSearchHistory:]
+	}
+	s.historyIdx = len(s.history)
+}
+
+// recallPrev steps to the previous (older) history entry and returns it. The
+// bool is false when there is no history to recall.
+func (s *searchState) recallPrev() (string, bool) {
+	if len(s.history) == 0 {
+		return "", false
+	}
+	if s.historyIdx > 0 {
+		s.historyIdx--
+	}
+	return s.history[s.historyIdx], true
+}
+
+// recallNext steps to the next (newer) history entry and returns it. When the
+// cursor moves past the newest entry it returns an empty string so the caller
+// can clear the input. The bool is false when there is no history to recall.
+func (s *searchState) recallNext() (string, bool) {
+	if len(s.history) == 0 {
+		return "", false
+	}
+	if s.historyIdx < len(s.history) {
+		s.historyIdx++
+	}
+	if s.historyIdx >= len(s.history) {
+		return "", true
+	}
+	return s.history[s.historyIdx], true
+}
+
+// triggerSearch reacts to a new search bar value: it records the raw input,
+// parses structured tokens, kicks off the quick reload, and schedules the
+// debounced deep and Copilot SDK searches. inputCmd, when non-nil, is the
+// command returned by the text input update and is batched in first.
+func (m *Model) triggerSearch(inputCmd tea.Cmd) tea.Cmd {
+	newQuery := m.searchBar.Value()
+	m.search.lastRawInput = newQuery
+	// Parse structured tokens from the input.
+	m.searchFilter = ParseSearchTokens(newQuery)
+	m.applySearchTokens()
+	m.filter.DeepSearch = false
+	// Quick search fires immediately; schedule deep search.
+	m.search.deepSearchVersion++
+	m.search.deepSearchPending = true
+	m.searchBar.SetSearching(true)
+
+	cmds := make([]tea.Cmd, 0, 4)
+	if inputCmd != nil {
+		cmds = append(cmds, inputCmd)
+	}
+	cmds = append(cmds, m.loadSessionsCmd(), m.scheduleDeepSearch(m.search.deepSearchVersion))
+
+	// Copilot SDK search is gated by config flag.
+	if m.cfg.AISearch {
+		m.search.copilotSearchVersion++
+		m.searchBar.SetAISearching(false) // reset until tick fires
+		m.searchBar.SetAIResults(0)       // clear stale count
+		m.search.aiSessionIDs = nil
+		m.sessionList.SetAISessions(nil)
+		cmds = append(cmds, m.scheduleCopilotSearch(m.search.copilotSearchVersion))
+	}
+
+	return tea.Batch(cmds...)
 }
 
 // workStatusState groups fields related to work status scanning.
@@ -918,12 +1010,14 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			// sort, pivot) continue to honour the search term. To clear the
 			// search, press Escape again from the session list.
 			if m.filter.Query != "" || m.searchFilter.HasTokens() {
+				m.search.pushHistory(m.searchBar.Value())
 				m.filter.DeepSearch = true
 				return m, m.loadSessionsCmd()
 			}
 			return m, nil
 		case key.Matches(msg, keys.Enter):
 			m.searchBar.Blur()
+			m.search.pushHistory(m.searchBar.Value())
 			// If deep search hasn't run yet, trigger it now.
 			if m.search.deepSearchPending && (m.filter.Query != "" || m.searchFilter.HasTokens()) {
 				m.search.deepSearchPending = false
@@ -936,6 +1030,24 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				m.filter.DeepSearch = true
 			}
 			return m, nil
+		case msg.String() == "up":
+			// Recall an older query. Only the literal arrow key triggers
+			// history; the k alias for Up is left to be typed normally.
+			if q, ok := m.search.recallPrev(); ok {
+				m.searchBar.SetValue(q)
+				m.searchBar.CursorEnd()
+				return m, m.triggerSearch(nil)
+			}
+			return m, nil
+		case msg.String() == "down":
+			// Recall a newer query, clearing the input when moving past the
+			// most recent entry. The j alias for Down is left to typing.
+			if q, ok := m.search.recallNext(); ok {
+				m.searchBar.SetValue(q)
+				m.searchBar.CursorEnd()
+				return m, m.triggerSearch(nil)
+			}
+			return m, nil
 		default:
 			// All other keys (including j/k which alias Up/Down) are
 			// forwarded to the search text input so they appear as typed
@@ -946,29 +1058,7 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.searchBar = sb
 			newQuery := m.searchBar.Value()
 			if newQuery != m.search.lastRawInput {
-				m.search.lastRawInput = newQuery
-				// Parse structured tokens from the input.
-				m.searchFilter = ParseSearchTokens(newQuery)
-				m.applySearchTokens()
-				m.filter.DeepSearch = false
-				// Quick search fires immediately; schedule deep search.
-				m.search.deepSearchVersion++
-				m.search.deepSearchPending = true
-				m.searchBar.SetSearching(true)
-
-				cmds := []tea.Cmd{cmd, m.loadSessionsCmd(), m.scheduleDeepSearch(m.search.deepSearchVersion)}
-
-				// Copilot SDK search is gated by config flag.
-				if m.cfg.AISearch {
-					m.search.copilotSearchVersion++
-					m.searchBar.SetAISearching(false) // reset until tick fires
-					m.searchBar.SetAIResults(0)       // clear stale count
-					m.search.aiSessionIDs = nil
-					m.sessionList.SetAISessions(nil)
-					cmds = append(cmds, m.scheduleCopilotSearch(m.search.copilotSearchVersion))
-				}
-
-				return m, tea.Batch(cmds...)
+				return m, m.triggerSearch(cmd)
 			}
 			return m, cmd
 		}
@@ -997,6 +1087,7 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.filter.DeepSearch = false
 			m.searchFilter = SearchFilter{}
 			m.search.lastRawInput = ""
+			m.search.historyIdx = len(m.search.history)
 			m.clearSearchTokenFilters()
 			m.searchBar.SetValue("")
 			m.searchBar.SetSearching(false)

--- a/internal/tui/model_search_history_test.go
+++ b/internal/tui/model_search_history_test.go
@@ -83,25 +83,6 @@ func TestSearchStateHistoryDedupAndCap(t *testing.T) {
 	}
 }
 
-func itoa(i int) string {
-	if i == 0 {
-		return "0"
-	}
-	neg := i < 0
-	if neg {
-		i = -i
-	}
-	var b []byte
-	for i > 0 {
-		b = append([]byte{byte('0' + i%10)}, b...)
-		i /= 10
-	}
-	if neg {
-		b = append([]byte{'-'}, b...)
-	}
-	return string(b)
-}
-
 func TestSearchHistoryRecallViaKeys(t *testing.T) {
 	m := newTestModel()
 

--- a/internal/tui/model_search_history_test.go
+++ b/internal/tui/model_search_history_test.go
@@ -1,0 +1,146 @@
+package tui
+
+import (
+	"strconv"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func upKeyMsg() tea.KeyPressMsg   { return tea.KeyPressMsg{Code: tea.KeyUp} }
+func downKeyMsg() tea.KeyPressMsg { return tea.KeyPressMsg{Code: tea.KeyDown} }
+
+func TestSearchStateHistory(t *testing.T) {
+	var s searchState
+
+	// No history yet: recall is a no-op.
+	if _, ok := s.recallPrev(); ok {
+		t.Fatal("recallPrev on empty history should return false")
+	}
+	if _, ok := s.recallNext(); ok {
+		t.Fatal("recallNext on empty history should return false")
+	}
+
+	// Blank queries are ignored.
+	s.pushHistory("   ")
+	if len(s.history) != 0 {
+		t.Fatalf("blank query should not be recorded, history=%v", s.history)
+	}
+
+	s.pushHistory("alpha")
+	s.pushHistory("beta")
+	s.pushHistory("gamma")
+
+	// Recall walks backwards from newest to oldest.
+	if q, _ := s.recallPrev(); q != "gamma" {
+		t.Errorf("first recallPrev = %q, want gamma", q)
+	}
+	if q, _ := s.recallPrev(); q != "beta" {
+		t.Errorf("second recallPrev = %q, want beta", q)
+	}
+	if q, _ := s.recallPrev(); q != "alpha" {
+		t.Errorf("third recallPrev = %q, want alpha", q)
+	}
+	// Past the oldest it stays on the oldest entry.
+	if q, _ := s.recallPrev(); q != "alpha" {
+		t.Errorf("recallPrev past oldest = %q, want alpha", q)
+	}
+
+	// Recall forward walks toward newest, then clears past the end.
+	if q, _ := s.recallNext(); q != "beta" {
+		t.Errorf("recallNext = %q, want beta", q)
+	}
+	if q, _ := s.recallNext(); q != "gamma" {
+		t.Errorf("recallNext = %q, want gamma", q)
+	}
+	if q, ok := s.recallNext(); !ok || q != "" {
+		t.Errorf("recallNext past newest = (%q,%v), want (\"\",true)", q, ok)
+	}
+}
+
+func TestSearchStateHistoryDedupAndCap(t *testing.T) {
+	var s searchState
+
+	// Re-submitting an existing query moves it to the newest slot without
+	// creating a duplicate.
+	s.pushHistory("one")
+	s.pushHistory("two")
+	s.pushHistory("one")
+	if len(s.history) != 2 {
+		t.Fatalf("dedup failed, history=%v", s.history)
+	}
+	if q, _ := s.recallPrev(); q != "one" {
+		t.Errorf("most recent after re-submit = %q, want one", q)
+	}
+
+	// The ring is capped at maxSearchHistory entries.
+	var s2 searchState
+	for i := 0; i < maxSearchHistory+10; i++ {
+		s2.pushHistory("q-" + strconv.Itoa(i))
+	}
+	if len(s2.history) != maxSearchHistory {
+		t.Errorf("history len = %d, want %d", len(s2.history), maxSearchHistory)
+	}
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	if neg {
+		b = append([]byte{'-'}, b...)
+	}
+	return string(b)
+}
+
+func TestSearchHistoryRecallViaKeys(t *testing.T) {
+	m := newTestModel()
+
+	// Commit "foo".
+	m.searchBar.Focus()
+	m.searchBar.SetValue("foo")
+	m.filter.Query = "foo"
+	r, _ := m.Update(enterKeyMsg())
+	m = r.(Model)
+
+	// Commit "bar".
+	m.searchBar.Focus()
+	m.searchBar.SetValue("bar")
+	m.filter.Query = "bar"
+	r, _ = m.Update(enterKeyMsg())
+	m = r.(Model)
+
+	// Up recalls the most recent query, then the older one.
+	m.searchBar.Focus()
+	r, _ = m.Update(upKeyMsg())
+	m = r.(Model)
+	if got := m.searchBar.Value(); got != "bar" {
+		t.Fatalf("first Up recall = %q, want bar", got)
+	}
+	r, _ = m.Update(upKeyMsg())
+	m = r.(Model)
+	if got := m.searchBar.Value(); got != "foo" {
+		t.Fatalf("second Up recall = %q, want foo", got)
+	}
+
+	// Down walks back toward newest, then clears past the newest entry.
+	r, _ = m.Update(downKeyMsg())
+	m = r.(Model)
+	if got := m.searchBar.Value(); got != "bar" {
+		t.Fatalf("Down recall = %q, want bar", got)
+	}
+	r, _ = m.Update(downKeyMsg())
+	m = r.(Model)
+	if got := m.searchBar.Value(); got != "" {
+		t.Fatalf("Down past newest = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Problem

The search box does not remember recent queries. Re-running a search you typed a minute ago means typing it out again.

## Proposed solution

Keep a short in-memory history of recent search queries. When the search box is focused, Up recalls the previous query and Down walks back toward the most recent, clearing the box when you move past the newest entry.

## What changed

- Added a capped history ring (20 entries) to the search state in `internal/tui`.
- Submitting a query (Enter, or Escape with an active query) records it. A repeated query moves to the most recent slot instead of being stored twice, and blank queries are ignored.
- Up and Down are intercepted in the focused search block only. The literal arrow keys drive recall while the j and k aliases are still typed normally, so list navigation is untouched.
- History is per run and is not persisted across restarts.
- Help overlay lists the new up/down recall.

## Acceptance criteria

- [x] While the search box is focused, Up recalls the previous query and Down moves toward the most recent.
- [x] Submitting a search adds it to the history; a repeated query moves to the most recent slot instead of being stored twice.
- [x] History is capped at 20 entries and does not persist across restarts.
- [x] Recall only applies while the search box is focused and does not affect list navigation otherwise.
- [x] Empty queries are not stored.

Closes #191