### PR TITLE
feat: make session-list auto-refresh interval configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **Configurable auto-refresh** — set `auto_refresh_seconds` (also in the settings panel) to tune the session-list poll interval, or set it to `0` to turn polling off and refresh only with `r` or reindex
+
 ## [v0.13.0] — 2026-06-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Dispatch reads your local Copilot CLI session store and presents every past sess
 - **Multi-session open** (`Space` / `L` / `a` / `d`) — select multiple sessions with Space, launch all at once with L, select/deselect all with a/d. Shift+↑/↓ for range selection, Ctrl+click and Shift+click for mouse selection
 - **Attention indicators** — colored dots showing real-time session status: working (blue, executing tools), thinking (cyan, generating response), compacting (magenta, context compaction), waiting (purple), active (green), stale (yellow), interrupted (orange ⚡), idle (gray). Jump to next waiting session with `n`, resume interrupted sessions with `R`, filter by status with `!`
 - **Host type icons** — sessions display an icon indicating their origin: CLI (desktop), Cloud (cloud), or Actions (gear)
-- **Incremental auto-refresh** — the session list auto-refreshes within 2 seconds when the Copilot CLI writes new data (WAL file polling when focused). No manual reindex needed for normal use
+- **Incremental auto-refresh** — the session list auto-refreshes within 2 seconds when the Copilot CLI writes new data (WAL file polling when focused). No manual reindex needed for normal use. Tune the interval or turn it off with `auto_refresh_seconds`
 - **Plan indicator** (`v`) — a dot next to sessions that have a `plan.md` file (`~/.copilot/session-state/{session-id}/plan.md`). Press `v` to view the plan in the preview pane. Filter sessions with plans via the `!` status picker
 - **Work status detection** — analyzes `plan.md` files to identify sessions with incomplete planned work. Colored dots show completion status in the session list and preview panel. Press `R` to explicitly scan work status. Filter by work completion via the `!` status picker. Supports AI-powered analysis via Copilot SDK `analyze_completion` tool
 - **Session hiding** (`h` / `H`) — hide sessions from the list, toggle visibility of hidden sessions, persistent state
@@ -290,6 +290,7 @@ Configuration is stored in the platform-specific config directory:
 | `excluded_dirs` | array | `[]` | Directory paths to hide from session list |
 | `excluded_words` | array | `[]` | Comma-separated words; sessions containing any word are hidden |
 | `attention_threshold` | string | `"15m"` | Duration after which an inactive running session is marked stale |
+| `auto_refresh_seconds` | int | *(unset)* | Session-list poll interval in seconds. Unset uses the default (2s); `0` disables polling; a positive value sets the interval (minimum 1s). Applies on next launch |
 | `theme` | string | `"auto"` | Color scheme: `auto` or a named scheme |
 | `workspace_recovery` | bool | `true` | Detect sessions interrupted by crash/reboot |
 | `ai_search` | bool | `false` | Enable Copilot SDK-powered AI semantic search |

