### PR TITLE
feat: add session tags with tag: search token

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Dispatch reads your local Copilot CLI session store and presents every past sess
 - **Work status detection** — analyzes `plan.md` files to identify sessions with incomplete planned work. Colored dots show completion status in the session list and preview panel. Press `R` to explicitly scan work status. Filter by work completion via the `!` status picker. Supports AI-powered analysis via Copilot SDK `analyze_completion` tool
 - **Session hiding** (`h` / `H`) — hide sessions from the list, toggle visibility of hidden sessions, persistent state
 - **Session favorites** (`*`) — star sessions as favorites. Filter to show only favorites via the `!` status picker
+- **Session tags** (`g`) — attach comma-separated tags to sessions and filter to a tag with the `tag:` search token
 - **Settings panel** (`,`) — 15 fields: Yolo Mode, Agent, Model, Launch Mode, Pane Direction, Terminal, Shell, Custom Command, Theme, Crash Recovery, Preview Position, Redact Secrets, Excluded Words, Auto Refresh, Notify On Waiting
 - **Shell picker** — auto-detects installed shells, modal picker when multiple available
 - **5 built-in themes** — Dispatch Dark, Dispatch Light, Campbell, One Half Dark, One Half Light + custom via Windows Terminal JSON
@@ -196,6 +197,7 @@ Add `--json` (`dispatch doctor --json`) to print the same checks as a single JSO
 | `h` | Hide/unhide current session |
 | `H` | Toggle visibility of hidden sessions |
 | `*` | Toggle favorite on current session |
+| `g` | Add or edit tags on current session |
 
 #### Search & Filter
 
