### PR TITLE
Launch sessions in a tmux split when running inside tmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Dispatch reads your local Copilot CLI session store and presents every past sess
 - **Copy session ID** (`c`) — copy the selected session's ID to the system clipboard. Also available by clicking the ID row in the preview pane
 - **Copy resume command** (`Y`) — copy the selected session's full resume command to the system clipboard. With a multi-select active, copies one resume command per selected session, one per line
 - **Open working directory** (`O`) — open the selected session's working directory in the system file manager (Explorer on Windows, Finder on macOS, the default file manager on Linux)
-- **Four launch modes** (`Enter` / `t` / `w` / `e`) — in-place, new tab, new window, split pane (Windows Terminal) with per-session overrides
+- **Four launch modes** (`Enter` / `t` / `w` / `e`) — in-place, new tab, new window, split pane (Windows Terminal, or tmux when running inside a tmux session) with per-session overrides
 - **Multi-session open** (`Space` / `L` / `a` / `d`) — select multiple sessions with Space, launch all at once with L, select/deselect all with a/d. Shift+↑/↓ for range selection, Ctrl+click and Shift+click for mouse selection. With a selection active, `h` (hide), `*` (favorite), and `Y` (copy resume command) apply to every selected session at once
 - **Attention indicators** — colored dots showing real-time session status: working (blue, executing tools), thinking (cyan, generating response), compacting (magenta, context compaction), waiting (purple), active (green), stale (yellow), interrupted (orange ⚡), idle (gray). Jump to next waiting session with `n`, resume interrupted sessions with `R`, filter by status with `!`
 - **Host type icons** — sessions display an icon indicating their origin: CLI (desktop), Cloud (cloud), or Actions (gear)
@@ -177,7 +177,7 @@ Add `--json` (`dispatch doctor --json`) to print the same checks as a single JSO
 | `Enter` | Launch selected session (or toggle folder) |
 | `w` | Launch in new window |
 | `t` | Launch in new tab |
-| `e` | Launch in split pane (Windows Terminal) |
+| `e` | Launch in split pane (Windows Terminal, or tmux inside a tmux session) |
 
 #### Multi-Select
 
@@ -357,6 +357,18 @@ When `launch_mode` is `"pane"`, the `pane_direction` value maps to Windows Termi
 | `auto` | *(none)* | Windows Terminal decides automatically |
 
 > **Note:** `-H` and `-V` control split *orientation* only (the direction the divider runs). Windows Terminal decides actual pane placement based on available space.
+
+#### tmux Support (macOS and Linux)
+
+When you run dispatch inside a tmux session (the `TMUX` environment variable is set), pane mode splits the current tmux window with `tmux split-window` instead of opening a new terminal emulator. The `pane_direction` value maps to tmux flags:
+
+| Direction | tmux Flag | Meaning |
+|-----------|-----------|---------|
+| `right` / `left` | `-h` | Vertical divider — new pane to the right |
+| `down` / `up` | `-v` | Horizontal divider — new pane below |
+| `auto` | *(none)* | tmux uses its default (a pane below) |
+
+The split starts in the session's working directory (`-c`) and runs the resume command in your shell. Outside tmux, pane mode behaves as before.
 
 ### Example config.json
 

--- a/internal/platform/assert_test.go
+++ b/internal/platform/assert_test.go
@@ -1,0 +1,40 @@
+package platform
+
+import (
+	"strings"
+	"testing"
+)
+
+// assertContains fails t unless every element of want appears somewhere in
+// args. These assertion helpers are shared across the platform package tests
+// on every build platform: the tmux tests run on Unix while the WSL tests are
+// gated behind //go:build windows, so the helpers must live in an
+// unconstrained file to be visible to both.
+func assertContains(t *testing.T, args []string, want ...string) {
+	t.Helper()
+	joined := strings.Join(args, " ")
+	for _, w := range want {
+		found := false
+		for _, a := range args {
+			if a == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("args %v should contain %q (full: %s)", args, w, joined)
+		}
+	}
+}
+
+// assertNotContains fails t if any element of excluded appears in args.
+func assertNotContains(t *testing.T, args []string, excluded ...string) {
+	t.Helper()
+	for _, e := range excluded {
+		for _, a := range args {
+			if a == e {
+				t.Errorf("args %v should NOT contain %q", args, e)
+			}
+		}
+	}
+}