--- a/internal/config/autorefresh_test.go
+++ b/internal/config/autorefresh_test.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEffectiveAutoRefreshInterval(t *testing.T) {
+	t.Parallel()
+
+	ptr := func(v int) *int { return &v }
+
+	tests := []struct {
+		name         string
+		seconds      *int
+		wantInterval time.Duration
+		wantEnabled  bool
+	}{
+		{"unset uses default", nil, defaultAutoRefreshInterval, true},
+		{"zero disables polling", ptr(0), 0, false},
+		{"negative falls back to default", ptr(-5), defaultAutoRefreshInterval, true},
+		{"positive sets interval", ptr(10), 10 * time.Second, true},
+		{"one second is the minimum", ptr(1), minAutoRefreshInterval, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &Config{AutoRefreshSeconds: tc.seconds}
+			gotInterval, gotEnabled := cfg.EffectiveAutoRefreshInterval()
+			if gotInterval != tc.wantInterval {
+				t.Errorf("interval = %v, want %v", gotInterval, tc.wantInterval)
+			}
+			if gotEnabled != tc.wantEnabled {
+				t.Errorf("enabled = %v, want %v", gotEnabled, tc.wantEnabled)
+			}
+		})
+	}
+}
+
+func TestAutoRefreshSeconds_JSONRoundTrip(t *testing.T) {
+	// Not parallel: withTempConfigDir sets process-wide env vars.
+	withTempConfigDir(t)
+
+	// A pointer keeps "unset" and "0" distinct through save/load, so an
+	// explicit 0 (disable) survives a restart instead of reverting to default.
+	zero := 0
+	cfg := Default()
+	cfg.AutoRefreshSeconds = &zero
+	if err := Save(cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.AutoRefreshSeconds == nil {
+		t.Fatal("AutoRefreshSeconds should persist as 0, got nil")
+	}
+	if *loaded.AutoRefreshSeconds != 0 {
+		t.Errorf("AutoRefreshSeconds = %d, want 0", *loaded.AutoRefreshSeconds)
+	}
+	if _, enabled := loaded.EffectiveAutoRefreshInterval(); enabled {
+		t.Error("interval should be disabled when AutoRefreshSeconds is 0")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -249,6 +249,14 @@ type Config struct {
 	// session data is never modified.
 	RedactPreviewSecrets bool `json:"redact_preview_secrets,omitempty"`
 
+	// AutoRefreshSeconds controls the session-list auto-refresh poll
+	// interval, in seconds. When unset (nil), the built-in default interval
+	// is used. A value of 0 disables polling entirely, so the list refreshes
+	// only on explicit reload or reindex. A positive value sets the interval
+	// (clamped to a one-second minimum); negative values are ignored and fall
+	// back to the default. A pointer is used so "unset" and "0" are distinct.
+	AutoRefreshSeconds *int `json:"auto_refresh_seconds,omitempty"`
+
 	// Views is a list of named views, each storing a combination of
 	// filter/sort/pivot settings that can be applied together.
 	Views []NamedView `json:"views,omitempty"`
@@ -399,6 +407,39 @@ func (c *Config) EffectiveAttentionThreshold() time.Duration {
 		return defaultAttentionThreshold
 	}
 	return d
+}
+
+// defaultAutoRefreshInterval is the built-in session-list poll interval used
+// when AutoRefreshSeconds is unset.
+const defaultAutoRefreshInterval = 2 * time.Second
+
+// minAutoRefreshInterval is the smallest allowed poll interval. Positive
+// AutoRefreshSeconds values below this are clamped up to avoid a busy loop.
+const minAutoRefreshInterval = 1 * time.Second
+
+// EffectiveAutoRefreshInterval returns the session-list auto-refresh poll
+// interval and whether polling is enabled. The rules are:
+//   - unset (nil): the default interval, enabled.
+//   - 0: disabled (no polling).
+//   - negative: the default interval, enabled (the invalid value is ignored).
+//   - positive: that many seconds, clamped to a one-second minimum, enabled.
+func (c *Config) EffectiveAutoRefreshInterval() (interval time.Duration, enabled bool) {
+	if c.AutoRefreshSeconds == nil {
+		return defaultAutoRefreshInterval, true
+	}
+	secs := *c.AutoRefreshSeconds
+	switch {
+	case secs == 0:
+		return 0, false
+	case secs < 0:
+		return defaultAutoRefreshInterval, true
+	default:
+		d := time.Duration(secs) * time.Second
+		if d < minAutoRefreshInterval {
+			d = minAutoRefreshInterval
+		}
+		return d, true
+	}
 }
 
 // EffectiveLaunchMode returns the active launch mode, resolving the

--- a/internal/data/dbwatch.go
+++ b/internal/data/dbwatch.go
@@ -50,6 +50,20 @@ func NewDBWatcher(onChange func()) *DBWatcher {
 	}
 }
 
+// SetInterval sets the polling interval. It must be called before the first
+// SetActive(true); once the loop is running the interval is fixed. A
+// non-positive interval is ignored so the built-in default is preserved.
+func (w *DBWatcher) SetInterval(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.started {
+		w.interval = d
+	}
+}
+
 // SetActive enables or disables polling. When active is false, no file
 // system operations are performed (near-zero CPU).
 func (w *DBWatcher) SetActive(active bool) {

--- a/internal/data/dbwatch_test.go
+++ b/internal/data/dbwatch_test.go
@@ -403,3 +403,54 @@ func TestStop_ClosesDB(t *testing.T) {
 		t.Fatal("expected watcher DB to be nil after Stop")
 	}
 }
+
+func TestSetInterval_BeforeStart(t *testing.T) {
+	w := NewDBWatcher(func() {})
+	defer w.Stop()
+
+	w.SetInterval(30 * time.Second)
+
+	w.mu.Lock()
+	got := w.interval
+	w.mu.Unlock()
+
+	if got != 30*time.Second {
+		t.Fatalf("interval = %v, want %v", got, 30*time.Second)
+	}
+}
+
+func TestSetInterval_IgnoresNonPositive(t *testing.T) {
+	w := NewDBWatcher(func() {})
+	defer w.Stop()
+
+	w.mu.Lock()
+	original := w.interval
+	w.mu.Unlock()
+
+	w.SetInterval(0)
+	w.SetInterval(-5 * time.Second)
+
+	w.mu.Lock()
+	got := w.interval
+	w.mu.Unlock()
+
+	if got != original {
+		t.Fatalf("interval = %v, want unchanged %v", got, original)
+	}
+}
+
+func TestSetInterval_IgnoredAfterStart(t *testing.T) {
+	w := NewDBWatcher(func() {})
+	defer w.Stop()
+
+	w.SetActive(true) // starts the loop, fixing the interval
+	w.SetInterval(45 * time.Second)
+
+	w.mu.Lock()
+	got := w.interval
+	w.mu.Unlock()
+
+	if got == 45*time.Second {
+		t.Fatal("interval should not change once the loop has started")
+	}
+}

--- a/internal/tui/autorefresh_test.go
+++ b/internal/tui/autorefresh_test.go
@@ -1,0 +1,39 @@
+package tui
+
+import "testing"
+
+func TestAutoRefreshFieldValue(t *testing.T) {
+	t.Parallel()
+
+	if got := autoRefreshFieldValue(nil); got != "" {
+		t.Errorf("nil = %q, want empty string", got)
+	}
+	zero := 0
+	if got := autoRefreshFieldValue(&zero); got != "0" {
+		t.Errorf("0 = %q, want \"0\"", got)
+	}
+	five := 5
+	if got := autoRefreshFieldValue(&five); got != "5" {
+		t.Errorf("5 = %q, want \"5\"", got)
+	}
+}
+
+func TestParseAutoRefresh(t *testing.T) {
+	t.Parallel()
+
+	if got := parseAutoRefresh(""); got != nil {
+		t.Errorf("empty = %v, want nil", got)
+	}
+	if got := parseAutoRefresh("   "); got != nil {
+		t.Errorf("blank = %v, want nil", got)
+	}
+	if got := parseAutoRefresh("notanumber"); got != nil {
+		t.Errorf("invalid = %v, want nil", got)
+	}
+	if got := parseAutoRefresh("0"); got == nil || *got != 0 {
+		t.Errorf("\"0\" = %v, want pointer to 0", got)
+	}
+	if got := parseAutoRefresh(" 12 "); got == nil || *got != 12 {
+		t.Errorf("\" 12 \" = %v, want pointer to 12", got)
+	}
+}

--- a/internal/tui/cmdpalette.go
+++ b/internal/tui/cmdpalette.go
@@ -140,6 +140,7 @@ func (m Model) handleCmdPaletteAction(msg cmdPaletteActionMsg) (tea.Model, tea.C
 			PreviewPosition:   m.cfg.EffectivePreviewPosition(),
 			RedactSecrets:     m.cfg.RedactPreviewSecrets,
 			ExcludedWords:     joinExcludedWords(m.cfg.ExcludedWords),
+			AutoRefresh:       autoRefreshFieldValue(m.cfg.AutoRefreshSeconds),
 		})
 		m.state = stateConfigPanel
 		return m, nil

--- a/internal/tui/components/configpanel.go
+++ b/internal/tui/components/configpanel.go
@@ -33,6 +33,7 @@ const (
 	cfgPreviewPosition
 	cfgRedactSecrets
 	cfgExcludedWords
+	cfgAutoRefresh
 	cfgFieldCount
 )
 
@@ -56,6 +57,7 @@ type ConfigPanel struct {
 	previewPosition   string // "right", "bottom", "left", "top"
 	redactSecrets     bool
 	excludedWords     string // comma-separated list of filter words
+	autoRefresh       string // session-list auto-refresh seconds ("" default, "0" off)
 
 	// Available options for cycling.
 	terminals  []string
@@ -101,6 +103,7 @@ type ConfigValues struct {
 	PreviewPosition   string
 	RedactSecrets     bool
 	ExcludedWords     string // comma-separated filter words
+	AutoRefresh       string // auto-refresh seconds ("" default, "0" off)
 }
 
 // SetValues loads the config panel state from external values.
@@ -118,6 +121,7 @@ func (c *ConfigPanel) SetValues(v ConfigValues) {
 	c.previewPosition = v.PreviewPosition
 	c.redactSecrets = v.RedactSecrets
 	c.excludedWords = v.ExcludedWords
+	c.autoRefresh = v.AutoRefresh
 }
 
 // Values returns the current state of all editable fields.
@@ -136,6 +140,7 @@ func (c *ConfigPanel) Values() ConfigValues {
 		PreviewPosition:   c.previewPosition,
 		RedactSecrets:     c.redactSecrets,
 		ExcludedWords:     c.excludedWords,
+		AutoRefresh:       c.autoRefresh,
 	}
 }
 
@@ -225,6 +230,11 @@ func (c *ConfigPanel) HandleEnter() tea.Cmd {
 		c.textInput.SetValue(c.excludedWords)
 		c.textInput.CharLimit = 512
 		return c.textInput.Focus()
+	case cfgAutoRefresh:
+		c.editing = true
+		c.textInput.SetValue(c.autoRefresh)
+		c.textInput.CharLimit = 8
+		return c.textInput.Focus()
 	case cfgTheme:
 		c.theme = c.cycleTheme(c.theme)
 	case cfgWorkspaceRecovery:
@@ -254,6 +264,8 @@ func (c *ConfigPanel) ConfirmEdit() {
 		c.customCommand = val
 	case cfgExcludedWords:
 		c.excludedWords = val
+	case cfgAutoRefresh:
+		c.autoRefresh = val
 	default:
 		// Non-editable fields are ignored.
 	}
@@ -309,6 +321,7 @@ func (c ConfigPanel) View() string {
 		{"Preview Position", previewPositionDisplay(c.previewPosition), false},
 		{"Redact Secrets", boolDisplay(c.redactSecrets), false},
 		{"Excluded Words", stringDisplay(c.excludedWords), false},
+		{"Auto Refresh", autoRefreshDisplay(c.autoRefresh), false},
 	}
 
 	var body strings.Builder
@@ -355,6 +368,14 @@ func (c ConfigPanel) View() string {
 		body.WriteString(styles.DimmedStyle.Render("  Comma-separated words to filter out sessions.") + "\n")
 		body.WriteString(styles.DimmedStyle.Render("  Matches against session name and turn content.") + "\n")
 		body.WriteString(styles.DimmedStyle.Render("  Example: MANDATORY, internal, secret") + "\n")
+	}
+
+	// Contextual help when the Auto Refresh field is focused.
+	if c.cursor == cfgAutoRefresh {
+		body.WriteString("\n")
+		body.WriteString(styles.DimmedStyle.Render("  Session-list auto-refresh interval, in seconds.") + "\n")
+		body.WriteString(styles.DimmedStyle.Render("  Empty uses the default; 0 turns polling off.") + "\n")
+		body.WriteString(styles.DimmedStyle.Render("  Takes effect on next launch.") + "\n")
 	}
 
 	body.WriteString("\n")
@@ -413,6 +434,20 @@ func stringDisplay(v string) string {
 		return styles.ConfigDimmedValue.Render("(none)")
 	}
 	return styles.ConfigValueStyle.Render(v)
+}
+
+// autoRefreshDisplay renders the auto-refresh setting as a friendly label.
+// An empty value means the built-in default, "0" means polling is off, and
+// any other value is shown as a seconds interval.
+func autoRefreshDisplay(v string) string {
+	switch strings.TrimSpace(v) {
+	case "":
+		return styles.ConfigDimmedValue.Render("Default")
+	case "0":
+		return styles.ConfigDimmedValue.Render("Off")
+	default:
+		return styles.ConfigValueStyle.Render(v + "s")
+	}
 }
 
 // cycleLaunchMode cycles through the four launch modes.

--- a/internal/tui/components/configpanel_autorefresh_test.go
+++ b/internal/tui/components/configpanel_autorefresh_test.go
@@ -1,0 +1,54 @@
+package components
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConfigPanel_AutoRefresh_RoundTrip(t *testing.T) {
+	t.Parallel()
+	cp := NewConfigPanel()
+	cp.SetValues(ConfigValues{AutoRefresh: "5"})
+	if got := cp.Values().AutoRefresh; got != "5" {
+		t.Errorf("AutoRefresh = %q, want %q", got, "5")
+	}
+}
+
+func TestConfigPanel_AutoRefresh_Edit(t *testing.T) {
+	t.Parallel()
+	cp := NewConfigPanel()
+	cp.cursor = cfgAutoRefresh
+	if cmd := cp.HandleEnter(); cmd == nil {
+		t.Fatal("HandleEnter on Auto Refresh should start text editing")
+	}
+	if !cp.IsEditing() {
+		t.Fatal("expected editing mode after HandleEnter")
+	}
+	cp.textInput.SetValue("  0  ")
+	cp.ConfirmEdit()
+	if got := cp.Values().AutoRefresh; got != "0" {
+		t.Errorf("AutoRefresh after confirm = %q, want %q", got, "0")
+	}
+}
+
+func TestAutoRefreshDisplay(t *testing.T) {
+	t.Parallel()
+	if got := autoRefreshDisplay(""); !strings.Contains(got, "Default") {
+		t.Errorf("empty display = %q, want to contain Default", got)
+	}
+	if got := autoRefreshDisplay("0"); !strings.Contains(got, "Off") {
+		t.Errorf("zero display = %q, want to contain Off", got)
+	}
+	if got := autoRefreshDisplay("5"); !strings.Contains(got, "5s") {
+		t.Errorf("positive display = %q, want to contain 5s", got)
+	}
+}
+
+func TestConfigPanel_View_ShowsAutoRefresh(t *testing.T) {
+	t.Parallel()
+	cp := NewConfigPanel()
+	cp.SetSize(80, 40)
+	if !strings.Contains(cp.View(), "Auto Refresh") {
+		t.Error("config panel view should list the Auto Refresh field")
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -305,6 +306,7 @@ func NewModel() Model {
 		PreviewPosition:   cfg.EffectivePreviewPosition(),
 		RedactSecrets:     cfg.RedactPreviewSecrets,
 		ExcludedWords:     strings.Join(cfg.ExcludedWords, ", "),
+		AutoRefresh:       autoRefreshFieldValue(cfg.AutoRefreshSeconds),
 	})
 
 	// Build the list of available theme names for the config panel.
@@ -372,7 +374,13 @@ func NewModel() Model {
 		default:
 		}
 	})
