### PR TITLE
deps: upgrade all dependencies to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/jongio/dispatch
 go 1.26.4
 
 require (
-	charm.land/bubbles/v2 v2.1.0
+	charm.land/bubbles/v2 v2.1.1
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/lipgloss/v2 v2.0.5
 	github.com/UserExistsError/conpty v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-charm.land/bubbles/v2 v2.1.0 h1:YSnNh5cPYlYjPxRrzs5VEn3vwhtEn3jVGRBT3M7/I0g=
-charm.land/bubbles/v2 v2.1.0/go.mod h1:l97h4hym2hvWBVfmJDtrEHHCtkIKeTEb3TTJ4ZOB3wY=
+charm.land/bubbles/v2 v2.1.1 h1:7r55WzBxpo/R3z98hGmY7KKPd3ET6vsf0Fb9sDHOV60=
+charm.land/bubbles/v2 v2.1.1/go.mod h1:GE6M31gaWZVXzGw73OeuTTgy4lX+OtkH0E5ymnNsHxo=
 charm.land/bubbletea/v2 v2.0.8 h1:SxTJMhCAI3lbPmy4SgX5LWZ24AdINr4I6UEqzZvYJuY=
 charm.land/bubbletea/v2 v2.0.8/go.mod h1:2SkdgoTXluXJHOUwAoRlRXF/28vklb1rFl6GcgV1/ss=
 charm.land/lipgloss/v2 v2.0.5 h1:kbNxgeeUOYv5J0YdpxFjfvf3dFvqH8Aci4zB6xqFtrY=


### PR DESCRIPTION
## Dependency upgrades

Automated `deps` workflow run — upgrade all dependencies to latest.

### Go module
- `charm.land/bubbles/v2` v2.1.0 → v2.1.1

Ran `go get -u ./... && go mod tidy`. All other Go modules were already at their latest compatible versions (a deps PR merged the day prior). No breaking API changes; no code fixes required.

### web/ (Astro site)
- `npm-check-updates`: all dependencies already match the latest package versions — no changes.

### Validation (local)
| Gate | Result |
| --- | --- |
| `go build ./...` | ✅ pass |
| `go vet ./...` | ✅ pass |
| `go test ./...` | ✅ all packages pass |
| `gofmt -l .` | ✅ clean |
| `gofumpt -l .` | ✅ clean |
| `go mod tidy` diff | ✅ clean |
| `mage deadcode` | ✅ OK |
| `golangci-lint` v2.12.2 | ✅ 0 issues |
| `govulncheck ./...` | ✅ no vulnerabilities |

Race detector (`-race`, CGO) and WSL tests were not run locally (no C compiler on this Windows host) — both run in CI on Ubuntu.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>