### PR TITLE
Add copy path action for session working directory

### DIFF
--- a/internal/tui/cmdpalette.go
+++ b/internal/tui/cmdpalette.go
@@ -20,6 +20,12 @@ func (m *Model) openCmdPalette() {
 	hasPreview := func() bool {
 		return m.showPreview && m.detail != nil
 	}
+	hasPath := func() bool {
+		if _, ok := m.sessionList.Selected(); ok {
+			return true
+		}
+		return m.sessionList.SelectedFolderCwd() != ""
+	}
 	alwaysEnabled := func() bool { return true }
 
 	cmds := []components.Command{
@@ -28,6 +34,7 @@ func (m *Model) openCmdPalette() {
 		{Name: "Open in Tab", Shortcut: "t", Description: "new tab", Action: "launch-tab", Enabled: hasSelection},
 		{Name: "Open in Pane", Shortcut: "e", Description: "new pane", Action: "launch-pane", Enabled: hasSelection},
 		{Name: "Copy Session ID", Shortcut: "c", Description: "copy to clipboard", Action: "copy-id", Enabled: hasSelection},
+		{Name: "Copy Path", Shortcut: "C", Description: "copy working dir", Action: "copy-path", Enabled: hasPath},
 		{Name: "Copy Preview", Shortcut: "y", Description: "copy preview text", Action: "copy-preview", Enabled: hasPreview},
 		{Name: "Search", Shortcut: "/", Description: "filter sessions", Action: "search", Enabled: alwaysEnabled},
 		{Name: "Filter Panel", Shortcut: "f", Description: "directory filter", Action: "filter", Enabled: alwaysEnabled},
@@ -77,6 +84,9 @@ func (m Model) handleCmdPaletteAction(msg cmdPaletteActionMsg) (tea.Model, tea.C
 
 	case "copy-id":
 		return m.handleCopyID()
+
+	case "copy-path":
+		return m.handleCopyPath()
 
 	case "copy-preview":
 		return m.handleCopyPreview()

--- a/internal/tui/components/help.go
+++ b/internal/tui/components/help.go
@@ -120,6 +120,8 @@ func (h HelpOverlay) View() string {
 	sb.WriteByte('\n')
 	sb.WriteString(shortcutRow("c", "Copy session ID", "y", "Copy preview"))
 	sb.WriteByte('\n')
+	sb.WriteString(shortcutRow("C", "Copy path", "", ""))
+	sb.WriteByte('\n')
 	sb.WriteString(shortcutRow("r", "Rebuild Index", "", ""))
 
 	// Time Range

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -46,6 +46,7 @@ type keyMap struct {
 	ResumeInterrupted key.Binding
 	ViewPlan          key.Binding
 	CopyID            key.Binding
+	CopyPath          key.Binding
 	CopyPreview       key.Binding
 	ExpandCollapseAll key.Binding
 	ScanWorkStatus    key.Binding
@@ -62,7 +63,7 @@ type keyMap struct {
 
 // ShortHelp returns a compact set of key bindings for the mini help bar.
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Enter, k.LaunchWindow, k.LaunchTab, k.LaunchPane, k.LaunchAll, k.Search, k.Filter, k.Sort, k.Preview, k.ViewPlan, k.Timeline, k.Compare, k.Hide, k.Star, k.Note, k.CopyID, k.CopyPreview, k.Export, k.OpenFile, k.JumpNextAttention, k.FilterAttention, k.ResumeInterrupted, k.ScanWorkStatus, k.ExpandCollapseAll, k.ViewSwitch, k.CmdPalette, k.Config, k.Help, k.Quit}
+	return []key.Binding{k.Enter, k.LaunchWindow, k.LaunchTab, k.LaunchPane, k.LaunchAll, k.Search, k.Filter, k.Sort, k.Preview, k.ViewPlan, k.Timeline, k.Compare, k.Hide, k.Star, k.Note, k.CopyID, k.CopyPath, k.CopyPreview, k.Export, k.OpenFile, k.JumpNextAttention, k.FilterAttention, k.ResumeInterrupted, k.ScanWorkStatus, k.ExpandCollapseAll, k.ViewSwitch, k.CmdPalette, k.Config, k.Help, k.Quit}
 }
 
 // FullHelp returns grouped key bindings for the expanded help view.
@@ -72,7 +73,7 @@ func (k keyMap) FullHelp() [][]key.Binding {
 		{k.Space, k.LaunchAll, k.SelectAll, k.DeselectAll, k.ShiftUp, k.ShiftDown},
 		{k.Search, k.Escape, k.Filter},
 		{k.Sort, k.SortOrder, k.Pivot, k.PivotOrder, k.ExpandCollapseAll},
-		{k.Preview, k.PreviewPosition, k.PreviewScrollUp, k.PreviewScrollDown, k.ConversationSort, k.ViewPlan, k.Timeline, k.Compare, k.CopyID, k.CopyPreview, k.Export, k.OpenFile, k.Reindex, k.ScanWorkStatus, k.ViewSwitch, k.Config},
+		{k.Preview, k.PreviewPosition, k.PreviewScrollUp, k.PreviewScrollDown, k.ConversationSort, k.ViewPlan, k.Timeline, k.Compare, k.CopyID, k.CopyPath, k.CopyPreview, k.Export, k.OpenFile, k.Reindex, k.ScanWorkStatus, k.ViewSwitch, k.Config},
 		{k.Hide, k.ToggleHidden, k.Star, k.Note, k.JumpNextAttention, k.FilterAttention, k.ResumeInterrupted},
 		{k.TimeRange1, k.TimeRange2, k.TimeRange3, k.TimeRange4},
 		{k.Help, k.CmdPalette, k.Quit},
@@ -121,6 +122,7 @@ var keys = keyMap{
 	ResumeInterrupted: key.NewBinding(key.WithKeys("N"), key.WithHelp("N", "resume interrupted")),
 	ViewPlan:          key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "view plan")),
 	CopyID:            key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "copy session ID")),
+	CopyPath:          key.NewBinding(key.WithKeys("C"), key.WithHelp("C", "copy path")),
 	CopyPreview:       key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "copy preview")),
 	ExpandCollapseAll: key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "expand/collapse all")),
 	ScanWorkStatus:    key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "scan work status")),

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -55,6 +55,10 @@ const (
 	// copied to the clipboard.
 	statusCopiedID = "Copied session ID ✓"
 
+	// statusCopiedPath is the status message shown when a session or folder
+	// working directory path is copied to the clipboard.
+	statusCopiedPath = "Copied path ✓"
+
 	// statusCopiedPreview is the status message shown when preview content
 	// is copied to the clipboard via the y key.
 	statusCopiedPreview = "Copied to clipboard ✓"
@@ -1259,6 +1263,9 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, keys.CopyID):
 		return m.handleCopyID()
 