-	m.dbWatcher.SetActive(true)
+	// Honour the configured auto-refresh interval. When disabled (0), the
+	// watcher is never activated so no polling happens; the list still
+	// refreshes on explicit reload and after reindex.
+	if interval, enabled := cfg.EffectiveAutoRefreshInterval(); enabled {
+		m.dbWatcher.SetInterval(interval)
+		m.dbWatcher.SetActive(true)
+	}
 
 	m.filter.Since = timeRangeToSince(m.timeRange)
 	m.filter.ExcludedDirs = cfg.ExcludedDirs
@@ -1032,6 +1040,7 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			PreviewPosition:   m.cfg.EffectivePreviewPosition(),
 			RedactSecrets:     m.cfg.RedactPreviewSecrets,
 			ExcludedWords:     strings.Join(m.cfg.ExcludedWords, ", "),
+			AutoRefresh:       autoRefreshFieldValue(m.cfg.AutoRefreshSeconds),
 		})
 		m.state = stateConfigPanel
 		return m, nil
@@ -1643,6 +1652,7 @@ func (m *Model) saveConfigFromPanel() {
 	m.preview.SetRedactSecrets(v.RedactSecrets)
 	m.cfg.ExcludedWords = parseExcludedWords(v.ExcludedWords)
 	m.filter.ExcludedWords = m.cfg.ExcludedWords
+	m.cfg.AutoRefreshSeconds = parseAutoRefresh(v.AutoRefresh)
 	resolveTheme(m.cfg)
 	// If the user switched back to "auto", re-apply with the detected
 	// terminal brightness so colours adapt immediately.
@@ -1673,6 +1683,31 @@ func parseExcludedWords(s string) []string {
 		return nil
 	}
 	return words
+}
+
+// autoRefreshFieldValue renders the config's AutoRefreshSeconds as the string
+// the settings panel edits: empty for unset (default), or the integer seconds.
+func autoRefreshFieldValue(secs *int) string {
+	if secs == nil {
+		return ""
+	}
+	return strconv.Itoa(*secs)
+}
+
+// parseAutoRefresh converts the settings-panel auto-refresh string back into a
+// config value. An empty or unparseable string means unset (nil), so the
+// default interval is used; otherwise the parsed integer is stored (including
+// 0 to disable polling). Range handling is applied by EffectiveAutoRefreshInterval.
+func parseAutoRefresh(s string) *int {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return nil
+	}
+	return &n
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Makes the session-list auto-refresh interval configurable and lets you turn it off.

