### PR TITLE
feat: add session aliases and open by alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Dispatch reads your local Copilot CLI session store and presents every past sess
 - **Session hiding** (`h` / `H`) — hide sessions from the list, toggle visibility of hidden sessions, persistent state
 - **Session favorites** (`*`) — star sessions as favorites. Filter to show only favorites via the `!` status picker
 - **Session tags** (`g`) — attach comma-separated tags to sessions and filter to a tag with the `tag:` search token
+- **Session aliases** (`A`) — give a session a short, memorable alias and resume it from the CLI with `dispatch open <alias>` instead of the full session ID
 - **Settings panel** (`,`) — 15 fields: Yolo Mode, Agent, Model, Launch Mode, Pane Direction, Terminal, Shell, Custom Command, Theme, Crash Recovery, Preview Position, Redact Secrets, Excluded Words, Auto Refresh, Notify On Waiting
 - **Shell picker** — auto-detects installed shells, modal picker when multiple available
 - **5 built-in themes** — Dispatch Dark, Dispatch Light, Campbell, One Half Dark, One Half Light + custom via Windows Terminal JSON
@@ -198,6 +199,7 @@ Add `--json` (`dispatch doctor --json`) to print the same checks as a single JSO
 | `H` | Toggle visibility of hidden sessions |
 | `*` | Toggle favorite on current session |
 | `g` | Add or edit tags on current session |
+| `A` | Set or clear a short alias on current session |
 
 #### Search & Filter
 