+	case key.Matches(msg, keys.CopyPath):
+		return m.handleCopyPath()
+
 	case key.Matches(msg, keys.CopyPreview):
 		return m.handleCopyPreview()
 
@@ -1426,6 +1433,28 @@ func (m Model) handleCopyID() (tea.Model, tea.Cmd) {
 		return m, clearStatusAfter(2 * time.Second)
 	}
 	m.statusInfo = statusCopiedID
+	return m, clearStatusAfter(2 * time.Second)
+}
+
+// handleCopyPath copies the selected session's working directory to the
+// system clipboard. When a folder row is selected under a folder or repo
+// pivot, the folder's path is copied instead.
+func (m Model) handleCopyPath() (tea.Model, tea.Cmd) {
+	path := ""
+	if sess, ok := m.sessionList.Selected(); ok {
+		path = sess.Cwd
+	} else {
+		path = m.sessionList.SelectedFolderCwd()
+	}
+	if path == "" {
+		m.statusInfo = "No path to copy"
+		return m, clearStatusAfter(2 * time.Second)
+	}
+	if err := clipboardWrite(path); err != nil {
+		m.statusErr = "clipboard: " + err.Error()
+		return m, clearStatusAfter(2 * time.Second)
+	}
+	m.statusInfo = statusCopiedPath
 	return m, clearStatusAfter(2 * time.Second)
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1440,7 +1440,7 @@ func (m Model) handleCopyID() (tea.Model, tea.Cmd) {
 // system clipboard. When a folder row is selected under a folder or repo
 // pivot, the folder's path is copied instead.
 func (m Model) handleCopyPath() (tea.Model, tea.Cmd) {
-	path := ""
+	var path string
 	if sess, ok := m.sessionList.Selected(); ok {
 		path = sess.Cwd
 	} else {

--- a/internal/tui/model_copypath_test.go
+++ b/internal/tui/model_copypath_test.go
@@ -1,0 +1,72 @@
+package tui
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jongio/dispatch/internal/data"
+)
+
+func TestHandleKey_CopyPath_Success(t *testing.T) {
+	var copied string
+	orig := clipboardWrite
+	clipboardWrite = func(text string) error {
+		copied = text
+		return nil
+	}
+	t.Cleanup(func() { clipboardWrite = orig })
+
+	m := newTestModel()
+	m.sessionList.SetSessions([]data.Session{{ID: "abc-123", Cwd: "/home/me/proj"}})
+	result, cmd := m.Update(runeKeyMsg('C'))
+	rm := result.(Model)
+	if copied != "/home/me/proj" {
+		t.Errorf("clipboard text = %q, want %q", copied, "/home/me/proj")
+	}
+	if rm.statusInfo != statusCopiedPath {
+		t.Errorf("statusInfo = %q, want %q", rm.statusInfo, statusCopiedPath)
+	}
+	if rm.statusErr != "" {
+		t.Errorf("statusErr = %q, want empty", rm.statusErr)
+	}
+	if cmd == nil {
+		t.Error("CopyPath success should return clearStatusAfter cmd")
+	}
+}
+
+func TestHandleKey_CopyPath_NoPath(t *testing.T) {
+	var called bool
+	orig := clipboardWrite
+	clipboardWrite = func(string) error {
+		called = true
+		return nil
+	}
+	t.Cleanup(func() { clipboardWrite = orig })
+
+	m := newTestModel()
+	m.sessionList.SetSessions([]data.Session{{ID: "abc-123", Cwd: ""}})
+	result, _ := m.Update(runeKeyMsg('C'))
+	rm := result.(Model)
+	if called {
+		t.Error("clipboard should not be written when there is no path")
+	}
+	if rm.statusInfo != "No path to copy" {
+		t.Errorf("statusInfo = %q, want %q", rm.statusInfo, "No path to copy")
+	}
+}
+
+func TestHandleKey_CopyPath_Error(t *testing.T) {
+	orig := clipboardWrite
+	clipboardWrite = func(string) error {
+		return errors.New("no display")
+	}
+	t.Cleanup(func() { clipboardWrite = orig })
+
+	m := newTestModel()
+	m.sessionList.SetSessions([]data.Session{{ID: "abc-123", Cwd: "/x"}})
+	result, _ := m.Update(runeKeyMsg('C'))
+	rm := result.(Model)
+	if rm.statusErr == "" {
+		t.Error("CopyPath clipboard error should set statusErr")
+	}
+}


### PR DESCRIPTION
## Problem

You can copy a session ID and the preview text, but not the session working directory. Copying that path is the quickest way to cd into the project a session ran in.

## Proposed solution

Add an action that copies the selected session working directory to the system clipboard, available from both a key binding and the command palette. It mirrors the existing copy session ID behavior, including the short confirmation message.

## What changed

- Added a `C` key binding and a `handleCopyPath` handler that copies the selected session `Cwd`.
- When a folder row is selected under a folder or repo pivot, the folder path is copied instead.
- Added a Copy Path entry to the command palette, enabled whenever there is a path to copy.
- No-op with a short `No path to copy` status when there is nothing to copy.
- Help overlay and key help lists include the new binding.

## Acceptance criteria

- [x] A key binding copies the selected session cwd to the clipboard.
- [x] The command palette lists a Copy Path action with the same behavior.
- [x] A short confirmation shows after copying, matching the copy session ID feedback.
- [x] The action is a no-op when no session is selected or the cwd is empty.
- [x] Help text lists the new binding.

Closes #192