Today the list polls the Copilot session store on a fixed two-second interval while focused (PRAGMA data_version, falling back to WAL and DB mtime). That is a good default for a local store, but there is no way to change it. On a network-mounted or slow filesystem the repeated stat and open calls are wasteful, and some people would rather refresh manually with `r`. The interval was already a field on the watcher, so it just needed to be exposed.

## How

- `internal/config/config.go`: adds `AutoRefreshSeconds *int` (`auto_refresh_seconds`). A pointer keeps "unset" and "0" distinct through save and load. New `EffectiveAutoRefreshInterval()` returns the interval and whether polling is enabled:
  - unset uses the built-in default (2s), enabled;
  - `0` disables polling;
  - negative falls back to the default (invalid value ignored);
  - positive sets the interval, clamped to a one-second minimum so a bad config cannot busy-loop.
- `internal/data/dbwatch.go`: adds `SetInterval`, applied before the watcher loop starts. Non-positive values are ignored so the default is preserved, and it is a no-op once the loop is running.
- `internal/tui/model.go`: reads the effective interval at startup. When enabled it sets the interval and activates the watcher; when disabled (0) it never activates the watcher, so no polling happens. The list still refreshes on `r` and after reindex. Save path converts the panel string back to the config value.
- `internal/tui/components/configpanel.go` and `internal/tui/cmdpalette.go`: adds an "Auto Refresh" field to the settings panel (empty for default, `0` for off, or a seconds value) with inline help. Interval changes take effect on next launch.

## Testing

- `go build ./...`
- `go vet ./...`
- `gofumpt -l .` (clean)
- `golangci-lint run --timeout 15m` (0 issues)
- `go test ./... -count=1` (all packages pass)

New tests cover interval selection (unset, 0, negative, positive, sub-minimum clamp), the pointer round-trip through save and load, the watcher `SetInterval` rules (before start, non-positive ignored, ignored after start), the config to panel string conversions, and the settings-panel field and display.

Closes #200