@@ -314,6 +316,7 @@ Configuration is stored in the platform-specific config directory:
 | `favoriteSessions` | array | `[]` | Session IDs starred as favorites |
 | `keybindings` | object | `{}` | Remap keyboard shortcuts. Keys are action names, values are comma-separated key lists (see [Customizing Keybindings](#customizing-keybindings)) |
 | `sessionTags` | object | `{}` | Map of session ID to a list of user-defined tags |
+| `sessionAliases` | object | `{}` | Map of session ID to a unique short alias for `dispatch open <alias>` |
 
 #### Pane Direction Semantics
 

--- a/cmd/dispatch/open.go
+++ b/cmd/dispatch/open.go
@@ -41,6 +41,12 @@ func runOpen(w io.Writer, args []string) error {
 
 	mode := resolveOpenMode(modeFlag, cfg)
 
+	// Resolve the argument as an alias first; fall back to treating it as a
+	// session ID when no alias matches.
+	if resolved := cfg.SessionIDForAlias(id); resolved != "" {
+		id = resolved
+	}
+
 	sess, err := openGetSessionFn(id)
 	if err != nil {
 		return err

--- a/cmd/dispatch/open_test.go
+++ b/cmd/dispatch/open_test.go
@@ -149,6 +149,37 @@ func TestRunOpen_HappyPath(t *testing.T) {
 	}
 }
 
+func TestRunOpen_ResolvesAlias(t *testing.T) {
+	cfg := config.Default()
+	cfg.SessionAliases = map[string]string{"sess-1": "authfix"}
+	sess := &data.Session{ID: "sess-1", Cwd: "/tmp/project"}
+	capture := withOpenStubs(t, cfg, sess, nil)
+
+	if err := runOpen(io.Discard, []string{"open", "authfix"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capture.gotID != "sess-1" {
+		t.Errorf("resolved id = %q, want sess-1", capture.gotID)
+	}
+	if !capture.launched {
+		t.Fatal("expected launch to be invoked")
+	}
+}
+
+func TestRunOpen_UnknownAliasFallsBackToID(t *testing.T) {
+	cfg := config.Default()
+	cfg.SessionAliases = map[string]string{"sess-1": "authfix"}
+	sess := &data.Session{ID: "raw-id", Cwd: "/tmp/p"}
+	capture := withOpenStubs(t, cfg, sess, nil)
+
+	if err := runOpen(io.Discard, []string{"open", "raw-id"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capture.gotID != "raw-id" {
+		t.Errorf("id = %q, want raw-id (fallback)", capture.gotID)
+	}
+}
+
 func TestRunOpen_NotFound(t *testing.T) {
 	withOpenStubs(t, config.Default(), nil, nil)
 	err := runOpen(io.Discard, []string{"open", "missing"})

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -262,6 +262,13 @@
     - Behavior: Opens an inline input to edit comma-separated tags (persisted to config as sessionTags); filter with the tag: search token
     - Condition: Only when a session is selected (not a folder)
 
+26c. **A** — Set or Clear a Short Alias on Current Session
+    - File: internal\tui\keys.go
+    - Code: key.NewBinding(key.WithKeys("A"), key.WithHelp("A", "edit alias"))
+    - Handler: internal\tui\model.go (handleEditAlias)
+    - Behavior: Opens an inline input to set or clear a unique alias (persisted to config as sessionAliases); resume from the CLI with dispatch open <alias>
+    - Condition: Only when a session is selected (not a folder)
+
 27b. **c** → Copy Session ID to Clipboard
      - File: internal\tui\keys.go
      - Code: key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "copy session ID"))

--- a/internal/config/aliases.go
+++ b/internal/config/aliases.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// NormalizeAlias trims and lowercases an alias and reduces it to its first
+// whitespace-delimited token so aliases stay usable as a single CLI argument.
+func NormalizeAlias(input string) string {
+	s := strings.ToLower(strings.TrimSpace(input))
+	if i := strings.IndexAny(s, " \t"); i >= 0 {
+		s = s[:i]
+	}
+	return s
+}
+
+// SetAlias assigns an alias to a session. An empty alias clears any existing
+// alias for the session. It returns an error when the alias is already used by
+// a different session so aliases stay unique.
+func (c *Config) SetAlias(sessionID, alias string) error {
+	if sessionID == "" {
+		return nil
+	}
+	alias = NormalizeAlias(alias)
+	if alias == "" {
+		delete(c.SessionAliases, sessionID)
+		return nil
+	}
+	for id, a := range c.SessionAliases {
+		if a == alias && id != sessionID {
+			return fmt.Errorf("alias %q is already used by another session", alias)
+		}
+	}
+	if c.SessionAliases == nil {
+		c.SessionAliases = make(map[string]string)
+	}
+	c.SessionAliases[sessionID] = alias
+	return nil
+}
+
+// AliasFor returns the alias for a session, or an empty string when none.
+func (c *Config) AliasFor(sessionID string) string {
+	return c.SessionAliases[sessionID]
+}
+
+// SessionIDForAlias returns the session ID mapped to the given alias, or an
+// empty string when no session uses it. The lookup is case-insensitive.
+func (c *Config) SessionIDForAlias(alias string) string {
+	alias = NormalizeAlias(alias)
+	if alias == "" {
+		return ""
+	}
+	for id, a := range c.SessionAliases {
+		if a == alias {
+			return id
+		}
+	}
+	return ""
+}

--- a/internal/config/aliases_test.go
+++ b/internal/config/aliases_test.go
@@ -1,0 +1,61 @@
+package config
+
+import "testing"
+
+func TestNormalizeAlias(t *testing.T) {
+	cases := map[string]string{
+		"  AuthFix ": "authfix",
+		"my alias":   "my",
+		"":           "",
+		"UPPER":      "upper",
+	}
+	for in, want := range cases {
+		if got := NormalizeAlias(in); got != want {
+			t.Errorf("NormalizeAlias(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSetAliasAndLookup(t *testing.T) {
+	c := Default()
+	if err := c.SetAlias("s1", "AuthFix"); err != nil {
+		t.Fatalf("SetAlias: %v", err)
+	}
+	if got := c.AliasFor("s1"); got != "authfix" {
+		t.Fatalf("AliasFor = %q, want authfix", got)
+	}
+	if got := c.SessionIDForAlias("AUTHFIX"); got != "s1" {
+		t.Fatalf("SessionIDForAlias = %q, want s1", got)
+	}
+	if got := c.SessionIDForAlias("nope"); got != "" {
+		t.Fatalf("expected empty for unknown alias, got %q", got)
+	}
+}
+
+func TestSetAliasUniqueness(t *testing.T) {
+	c := Default()
+	if err := c.SetAlias("s1", "dup"); err != nil {
+		t.Fatalf("SetAlias s1: %v", err)
+	}
+	if err := c.SetAlias("s2", "dup"); err == nil {
+		t.Fatal("expected uniqueness error for duplicate alias")
+	}
+	// Re-setting the same alias on the same session is allowed.
+	if err := c.SetAlias("s1", "dup"); err != nil {
+		t.Fatalf("re-set same alias: %v", err)
+	}
+}
+
+func TestSetAliasClear(t *testing.T) {
+	c := Default()
+	_ = c.SetAlias("s1", "temp")
+	if err := c.SetAlias("s1", ""); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if got := c.AliasFor("s1"); got != "" {
+		t.Fatalf("expected cleared alias, got %q", got)
+	}
+	if _, ok := c.SessionAliases["s1"]; ok {
+		t.Fatal("expected entry removed after clear")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -212,6 +212,11 @@ type Config struct {
 	// indicated by a marker in the session list.
 	SessionTags map[string][]string `json:"sessionTags,omitempty"`
 
+	// SessionAliases maps session IDs to a single short, user-chosen alias.
+	// Aliases are unique and let "dispatch open <alias>" resume a session
+	// without typing the full ID.
+	SessionAliases map[string]string `json:"sessionAliases,omitempty"`
+
 	// AISearch enables Copilot SDK-powered AI search. When false (the
 	// default), only the local FTS5 index is used.  Set to true to also
 	// query the Copilot backend for semantically relevant sessions.

--- a/internal/tui/components/aliasinput.go
+++ b/internal/tui/components/aliasinput.go
@@ -1,0 +1,84 @@
+package components
+
+import (
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/jongio/dispatch/internal/tui/styles"
+)
+
+// AliasInput provides an inline text input for editing a session's alias.
+type AliasInput struct {
+	input     textinput.Model
+	active    bool
+	sessionID string
+	width     int
+}
+
+// NewAliasInput returns an AliasInput ready for use.
+func NewAliasInput() AliasInput {
+	ti := textinput.New()
+	ti.Placeholder = "Enter alias (Enter to save, Esc to cancel)..."
+	ti.Prompt = styles.IconAlias() + " "
+	ti.CharLimit = 60
+	tiStyles := ti.Styles()
+	tiStyles.Focused.Placeholder = styles.DimmedStyle
+	tiStyles.Blurred.Placeholder = styles.DimmedStyle
+	tiStyles.Focused.Prompt = styles.NoteIndicatorStyle
+	tiStyles.Blurred.Prompt = styles.NoteIndicatorStyle
+	ti.SetStyles(tiStyles)
+	return AliasInput{input: ti}
+}
+
+// Focus activates the alias input for the given session, pre-filling the
+// existing alias value.
+func (n *AliasInput) Focus(sessionID, current string) tea.Cmd {
+	n.active = true
+	n.sessionID = sessionID
+	n.input.SetValue(current)
+	return n.input.Focus()
+}
+
+// Blur deactivates the alias input.
+func (n *AliasInput) Blur() {
+	n.active = false
+	n.sessionID = ""
+	n.input.Blur()
+}
+
+// Focused returns true when the alias input is capturing keystrokes.
+func (n *AliasInput) Focused() bool {
+	return n.active
+}
+
+// Value returns the current alias text.
+func (n *AliasInput) Value() string {
+	return n.input.Value()
+}
+
+// SessionID returns the session ID being edited.
+func (n *AliasInput) SessionID() string {
+	return n.sessionID
+}
+
+// SetWidth sets the available width for the alias input.
+func (n *AliasInput) SetWidth(w int) {
+	n.width = w
+	n.input.SetWidth(max(10, w-6))
+}
+
+// Update delegates a tea.Msg to the underlying textinput.
+func (n AliasInput) Update(msg tea.Msg) (AliasInput, tea.Cmd) {
+	var cmd tea.Cmd
+	n.input, cmd = n.input.Update(msg)
+	return n, cmd
+}
+
+// View renders the alias input bar.
+func (n AliasInput) View() string {
+	v := n.input.View()
+	if n.width > 0 && lipgloss.Width(v) > n.width {
+		v = lipgloss.NewStyle().MaxWidth(n.width).Render(v)
+	}
+	return v
+}

--- a/internal/tui/components/preview.go
+++ b/internal/tui/components/preview.go
@@ -18,6 +18,7 @@ type PreviewPanel struct {
 	detail          *data.SessionDetail
 	attentionStatus data.AttentionStatus
 	note            string // user note for the current session
+	alias           string // user-chosen alias for the current session
 	width           int
 	height          int
 	scroll          int
@@ -89,6 +90,12 @@ func (p *PreviewPanel) SetDetail(d *data.SessionDetail) {
 // SetNote updates the user note shown at the top of the preview.
 func (p *PreviewPanel) SetNote(note string) {
 	p.note = note
+	p.updateTotalLines()
+}
+
+// SetAlias updates the alias shown at the top of the preview.
+func (p *PreviewPanel) SetAlias(alias string) {
+	p.alias = alias
 	p.updateTotalLines()
 }
 
@@ -583,6 +590,12 @@ func (p PreviewPanel) renderContent() (string, int, int) {
 	}
 
 	// ── Note ──
+	if p.alias != "" {
+		aliasLabel := styles.PreviewLabelStyle.Render(styles.IconAlias() + " Alias: ")
+		aliasValue := styles.NoteIndicatorStyle.Render(p.alias)
+		b.WriteString(aliasLabel + aliasValue + "\n\n")
+	}
+
 	if p.note != "" {
 		noteLabel := styles.PreviewLabelStyle.Render(styles.IconNote() + " Note: ")
 		noteValue := styles.NoteIndicatorStyle.Render(wordWrap(p.note, max(1, contentW-lipgloss.Width(noteLabel))))

--- a/internal/tui/handlers.go
+++ b/internal/tui/handlers.go
@@ -259,6 +259,7 @@ func (m Model) handleSessionDetail(msg sessionDetailMsg) (Model, tea.Cmd) {
 	} else {
 		m.preview.SetNote("")
 	}
+	m.preview.SetAlias(m.cfg.AliasFor(m.detail.Session.ID))
 	m.preview.SetAttentionStatus(m.attentionStatusForSession(m.detail.Session.ID))
 	m.preview.SetHasPlan(m.planMap[m.detail.Session.ID])
 	if result, ok := m.workStatus.workStatusMap[m.detail.Session.ID]; ok {

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -60,6 +60,7 @@ type keyMap struct {
 	Export            key.Binding
 	Note              key.Binding
 	Tags              key.Binding
+	Alias             key.Binding
 	ShiftUp           key.Binding
 	ShiftDown         key.Binding
 	ViewSwitch        key.Binding
@@ -72,7 +73,7 @@ type keyMap struct {
 
 // ShortHelp returns a compact set of key bindings for the mini help bar.
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Enter, k.LaunchWindow, k.LaunchTab, k.LaunchPane, k.LaunchAll, k.Search, k.Filter, k.Sort, k.Preview, k.ViewPlan, k.Timeline, k.Compare, k.Hide, k.Star, k.Note, k.Tags, k.CopyID, k.CopyPath, k.CopyResumeCommand, k.CopyPreview, k.Export, k.OpenFile, k.OpenDir, k.JumpNextAttention, k.FilterAttention, k.ResumeInterrupted, k.ScanWorkStatus, k.ExpandCollapseAll, k.ViewSwitch, k.CmdPalette, k.Config, k.Help, k.Quit}
+	return []key.Binding{k.Enter, k.LaunchWindow, k.LaunchTab, k.LaunchPane, k.LaunchAll, k.Search, k.Filter, k.Sort, k.Preview, k.ViewPlan, k.Timeline, k.Compare, k.Hide, k.Star, k.Note, k.Tags, k.Alias, k.CopyID, k.CopyPath, k.CopyResumeCommand, k.CopyPreview, k.Export, k.OpenFile, k.OpenDir, k.JumpNextAttention, k.FilterAttention, k.ResumeInterrupted, k.ScanWorkStatus, k.ExpandCollapseAll, k.ViewSwitch, k.CmdPalette, k.Config, k.Help, k.Quit}
 }
 
 // FullHelp returns grouped key bindings for the expanded help view.
@@ -83,7 +84,7 @@ func (k keyMap) FullHelp() [][]key.Binding {
 		{k.Search, k.Escape, k.Filter},
 		{k.Sort, k.SortOrder, k.Pivot, k.PivotOrder, k.ExpandCollapseAll},
 		{k.Preview, k.PreviewPosition, k.PreviewScrollUp, k.PreviewScrollDown, k.ConversationSort, k.ViewPlan, k.Timeline, k.Compare, k.CopyID, k.CopyPath, k.CopyResumeCommand, k.CopyPreview, k.Export, k.OpenFile, k.OpenDir, k.Reindex, k.ScanWorkStatus, k.ViewSwitch, k.Config},
-		{k.Hide, k.ToggleHidden, k.Star, k.Note, k.Tags, k.JumpNextAttention, k.FilterAttention, k.ResumeInterrupted},
+		{k.Hide, k.ToggleHidden, k.Star, k.Note, k.Tags, k.Alias, k.JumpNextAttention, k.FilterAttention, k.ResumeInterrupted},
 		{k.TimeRange1, k.TimeRange2, k.TimeRange3, k.TimeRange4},
 		{k.Help, k.CmdPalette, k.Quit},
 	}
@@ -144,6 +145,7 @@ func defaultKeyMap() keyMap {
 		Export:            key.NewBinding(key.WithKeys("X"), key.WithHelp("X", "export markdown")),
 		Note:              key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "edit note")),
 		Tags:              key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "edit tags")),
+		Alias:             key.NewBinding(key.WithKeys("A"), key.WithHelp("A", "edit alias")),
 		ShiftUp:           key.NewBinding(key.WithKeys("shift+up"), key.WithHelp("shift+\u2191", "extend select up")),
 		ShiftDown:         key.NewBinding(key.WithKeys("shift+down"), key.WithHelp("shift+\u2193", "extend select down")),
 		ViewSwitch:        key.NewBinding(key.WithKeys("V"), key.WithHelp("V", "switch view")),
@@ -216,6 +218,7 @@ func keybindingEntries(km *keyMap) []keybindingEntry {
 		{"export", &km.Export},
 		{"note", &km.Note},
 		{"tags", &km.Tags},
+		{"alias", &km.Alias},
 		{"shift_up", &km.ShiftUp},
 		{"shift_down", &km.ShiftDown},
 		{"view_switch", &km.ViewSwitch},

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -317,6 +317,7 @@ type Model struct {
 	searchBar       components.SearchBar
 	noteInput       components.NoteInput
 	tagInput        components.TagInput
+	aliasInput      components.AliasInput
 	filterPanel     components.FilterPanel
 	preview         components.PreviewPanel
 	help            components.HelpOverlay
@@ -486,6 +487,7 @@ func NewModel() Model {
 		searchBar:       components.NewSearchBar(),
 		noteInput:       components.NewNoteInput(),
 		tagInput:        components.NewTagInput(),
+		aliasInput:      components.NewAliasInput(),
 		filterPanel:     components.NewFilterPanel(),
 		preview:         components.NewPreviewPanel(),
 		help:            components.NewHelpOverlay(),
@@ -1105,6 +1107,43 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	// ---------- Alias input focused -----------------------------------------
+	if m.aliasInput.Focused() {
+		switch {
+		case key.Matches(msg, keys.Escape):
+			m.aliasInput.Blur()
+			return m, nil
+		case key.Matches(msg, keys.Enter):
+			sessionID := m.aliasInput.SessionID()
+			aliasText := m.aliasInput.Value()
+			m.aliasInput.Blur()
+
+			if err := m.cfg.SetAlias(sessionID, aliasText); err != nil {
+				m.statusErr = err.Error()
+				return m, clearStatusAfter(3 * time.Second)
+			}
+
+			if err := config.Save(m.cfg); err != nil {
+				m.statusErr = "config save: " + err.Error()
+				return m, clearStatusAfter(3 * time.Second)
+			}
+
+			m.preview.SetAlias(m.cfg.AliasFor(sessionID))
+			if m.cfg.AliasFor(sessionID) == "" {
+				m.statusInfo = "Alias cleared"
+			} else {
+				m.statusInfo = "Alias saved"
+			}
+			return m, clearStatusAfter(2 * time.Second)
+		default:
+			var cmd tea.Cmd
+			ai := m.aliasInput
+			ai, cmd = ai.Update(msg)
+			m.aliasInput = ai
+			return m, cmd
+		}
+	}
+
 	// ---------- Search bar focused ----------------------------------------
 	if m.searchBar.Focused() {
 		switch {
@@ -1465,6 +1504,8 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	case key.Matches(msg, keys.Tags):
 		return m.handleEditTags()
+	case key.Matches(msg, keys.Alias):
+		return m.handleEditAlias()
 
 	case key.Matches(msg, keys.CopyID):
 		return m.handleCopyID()
@@ -1741,6 +1782,17 @@ func (m Model) handleEditTags() (tea.Model, tea.Cmd) {
 	}
 	current := strings.Join(m.cfg.TagsFor(sess.ID), ", ")
 	cmd := m.tagInput.Focus(sess.ID, current)
+	return m, cmd
+}
+
+// handleEditAlias opens the inline alias input for the currently selected session.
+func (m Model) handleEditAlias() (tea.Model, tea.Cmd) {
+	sess, ok := m.sessionList.Selected()
+	if !ok {
+		return m, nil
+	}
+	current := m.cfg.AliasFor(sess.ID)
+	cmd := m.aliasInput.Focus(sess.ID, current)
 	return m, cmd
 }
 
@@ -2714,6 +2766,12 @@ func (m Model) renderFooter() string {
 	if m.tagInput.Focused() {
 		m.tagInput.SetWidth(m.width)
 		return m.tagInput.View()
+	}
+
+	// When alias input is active, show it instead of the normal footer.
+	if m.aliasInput.Focused() {
+		m.aliasInput.SetWidth(m.width)
+		return m.aliasInput.View()
 	}
 
 	count := m.sessionList.SessionCount()

--- a/internal/tui/styles/icons.go
+++ b/internal/tui/styles/icons.go
@@ -60,11 +60,12 @@ const (
 	nfList       = "\uf03a" //  nf-fa-list
 
 	// Host type icons — distinguish session origin (GitHub, Azure DevOps).
-	nfGitHub = "\uf09b" //  nf-fa-github
-	nfADO    = "\uf0c2" //  nf-fa-cloud (Azure DevOps)
-	nfHost   = "\uf233" //  nf-fa-server (host type pivot group)
-	nfPencil = "\uf040" //  nf-fa-pencil
-	nfTag    = "\uf02b" //  nf-fa-tag
+	nfGitHub   = "\uf09b" //  nf-fa-github
+	nfADO      = "\uf0c2" //  nf-fa-cloud (Azure DevOps)
+	nfHost     = "\uf233" //  nf-fa-server (host type pivot group)
+	nfPencil   = "\uf040" //  nf-fa-pencil
+	nfTag      = "\uf02b" //  nf-fa-tag
+	nfBookmark = "\uf02e" //  nf-fa-bookmark
 )
 
 // ---------------------------------------------------------------------------
@@ -98,6 +99,7 @@ const (
 	fbHost   = "⛁"
 	fbPencil = "✎"
 	fbTag    = "#"
+	fbAlias  = "@"
 )
 
 // ---------------------------------------------------------------------------
@@ -221,6 +223,9 @@ func IconNote() string { return icon(nfPencil, fbPencil) }
 
 // IconTag returns a tag icon for sessions that carry user tags.
 func IconTag() string { return icon(nfTag, fbTag) }
+
+// IconAlias returns a bookmark icon used when editing or showing a session alias.
+func IconAlias() string { return icon(nfBookmark, fbAlias) }
 
 // IconWorkComplete returns a check icon for sessions with all planned work complete.
 func IconWorkComplete() string { return icon(nfCheck, fbCheck) }


### PR DESCRIPTION
## Session aliases

Gives a session a short, memorable alias so it can be resumed from the command line with `dispatch open <alias>` instead of a long opaque session ID. Aliases are stored per session in the local config and never leave the machine.

Closes #232

### What you get

- Press `A` on a selected session to open an inline editor and set or clear a single alias. Aliases are normalized to one lowercase token and must be unique across sessions.
- The alias shows at the top of the preview pane for the selected session.
- Resume from the CLI with `dispatch open authfix`. When the argument is not a known alias, the existing session ID lookup still applies, so `dispatch open <id>` keeps working.

### How it fits together

```mermaid
flowchart TD
    A[Selected session] -->|press A| B[Alias editor]
    B --> C{Unique?}
    C -- no --> D[Show error, nothing saved]
    C -- yes --> E[config.SessionAliases map]
    E --> F[Saved to config.json]
    E --> G[Preview shows alias]
    H[dispatch open authfix] --> I[SessionIDForAlias]
    I -- match --> J[Resolve to session ID]
    I -- no match --> K[Use argument as ID]
    J --> L[Launch session]
    K --> L
```

### Implementation notes

- New `SessionAliases map[string]string` config field with `NormalizeAlias`, `SetAlias` (rejects duplicates), `AliasFor`, and `SessionIDForAlias` helpers. Clearing an alias removes the entry so the config stays compact.
- New `AliasInput` component following the existing inline note input pattern, wired into the model with the `A` key and a footer view. A uniqueness collision surfaces as a status error and saves nothing.
- The preview panel gained an alias line rendered above the note, using a bookmark icon with an ASCII fallback.
- `cmd/dispatch/open.go` resolves the positional argument through `SessionIDForAlias` before the store lookup, with a clean fallback to ID lookup.

### Verification

- `go build ./...`
- `go vet ./...`
- `golangci-lint run` (0 issues)
- `go test ./...` (all packages pass, including new tests for alias normalize, set/clear, uniqueness, reverse lookup, and `dispatch open` alias resolution plus ID fallback)