@@ -311,6 +313,7 @@ Configuration is stored in the platform-specific config directory:
 | `hiddenSessions` | array | `[]` | Session IDs hidden from the main list |
 | `favoriteSessions` | array | `[]` | Session IDs starred as favorites |
 | `keybindings` | object | `{}` | Remap keyboard shortcuts. Keys are action names, values are comma-separated key lists (see [Customizing Keybindings](#customizing-keybindings)) |
+| `sessionTags` | object | `{}` | Map of session ID to a list of user-defined tags |
 
 #### Pane Direction Semantics
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -255,6 +255,13 @@
 
     Note: Favorites filter was previously on `F` — now toggled via the `!` status picker "Favorites only" row.
 
+26b. **g** — Add or Edit Tags on Current Session
+    - File: internal\tui\keys.go
+    - Code: key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "edit tags"))
+    - Handler: internal\tui\model.go (handleEditTags)
+    - Behavior: Opens an inline input to edit comma-separated tags (persisted to config as sessionTags); filter with the tag: search token
+    - Condition: Only when a session is selected (not a folder)
+
 27b. **c** → Copy Session ID to Clipboard
      - File: internal\tui\keys.go
      - Code: key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "copy session ID"))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -207,6 +207,11 @@ type Config struct {
 	// and recently ahead of ones they rarely open.
 	SessionLaunches map[string]SessionLaunch `json:"sessionLaunches,omitempty"`
 
+	// SessionTags maps session IDs to a list of user-defined tags. Tags group
+	// related sessions for quick filtering with the tag: search token and are
+	// indicated by a marker in the session list.
+	SessionTags map[string][]string `json:"sessionTags,omitempty"`
+
 	// AISearch enables Copilot SDK-powered AI search. When false (the
 	// default), only the local FTS5 index is used.  Set to true to also
 	// query the Copilot backend for semantically relevant sessions.

--- a/internal/config/tags.go
+++ b/internal/config/tags.go
@@ -1,0 +1,63 @@
+package config
+
+import (
+	"sort"
+	"strings"
+)
+
+// ParseTags splits a comma-separated tag string into a normalized,
+// de-duplicated slice. Tags are lowercased and trimmed; blank entries are
+// dropped. The result is sorted so persistence and display stay stable.
+func ParseTags(input string) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	for _, part := range strings.Split(input, ",") {
+		t := strings.ToLower(strings.TrimSpace(part))
+		if t == "" {
+			continue
+		}
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// SetTags stores the tags for a session. Passing an empty slice removes the
+// entry so the config stays compact.
+func (c *Config) SetTags(sessionID string, tags []string) {
+	if sessionID == "" {
+		return
+	}
+	if len(tags) == 0 {
+		delete(c.SessionTags, sessionID)
+		return
+	}
+	if c.SessionTags == nil {
+		c.SessionTags = make(map[string][]string)
+	}
+	c.SessionTags[sessionID] = tags
+}
+
+// TagsFor returns the tags for a session, or nil when it has none.
+func (c *Config) TagsFor(sessionID string) []string {
+	return c.SessionTags[sessionID]
+}
+
+// HasTag reports whether a session carries the given tag. The comparison is
+// case-insensitive.
+func (c *Config) HasTag(sessionID, tag string) bool {
+	tag = strings.ToLower(strings.TrimSpace(tag))
+	if tag == "" {
+		return false
+	}
+	for _, t := range c.SessionTags[sessionID] {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/tags_test.go
+++ b/internal/config/tags_test.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseTags(t *testing.T) {
+	got := ParseTags(" Work, personal ,,work,PERSONAL ")
+	want := []string{"personal", "work"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ParseTags = %v, want %v", got, want)
+	}
+	if ParseTags("   ") != nil {
+		t.Fatal("expected nil for blank input")
+	}
+}
+
+func TestSetTagsAndTagsFor(t *testing.T) {
+	c := Default()
+	c.SetTags("s1", []string{"a", "b"})
+	if got := c.TagsFor("s1"); !reflect.DeepEqual(got, []string{"a", "b"}) {
+		t.Fatalf("TagsFor = %v", got)
+	}
+	c.SetTags("s1", nil)
+	if got := c.TagsFor("s1"); got != nil {
+		t.Fatalf("expected nil after clearing, got %v", got)
+	}
+	c.SetTags("", []string{"x"})
+	if len(c.SessionTags) != 0 {
+		t.Fatalf("expected no tags for empty id, got %v", c.SessionTags)
+	}
+}
+
+func TestHasTag(t *testing.T) {
+	c := Default()
+	c.SetTags("s1", []string{"work", "urgent"})
+	if !c.HasTag("s1", "WORK") {
+		t.Fatal("expected HasTag to be case-insensitive")
+	}
+	if c.HasTag("s1", "missing") {
+		t.Fatal("expected false for missing tag")
+	}
+	if c.HasTag("s1", "  ") {
+		t.Fatal("expected false for blank tag")
+	}
+}

--- a/internal/tui/components/sessionlist.go
+++ b/internal/tui/components/sessionlist.go
@@ -39,6 +39,7 @@ type SessionList struct {
 	workStatusMap  map[string]data.WorkStatusResult // session ID → work status
 	gitStateMap    map[string]platform.GitState     // session ID → git workspace state
 	notesSet       map[string]struct{}              // session ID → has a user note
+	tagsSet        map[string]struct{}              // session ID → has tags
 	selected       map[string]struct{}              // session ID → selected for multi-open
 	treeMode       bool                             // true when showing grouped/tree view
 	pivotField     string                           // current pivot mode (e.g. "folder", "repo")
@@ -128,6 +129,12 @@ func (s *SessionList) SetFavoritedSessions(set map[string]struct{}) {
 // used to render those sessions with a pencil marker.
 func (s *SessionList) SetNoteSessions(set map[string]struct{}) {
 	s.notesSet = set
+}
+
+// SetTagSessions updates the set of session IDs that carry user tags,
+// used to render those sessions with a tag marker.
+func (s *SessionList) SetTagSessions(set map[string]struct{}) {
+	s.tagsSet = set
 }
 
 // SetAISessions updates the set of AI-found session IDs, used to
@@ -788,6 +795,7 @@ func (s SessionList) renderSessionRow(sess data.Session, selected bool, hidden b
 
 	plnDot := s.planDot(sess.ID, selected)
 	ntDot := s.noteDot(sess.ID, selected)
+	tgDot := s.tagDot(sess.ID, selected)
 	wrkDot := s.workStatusDot(sess.ID, selected)
 	gitDot := s.gitStateDot(sess.ID, selected)
 
@@ -803,6 +811,7 @@ func (s SessionList) renderSessionRow(sess data.Session, selected bool, hidden b
 	const hostDotW = 2 // host icon + space (always reserved)
 	const planDotW = 2 // plan dot + space
 	const noteDotW = 2 // note dot + space
+	const tagDotW = 2  // tag dot + space
 	const wrkDotW = 2  // work status dot + space
 	const gitDotW = 2  // git state dot + space
 	const timeW = 9
@@ -811,8 +820,8 @@ func (s SessionList) renderSessionRow(sess data.Session, selected bool, hidden b
 
 	// Very narrow terminal: summary + time only.
 	if w < 50 {
-		summaryW := max(10, w-selectorW-dotW-hostDotW-planDotW-noteDotW-wrkDotW-gitDotW-timeW-spacing)
-		line := indent + selector + attDot + hostDot + plnDot + ntDot + wrkDot + gitDot + PadRight(summary, summaryW) + "  " + PadLeft(relTime, timeW)
+		summaryW := max(10, w-selectorW-dotW-hostDotW-planDotW-noteDotW-tagDotW-wrkDotW-gitDotW-timeW-spacing)
+		line := indent + selector + attDot + hostDot + plnDot + ntDot + tgDot + wrkDot + gitDot + PadRight(summary, summaryW) + "  " + PadLeft(relTime, timeW)
 		return s.applyRowStyle(line, selected, hidden, favorited)
 	}
 
@@ -825,7 +834,7 @@ func (s SessionList) renderSessionRow(sess data.Session, selected bool, hidden b
 		folderW = 18
 	}
 
-	summaryW := w - selectorW - dotW - hostDotW - planDotW - noteDotW - wrkDotW - gitDotW - timeW - turnsW - 2*spacing
+	summaryW := w - selectorW - dotW - hostDotW - planDotW - noteDotW - tagDotW - wrkDotW - gitDotW - timeW - turnsW - 2*spacing
 	if folderW > 0 {
 		summaryW -= folderW + spacing
 	}
@@ -843,6 +852,7 @@ func (s SessionList) renderSessionRow(sess data.Session, selected bool, hidden b
 	b.WriteString(hostDot)
 	b.WriteString(plnDot)
 	b.WriteString(ntDot)
+	b.WriteString(tgDot)
 	b.WriteString(wrkDot)
 	b.WriteString(gitDot)
 	b.WriteString(PadRight(summary, summaryW))
@@ -961,6 +971,18 @@ func (s SessionList) noteDot(sessionID string, selected bool) string {
 		return "  "
 	}
 	return renderDot(styles.IconNote(), styles.NoteIndicatorStyle, selected)
+}
+
+// tagDot returns a styled 2-character string (tag icon + space) for sessions
+// that carry user tags, or two spaces if none exist.
+func (s SessionList) tagDot(sessionID string, selected bool) string {
+	if s.tagsSet == nil {
+		return "  "
+	}
+	if _, ok := s.tagsSet[sessionID]; !ok {
+		return "  "
+	}
+	return renderDot(styles.IconTag(), styles.TagIndicatorStyle, selected)
 }
 
 // workStatusDot returns a styled 2-character string (icon + space) representing

--- a/internal/tui/components/taginput.go
+++ b/internal/tui/components/taginput.go
@@ -1,0 +1,85 @@
+package components
+
+import (
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/jongio/dispatch/internal/tui/styles"
+)
+
+// TagInput provides an inline text input for editing a session's tags as a
+// comma-separated list.
+type TagInput struct {
+	input     textinput.Model
+	active    bool
+	sessionID string
+	width     int
+}
+
+// NewTagInput returns a TagInput ready for use.
+func NewTagInput() TagInput {
+	ti := textinput.New()
+	ti.Placeholder = "Comma-separated tags (Enter to save, Esc to cancel)..."
+	ti.Prompt = styles.IconTag() + " "
+	ti.CharLimit = 200
+	tiStyles := ti.Styles()
+	tiStyles.Focused.Placeholder = styles.DimmedStyle
+	tiStyles.Blurred.Placeholder = styles.DimmedStyle
+	tiStyles.Focused.Prompt = styles.TagIndicatorStyle
+	tiStyles.Blurred.Prompt = styles.TagIndicatorStyle
+	ti.SetStyles(tiStyles)
+	return TagInput{input: ti}
+}
+
+// Focus activates the tag input for the given session, pre-filling the
+// existing comma-separated tag value.
+func (n *TagInput) Focus(sessionID, current string) tea.Cmd {
+	n.active = true
+	n.sessionID = sessionID
+	n.input.SetValue(current)
+	return n.input.Focus()
+}
+
+// Blur deactivates the tag input.
+func (n *TagInput) Blur() {
+	n.active = false
+	n.sessionID = ""
+	n.input.Blur()
+}
+
+// Focused returns true when the tag input is capturing keystrokes.
+func (n *TagInput) Focused() bool {
+	return n.active
+}
+
+// Value returns the current comma-separated tag text.
+func (n *TagInput) Value() string {
+	return n.input.Value()
+}
+
+// SessionID returns the session ID being edited.
+func (n *TagInput) SessionID() string {
+	return n.sessionID
+}
+
+// SetWidth sets the available width for the tag input.
+func (n *TagInput) SetWidth(w int) {
+	n.width = w
+	n.input.SetWidth(max(10, w-6))
+}
+
+// Update delegates a tea.Msg to the underlying textinput.
+func (n TagInput) Update(msg tea.Msg) (TagInput, tea.Cmd) {
+	var cmd tea.Cmd
+	n.input, cmd = n.input.Update(msg)
+	return n, cmd
+}
+
+// View renders the tag input bar.
+func (n TagInput) View() string {
+	v := n.input.View()
+	if n.width > 0 && lipgloss.Width(v) > n.width {
+		v = lipgloss.NewStyle().MaxWidth(n.width).Render(v)
+	}
+	return v
+}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -59,6 +59,7 @@ type keyMap struct {
 	ScanWorkStatus    key.Binding
 	Export            key.Binding
 	Note              key.Binding
+	Tags              key.Binding
 	ShiftUp           key.Binding
 	ShiftDown         key.Binding
 	ViewSwitch        key.Binding
@@ -71,7 +72,7 @@ type keyMap struct {
 
 // ShortHelp returns a compact set of key bindings for the mini help bar.
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Enter, k.LaunchWindow, k.LaunchTab, k.LaunchPane, k.LaunchAll, k.Search, k.Filter, k.Sort, k.Preview, k.ViewPlan, k.Timeline, k.Compare, k.Hide, k.Star, k.Note, k.CopyID, k.CopyPath, k.CopyResumeCommand, k.CopyPreview, k.Export, k.OpenFile, k.OpenDir, k.JumpNextAttention, k.FilterAttention, k.ResumeInterrupted, k.ScanWorkStatus, k.ExpandCollapseAll, k.ViewSwitch, k.CmdPalette, k.Config, k.Help, k.Quit}
+	return []key.Binding{k.Enter, k.LaunchWindow, k.LaunchTab, k.LaunchPane, k.LaunchAll, k.Search, k.Filter, k.Sort, k.Preview, k.ViewPlan, k.Timeline, k.Compare, k.Hide, k.Star, k.Note, k.Tags, k.CopyID, k.CopyPath, k.CopyResumeCommand, k.CopyPreview, k.Export, k.OpenFile, k.OpenDir, k.JumpNextAttention, k.FilterAttention, k.ResumeInterrupted, k.ScanWorkStatus, k.ExpandCollapseAll, k.ViewSwitch, k.CmdPalette, k.Config, k.Help, k.Quit}
 }
 
 // FullHelp returns grouped key bindings for the expanded help view.
@@ -82,7 +83,7 @@ func (k keyMap) FullHelp() [][]key.Binding {
 		{k.Search, k.Escape, k.Filter},
 		{k.Sort, k.SortOrder, k.Pivot, k.PivotOrder, k.ExpandCollapseAll},
 		{k.Preview, k.PreviewPosition, k.PreviewScrollUp, k.PreviewScrollDown, k.ConversationSort, k.ViewPlan, k.Timeline, k.Compare, k.CopyID, k.CopyPath, k.CopyResumeCommand, k.CopyPreview, k.Export, k.OpenFile, k.OpenDir, k.Reindex, k.ScanWorkStatus, k.ViewSwitch, k.Config},
-		{k.Hide, k.ToggleHidden, k.Star, k.Note, k.JumpNextAttention, k.FilterAttention, k.ResumeInterrupted},
+		{k.Hide, k.ToggleHidden, k.Star, k.Note, k.Tags, k.JumpNextAttention, k.FilterAttention, k.ResumeInterrupted},
 		{k.TimeRange1, k.TimeRange2, k.TimeRange3, k.TimeRange4},
 		{k.Help, k.CmdPalette, k.Quit},
 	}
@@ -142,6 +143,7 @@ func defaultKeyMap() keyMap {
 		ScanWorkStatus:    key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "scan work status")),
 		Export:            key.NewBinding(key.WithKeys("X"), key.WithHelp("X", "export markdown")),
 		Note:              key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "edit note")),
+		Tags:              key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "edit tags")),
 		ShiftUp:           key.NewBinding(key.WithKeys("shift+up"), key.WithHelp("shift+\u2191", "extend select up")),
 		ShiftDown:         key.NewBinding(key.WithKeys("shift+down"), key.WithHelp("shift+\u2193", "extend select down")),
 		ViewSwitch:        key.NewBinding(key.WithKeys("V"), key.WithHelp("V", "switch view")),
@@ -213,6 +215,7 @@ func keybindingEntries(km *keyMap) []keybindingEntry {
 		{"scan_work_status", &km.ScanWorkStatus},
 		{"export", &km.Export},
 		{"note", &km.Note},
+		{"tags", &km.Tags},
 		{"shift_up", &km.ShiftUp},
 		{"shift_down", &km.ShiftDown},
 		{"view_switch", &km.ViewSwitch},

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -316,6 +316,7 @@ type Model struct {
 	sessionList     components.SessionList
 	searchBar       components.SearchBar
 	noteInput       components.NoteInput
+	tagInput        components.TagInput
 	filterPanel     components.FilterPanel
 	preview         components.PreviewPanel
 	help            components.HelpOverlay
@@ -335,6 +336,7 @@ type Model struct {
 	hiddenSet       map[string]struct{} // session ID → struct{} for fast hidden-session lookup
 	favoritedSet    map[string]struct{} // session ID → struct{} for fast favorited-session lookup
 	notesSet        map[string]struct{} // session ID → struct{} for fast note-existence lookup
+	tagsSet         map[string]struct{}
 	showFavorited   bool
 	activeView      string // name of the active named view (empty means Default)
 	reindexing      bool
@@ -347,6 +349,7 @@ type Model struct {
 	search       searchState
 	workStatus   workStatusState
 	searchFilter SearchFilter // structured tokens parsed from search bar input
+	tagFilter    string       // active tag: token; when set only show sessions carrying the tag
 
 	// initialQuery is a search string passed on the command line. It is
 	// applied once, when the session store first opens, then cleared.
@@ -457,6 +460,11 @@ func NewModel() Model {
 		notesSet[id] = struct{}{}
 	}
 
+	tagsSet := make(map[string]struct{}, len(cfg.SessionTags))
+	for id := range cfg.SessionTags {
+		tagsSet[id] = struct{}{}
+	}
+
 	m := Model{
 		state: stateLoading,
 		cfg:   cfg,
@@ -472,10 +480,12 @@ func NewModel() Model {
 		hiddenSet:       hiddenSet,
 		favoritedSet:    favoritedSet,
 		notesSet:        notesSet,
+		tagsSet:         tagsSet,
 
 		sessionList:     components.NewSessionList(),
 		searchBar:       components.NewSearchBar(),
 		noteInput:       components.NewNoteInput(),
+		tagInput:        components.NewTagInput(),
 		filterPanel:     components.NewFilterPanel(),
 		preview:         components.NewPreviewPanel(),
 		help:            components.NewHelpOverlay(),
@@ -1061,6 +1071,40 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	// ---------- Tag input focused -------------------------------------------
+	if m.tagInput.Focused() {
+		switch {
+		case key.Matches(msg, keys.Escape):
+			m.tagInput.Blur()
+			return m, nil
+		case key.Matches(msg, keys.Enter):
+			sessionID := m.tagInput.SessionID()
+			tags := config.ParseTags(m.tagInput.Value())
+			m.tagInput.Blur()
+
+			m.cfg.SetTags(sessionID, tags)
+			if len(tags) == 0 {
+				delete(m.tagsSet, sessionID)
+			} else {
+				m.tagsSet[sessionID] = struct{}{}
+			}
+
+			if err := config.Save(m.cfg); err != nil {
+				m.statusErr = "config save: " + err.Error()
+			}
+
+			m.sessionList.SetTagSessions(m.tagsSet)
+			m.statusInfo = "Tags saved"
+			return m, clearStatusAfter(2 * time.Second)
+		default:
+			var cmd tea.Cmd
+			ti := m.tagInput
+			ti, cmd = ti.Update(msg)
+			m.tagInput = ti
+			return m, cmd
+		}
+	}
+
 	// ---------- Search bar focused ----------------------------------------
 	if m.searchBar.Focused() {
 		switch {
@@ -1419,6 +1463,9 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case key.Matches(msg, keys.Note):
 		return m.handleEditNote()
 
+	case key.Matches(msg, keys.Tags):
+		return m.handleEditTags()
+
 	case key.Matches(msg, keys.CopyID):
 		return m.handleCopyID()
 
@@ -1683,6 +1730,17 @@ func (m Model) handleEditNote() (tea.Model, tea.Cmd) {
 		currentNote = m.cfg.SessionNotes[sess.ID]
 	}
 	cmd := m.noteInput.Focus(sess.ID, currentNote)
+	return m, cmd
+}
+
+// handleEditTags opens the inline tag input for the currently selected session.
+func (m Model) handleEditTags() (tea.Model, tea.Cmd) {
+	sess, ok := m.sessionList.Selected()
+	if !ok {
+		return m, nil
+	}
+	current := strings.Join(m.cfg.TagsFor(sess.ID), ", ")
+	cmd := m.tagInput.Focus(sess.ID, current)
 	return m, cmd
 }
 
@@ -2652,6 +2710,12 @@ func (m Model) renderFooter() string {
 		return m.noteInput.View()
 	}
 
+	// When tag input is active, show it instead of the normal footer.
+	if m.tagInput.Focused() {
+		m.tagInput.SetWidth(m.width)
+		return m.tagInput.View()
+	}
+
 	count := m.sessionList.SessionCount()
 
 	// Left: session count + active filter summary.
@@ -2890,6 +2954,7 @@ func (m *Model) syncSessionListStatuses() {
 	m.sessionList.SetHiddenSessions(m.visibleHiddenSet())
 	m.sessionList.SetFavoritedSessions(m.favoritedSet)
 	m.sessionList.SetNoteSessions(m.notesSet)
+	m.sessionList.SetTagSessions(m.tagsSet)
 	m.sessionList.SetAttentionStatuses(m.attentionMap)
 	m.sessionList.SetPlanStatuses(m.planMap)
 	m.sessionList.SetWorkStatuses(m.workStatus.workStatusMap)
@@ -2915,6 +2980,7 @@ func (m *Model) applySessionFilters(sessions []data.Session) []data.Session {
 	sessions = m.filterPlanSessions(sessions)
 	sessions = m.filterWorkStatusSessions(sessions)
 	sessions = m.filterGitDirtySessions(sessions)
+	sessions = m.filterTaggedSessions(sessions)
 	return sessions
 }
 
@@ -2927,7 +2993,34 @@ func (m *Model) applyGroupFilters(groups []data.SessionGroup) []data.SessionGrou
 	groups = m.filterPlanGroups(groups)
 	groups = m.filterWorkStatusGroups(groups)
 	groups = m.filterGitDirtyGroups(groups)
+	groups = m.filterTaggedGroups(groups)
 	return groups
+}
+
+// ---------------------------------------------------------------------------
+// Tag filtering
+// ---------------------------------------------------------------------------
+
+// filterTaggedSessions keeps only sessions carrying the active tag filter.
+// When no tag filter is set the input is returned unchanged.
+func (m *Model) filterTaggedSessions(sessions []data.Session) []data.Session {
+	if m.tagFilter == "" {
+		return sessions
+	}
+	return filterSessionsWhere(sessions, func(s data.Session) bool {
+		return m.cfg.HasTag(s.ID, m.tagFilter)
+	})
+}
+
+// filterTaggedGroups keeps only sessions carrying the active tag filter
+// within each group. When no tag filter is set the input is returned unchanged.
+func (m *Model) filterTaggedGroups(groups []data.SessionGroup) []data.SessionGroup {
+	if m.tagFilter == "" {
+		return groups
+	}
+	return filterGroupsWhere(groups, func(s data.Session) bool {
+		return m.cfg.HasTag(s.ID, m.tagFilter)
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/tui/searchtoken.go
+++ b/internal/tui/searchtoken.go
@@ -14,6 +14,7 @@ type SearchFilter struct {
 	HasPlan  bool   // has:plan
 	IsFav    bool   // is:favorite
 	IsHidden bool   // is:hidden
+	Tag      string // tag:<value>
 	FreeText string // remaining non-token words
 }
 
@@ -26,7 +27,8 @@ func (sf SearchFilter) HasTokens() bool {
 		sf.Status != "" ||
 		sf.HasPlan ||
 		sf.IsFav ||
-		sf.IsHidden
+		sf.IsHidden ||
+		sf.Tag != ""
 }
 
 // TokenSummary returns a short description of active tokens suitable for
@@ -56,6 +58,9 @@ func (sf SearchFilter) TokenSummary() string {
 	}
 	if sf.IsHidden {
 		parts = append(parts, "is:hidden")
+	}
+	if sf.Tag != "" {
+		parts = append(parts, "tag:"+sf.Tag)
 	}
 	if len(parts) == 0 {
 		return ""
@@ -90,6 +95,8 @@ func ParseSearchTokens(input string) SearchFilter {
 			sf.Host = value
 		case "status":
 			sf.Status = value
+		case "tag":
+			sf.Tag = value
 		case "has":
 			if value == "plan" {
 				sf.HasPlan = true

--- a/internal/tui/searchtoken_apply.go
+++ b/internal/tui/searchtoken_apply.go
@@ -18,6 +18,7 @@ func (m *Model) applySearchTokens() {
 	m.filter.Branch = sf.Branch
 	m.filter.Folder = sf.Folder
 	m.filter.HostType = sf.Host
+	m.tagFilter = sf.Tag
 
 	// Status token maps to the attention filter.
 	if sf.Status != "" {
@@ -44,6 +45,7 @@ func (m *Model) clearSearchTokenFilters() {
 	m.filter.Branch = ""
 	m.filter.Folder = ""
 	m.filter.HostType = ""
+	m.tagFilter = ""
 	m.attentionFilter = make(map[data.AttentionStatus]struct{})
 	m.filterPlans = false
 	m.showFavorited = false

--- a/internal/tui/styles/icons.go
+++ b/internal/tui/styles/icons.go
@@ -64,6 +64,7 @@ const (
 	nfADO    = "\uf0c2" //  nf-fa-cloud (Azure DevOps)
 	nfHost   = "\uf233" //  nf-fa-server (host type pivot group)
 	nfPencil = "\uf040" //  nf-fa-pencil
+	nfTag    = "\uf02b" //  nf-fa-tag
 )
 
 // ---------------------------------------------------------------------------
@@ -96,6 +97,7 @@ const (
 	fbADO    = "☁"
 	fbHost   = "⛁"
 	fbPencil = "✎"
+	fbTag    = "#"
 )
 
 // ---------------------------------------------------------------------------
@@ -216,6 +218,9 @@ func IconPlan() string { return icon(nfBullet, fbAttentionDot) }
 
 // IconNote returns a pencil icon for sessions that have a user note.
 func IconNote() string { return icon(nfPencil, fbPencil) }
+
+// IconTag returns a tag icon for sessions that carry user tags.
+func IconTag() string { return icon(nfTag, fbTag) }
 
 // IconWorkComplete returns a check icon for sessions with all planned work complete.
 func IconWorkComplete() string { return icon(nfCheck, fbCheck) }

--- a/internal/tui/styles/scheme.go
+++ b/internal/tui/styles/scheme.go
@@ -96,6 +96,9 @@ type Theme struct {
 	// Note indicator style.
 	NoteIndicatorStyle lipgloss.Style
 
+	// Tag indicator style.
+	TagIndicatorStyle lipgloss.Style
+
 	// Work status indicator styles.
 	WorkCompleteStyle   lipgloss.Style
 	WorkIncompleteStyle lipgloss.Style
@@ -261,6 +264,9 @@ func (t *Theme) buildStyles() {
 
 	// Note indicator — BrightYellow from the ANSI palette.
 	t.NoteIndicatorStyle = lipgloss.NewStyle().Foreground(c(t.ANSIPalette[11])).Bold(true)
+
+	// Tag indicator — BrightMagenta from the ANSI palette.
+	t.TagIndicatorStyle = lipgloss.NewStyle().Foreground(c(t.ANSIPalette[13])).Bold(true)
 
 	// Work status indicators — green (complete), yellow (incomplete), magenta (analyzing).
 	t.WorkCompleteStyle = lipgloss.NewStyle().Foreground(c(t.ANSIPalette[10])).Bold(true)   // BrightGreen

--- a/internal/tui/styles/theme.go
+++ b/internal/tui/styles/theme.go
@@ -97,6 +97,7 @@ func SetTheme(t *Theme) {
 	AttentionCompactingStyle = t.AttentionCompactingStyle
 	PlanIndicatorStyle = t.PlanIndicatorStyle
 	NoteIndicatorStyle = t.NoteIndicatorStyle
+	TagIndicatorStyle = t.TagIndicatorStyle
 	WorkCompleteStyle = t.WorkCompleteStyle
 	WorkIncompleteStyle = t.WorkIncompleteStyle
 	WorkAnalyzingStyle = t.WorkAnalyzingStyle
@@ -264,6 +265,9 @@ var (
 	// NoteIndicatorStyle renders the pencil marker for sessions that have a user note.
 	NoteIndicatorStyle lipgloss.Style
 
+	// TagIndicatorStyle renders the tag marker for sessions that carry user tags.
+	TagIndicatorStyle lipgloss.Style
+
 	// WorkCompleteStyle renders indicators for sessions with all planned work complete.
 	WorkCompleteStyle lipgloss.Style
 
@@ -379,6 +383,7 @@ func applyLegacyDefaults(isDark bool) {
 	AttentionCompactingStyle = lipgloss.NewStyle().Foreground(lightDark(c("#C19C00"), c("#C19C00"))).Faint(true) // Dim yellow
 	PlanIndicatorStyle = lipgloss.NewStyle().Foreground(lightDark(c("#0891B2"), c("#22D3EE"))).Bold(true)
 	NoteIndicatorStyle = lipgloss.NewStyle().Foreground(lightDark(c("#D97706"), c("#FBBF24"))).Bold(true)
+	TagIndicatorStyle = lipgloss.NewStyle().Foreground(lightDark(c("#9333EA"), c("#C084FC"))).Bold(true)
 	WorkCompleteStyle = lipgloss.NewStyle().Foreground(lightDark(c("#16A34A"), c("#4ADE80"))).Bold(true)
 	WorkIncompleteStyle = lipgloss.NewStyle().Foreground(lightDark(c("#CA8A04"), c("#FACC15"))).Bold(true)
 	WorkAnalyzingStyle = lipgloss.NewStyle().Foreground(lightDark(c("#9333EA"), c("#C084FC")))

--- a/internal/tui/tags_test.go
+++ b/internal/tui/tags_test.go
@@ -1,0 +1,57 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/jongio/dispatch/internal/config"
+	"github.com/jongio/dispatch/internal/data"
+)
+
+func TestParseSearchTokens_Tag(t *testing.T) {
+	sf := ParseSearchTokens("tag:work")
+	if sf.Tag != "work" {
+		t.Fatalf("expected tag work, got %q", sf.Tag)
+	}
+	if !sf.HasTokens() {
+		t.Fatal("expected HasTokens true")
+	}
+	if got := sf.TokenSummary(); got != "tag:work" {
+		t.Fatalf("expected summary tag:work, got %q", got)
+	}
+}
+
+func TestFilterTaggedSessions(t *testing.T) {
+	m := newTestModel()
+	m.cfg = config.Default()
+	m.cfg.SessionTags = map[string][]string{
+		"a": {"work"},
+		"b": {"personal"},
+	}
+	sessions := []data.Session{{ID: "a"}, {ID: "b"}, {ID: "c"}}
+
+	if got := m.filterTaggedSessions(sessions); len(got) != 3 {
+		t.Fatalf("expected 3 sessions with no filter, got %d", len(got))
+	}
+
+	m.tagFilter = "work"
+	got := m.filterTaggedSessions(sessions)
+	if len(got) != 1 || got[0].ID != "a" {
+		t.Fatalf("expected only session a, got %+v", got)
+	}
+}
+
+func TestFilterTaggedGroups(t *testing.T) {
+	m := newTestModel()
+	m.cfg = config.Default()
+	m.cfg.SessionTags = map[string][]string{"a": {"work"}}
+	m.tagFilter = "work"
+	groups := []data.SessionGroup{{
+		Label:    "g",
+		Sessions: []data.Session{{ID: "a"}, {ID: "b"}},
+		Count:    2,
+	}}
+	got := m.filterTaggedGroups(groups)
+	if len(got) != 1 || len(got[0].Sessions) != 1 || got[0].Sessions[0].ID != "a" {
+		t.Fatalf("expected group with only session a, got %+v", got)
+	}
+}


### PR DESCRIPTION
## Session tags

Adds lightweight, user-defined tags to sessions so related work can be grouped and filtered without renaming branches or folders. Tags are stored per session in the local config and never leave the machine.

Closes #231

### What you get

- Press `g` on a selected session to open an inline editor and enter comma-separated tags. Tags are lowercased, trimmed, de-duplicated, and sorted for stable storage.
- A compact marker appears on tagged rows in the session list.
- Filter to a single tag from the search bar with the `tag:` token, for example `tag:work` or `tag:"needs review"`. The active token shows in the badge row and combines with existing filters.

### How it fits together

```mermaid
flowchart TD
    A[Select session] -->|press g| B[Tag input]
    B -->|Enter| C[ParseTags: trim, lowercase, dedupe, sort]
    C --> D[config.SessionTags map]
    D --> E[Saved to config.json]
    D --> F[Row tag marker]
    G[Search bar] -->|tag:value| H[ParseSearchTokens]
    H --> I[tagFilter]
    I --> J[filterTaggedSessions / filterTaggedGroups]
    D --> J
    J --> K[Filtered list]
```

### Implementation notes

- New `SessionTags map[string][]string` config field with `ParseTags`, `SetTags`, `TagsFor`, and `HasTag` helpers. Empty tag sets are removed so the config stays compact.
- New `tag:` structured search token wired through `SearchFilter`, `TokenSummary`, and the apply/clear paths, mirroring the existing token handling.
- Tag filtering runs client-side in the session and group filter chains, since tags live in config rather than the session store (same pattern as favorites).
- New `TagInput` component and a dedicated `TagIndicatorStyle` theme entry (bright magenta) so the tag marker is visually distinct from the note and plan markers.

### Verification

- `go build ./...`
- `go vet ./...`
- `golangci-lint run` (0 issues)
- `go test ./...` (all packages pass, including new tests for `ParseTags`, `SetTags`, `HasTag`, the `tag:` token parse, and tag filtering for sessions and groups)