--- a/internal/platform/mq_wsl_coverage_test.go
+++ b/internal/platform/mq_wsl_coverage_test.go
@@ -4,7 +4,6 @@ package platform
 
 import (
 	"os/exec"
-	"strings"
 	"testing"
 )
 
@@ -126,37 +125,5 @@ func TestEscapeAppleScript_Basic(t *testing.T) {
 				t.Errorf("escapeAppleScript(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
-	}
-}
-
-// ---------------------------------------------------------------------------
-// helpers
-// ---------------------------------------------------------------------------
-
-func assertContains(t *testing.T, args []string, want ...string) {
-	t.Helper()
-	joined := strings.Join(args, " ")
-	for _, w := range want {
-		found := false
-		for _, a := range args {
-			if a == w {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("args %v should contain %q (full: %s)", args, w, joined)
-		}
-	}
-}
-
-func assertNotContains(t *testing.T, args []string, excluded ...string) {
-	t.Helper()
-	for _, e := range excluded {
-		for _, a := range args {
-			if a == e {
-				t.Errorf("args %v should NOT contain %q", args, e)
-			}
-		}
 	}
 }

--- a/internal/platform/shell.go
+++ b/internal/platform/shell.go
@@ -460,6 +460,14 @@ var platformLaunchSessionFn = platformLaunchSession
 
 // platformLaunchSession is the default implementation of platformLaunchSessionFn.
 func platformLaunchSession(shell ShellInfo, resumeCmd string, terminal string, cwd string, launchStyle string, paneDirection string) error {
+	// Inside tmux, pane mode splits the current tmux window instead of
+	// spawning a new terminal emulator. This makes pane mode work on macOS
+	// and Linux for users who live in tmux, matching the Windows Terminal
+	// split-pane behavior.
+	if launchStyle == LaunchStylePane && insideTmux() {
+		return launchTmuxPane(shell, resumeCmd, cwd, paneDirection)
+	}
+
 	switch runtime.GOOS {
 	case "windows":
 		return launchWindowsSession(shell, resumeCmd, terminal, cwd, launchStyle, paneDirection)
@@ -580,6 +588,54 @@ func appendWTPaneDirFlags(args []string, dir string) []string {
 		// "auto" or empty — let Windows Terminal choose.
 		return args
 	}
+}
+
+// insideTmux reports whether the current process is running inside a tmux
+// session, detected via the TMUX environment variable that tmux sets for
+// every process in a pane.
+func insideTmux() bool {
+	return os.Getenv("TMUX") != ""
+}
+
+// buildTmuxSplitArgs builds the argument list for `tmux split-window` that
+// opens the resume command in a new split of the current tmux window.
+//
+// direction selects the divider orientation:
+//
+//	"right"/"left" → -h  vertical divider, new pane to the right
+//	"down"/"up"    → -v  horizontal divider, new pane below
+//	"auto"/""      → (no flag) tmux uses its default (a pane below)
+//
+// The working directory is set with -c so the split starts where the session
+// lives, and the resume command runs through the user's shell.
+func buildTmuxSplitArgs(shell ShellInfo, resumeCmd, cwd, direction string) []string {
+	args := []string{"split-window"}
+	switch direction {
+	case "right", "left":
+		args = append(args, "-h")
+	case "down", "up":
+		args = append(args, "-v")
+	}
+	if cwd != "" {
+		args = append(args, "-c", cwd)
+	}
+	args = append(args, shell.Path, "-c", resumeCmd)
+	return args
+}
+
+// launchTmuxPane opens the resume command in a split of the current tmux
+// window. It is only used when running inside tmux (see insideTmux).
+func launchTmuxPane(shell ShellInfo, resumeCmd, cwd, paneDirection string) error {
+	tmuxPath, err := exec.LookPath("tmux")
+	if err != nil {
+		return fmt.Errorf("TMUX is set but the tmux binary was not found on PATH: %w", err)
+	}
+	args := buildTmuxSplitArgs(shell, resumeCmd, cwd, paneDirection)
+	cmd := exec.CommandContext(context.Background(), tmuxPath, args...)
+	if cwd != "" {
+		cmd.Dir = cwd
+	}
+	return startAndWaitBriefly(cmd)
 }
 
 func launchWindowsSession(shell ShellInfo, resumeCmd string, terminal string, cwd string, launchStyle string, paneDirection string) error {

--- a/internal/platform/tmux_test.go
+++ b/internal/platform/tmux_test.go
@@ -1,0 +1,100 @@
+package platform
+
+import (
+	"testing"
+)
+
+func TestBuildTmuxSplitArgs_Direction(t *testing.T) {
+	shell := ShellInfo{Path: "/usr/bin/bash"}
+	resume := "ghcs --resume s1"
+
+	tests := []struct {
+		name    string
+		dir     string
+		wantDir string // "-h", "-v", or "" for no direction flag
+	}{
+		{"right maps to -h", "right", "-h"},
+		{"left maps to -h", "left", "-h"},
+		{"down maps to -v", "down", "-v"},
+		{"up maps to -v", "up", "-v"},
+		{"auto has no flag", "auto", ""},
+		{"empty has no flag", "", ""},
+		{"unknown has no flag", "sideways", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			args := buildTmuxSplitArgs(shell, resume, "/work/dir", tc.dir)
+
+			if len(args) == 0 || args[0] != "split-window" {
+				t.Fatalf("args must start with split-window, got %v", args)
+			}
+
+			switch tc.wantDir {
+			case "-h":
+				assertContains(t, args, "-h")
+				assertNotContains(t, args, "-v")
+			case "-v":
+				assertContains(t, args, "-v")
+				assertNotContains(t, args, "-h")
+			default:
+				assertNotContains(t, args, "-h", "-v")
+			}
+
+			// Working directory and resume command must always be present.
+			assertContains(t, args, "-c", "/work/dir")
+			if !containsSeq(args, shell.Path, "-c", resume) {
+				t.Errorf("dir %q: missing shell resume command in %v", tc.dir, args)
+			}
+		})
+	}
+}
+
+func TestBuildTmuxSplitArgs_NoCwd(t *testing.T) {
+	shell := ShellInfo{Path: "/bin/zsh"}
+	args := buildTmuxSplitArgs(shell, "cmd", "", "right")
+
+	// With no cwd there is exactly one -c (the shell flag), never a
+	// working-directory -c pair.
+	if !containsSeq(args, shell.Path, "-c", "cmd") {
+		t.Errorf("missing shell resume command in %v", args)
+	}
+	if containsSeq(args, "-c", "") {
+		t.Errorf("unexpected empty working directory flag in %v", args)
+	}
+}
+
+func TestInsideTmux(t *testing.T) {
+	t.Run("set", func(t *testing.T) {
+		t.Setenv("TMUX", "/tmp/tmux-1000/default,1234,0")
+		if !insideTmux() {
+			t.Error("insideTmux() = false with TMUX set, want true")
+		}
+	})
+	t.Run("empty", func(t *testing.T) {
+		t.Setenv("TMUX", "")
+		if insideTmux() {
+			t.Error("insideTmux() = true with empty TMUX, want false")
+		}
+	})
+}
+
+// containsSeq reports whether seq appears as a contiguous subsequence of s.
+func containsSeq(s []string, seq ...string) bool {
+	if len(seq) == 0 {
+		return true
+	}
+	for i := 0; i+len(seq) <= len(s); i++ {
+		match := true
+		for j := range seq {
+			if s[i+j] != seq[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Makes pane launch mode work inside tmux on macOS and Linux. Previously `e` (split pane) only did anything in Windows Terminal; a tmux user on mac or Linux got a brand-new terminal window instead of a split.

## Behavior

- When the `TMUX` environment variable is set, pane launches route through `tmux split-window` in the current tmux window.
- Pane direction maps to tmux flags: `right`/`left` use `-h` (pane to the right), `down`/`up` use `-v` (pane below), `auto` lets tmux choose.
- The split starts in the session working directory (`-c`) and runs the resume command in the user's shell.
- Outside tmux, behavior is unchanged.

## Changes

- `internal/platform/shell.go`: `insideTmux`, `buildTmuxSplitArgs`, and `launchTmuxPane` helpers; `platformLaunchSession` routes pane mode to tmux when inside a tmux session.
- Unit tests cover the direction mapping for each value and the tmux detection.
- README documents tmux support for pane mode.

Closes #219