### PR TITLE
Add fullscreen preview zoom (z)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Dispatch reads your local Copilot CLI session store and presents every past sess
 - **Sorting** (`s` / `S`) — 5 fields (updated, folder, name, created, turns) with toggleable direction
 - **Grouping (pivot) modes** (`Tab`) — flat, folder, repo, branch, date — displayed as collapsible trees with session counts
 - **Time range filtering** (`1`–`4`) — 1 hour, 1 day, 7 days, all
-- **Preview panel** (`p`) — metadata, chat-style conversation bubbles, checkpoints (up to 5), files (up to 5), refs (up to 5), scroll indicators. Toggle conversation sort order with `o`. Click the session ID row to copy it to clipboard
+- **Preview panel** (`p`) — metadata, chat-style conversation bubbles, checkpoints (up to 5), files (up to 5), refs (up to 5), scroll indicators. Toggle conversation sort order with `o`. Press `z` to view the preview fullscreen. Click the session ID row to copy it to clipboard
 - **Copy session ID** (`c`) — copy the selected session's ID to the system clipboard. Also available by clicking the ID row in the preview pane
 - **Copy resume command** (`Y`) — copy the selected session's full resume command to the system clipboard. With a multi-select active, copies one resume command per selected session, one per line
 - **Open working directory** (`O`) — open the selected session's working directory in the system file manager (Explorer on Windows, Finder on macOS, the default file manager on Linux)
@@ -218,6 +218,7 @@ Add `--json` (`dispatch doctor --json`) to print the same checks as a single JSO
 | `Tab` | Cycle grouping mode |
 | `p` | Toggle preview panel |
 | `P` | Cycle preview position (right → bottom → left → top) |
+| `z` | Toggle fullscreen preview |
 | `v` | View plan in preview pane |
 | `o` | Toggle conversation sort order (oldest/newest first) |
 | `c` | Copy session ID to clipboard |

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -203,6 +203,13 @@
      - Behavior: Copies the selected session's resume command to the system clipboard using the same launch settings as Dispatch.
      - Condition: Only when a session is selected
 
+20f. **z** → Toggle Fullscreen Preview
+     - File: internal\tui\keys.go
+     - Code: key.NewBinding(key.WithKeys("z"), key.WithHelp("z", "fullscreen preview"))
+     - Handler: internal\tui\model.go (previewFullscreen toggle), internal\tui\layout.go (recalcLayout)
+     - Behavior: Expands the preview to fill the entire content area and hides the session list so a long conversation is easier to read. Press z again or Esc to restore the split layout. PgUp/PgDn scrolling still works, and toggling on shows the preview even when the split preview is hidden.
+     - Condition: In session list view
+
 21. **PgUp (Page Up)** → Preview Panel Scroll Up
     - File: internal\tui\keys.go (line 85)
     - Code: key.NewBinding(key.WithKeys("pgup"))

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -27,6 +27,7 @@ type keyMap struct {
 	Pivot             key.Binding
 	PivotOrder        key.Binding
 	Preview           key.Binding
+	PreviewFullscreen key.Binding
 	Reindex           key.Binding
 	Help              key.Binding
 	Config            key.Binding
@@ -73,7 +74,7 @@ type keyMap struct {
 
 // ShortHelp returns a compact set of key bindings for the mini help bar.
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Enter, k.LaunchWindow, k.LaunchTab, k.LaunchPane, k.LaunchAll, k.Search, k.Filter, k.Sort, k.Preview, k.ViewPlan, k.Timeline, k.Compare, k.Hide, k.Star, k.Note, k.Tags, k.Alias, k.CopyID, k.CopyPath, k.CopyResumeCommand, k.CopyPreview, k.Export, k.OpenFile, k.OpenDir, k.JumpNextAttention, k.FilterAttention, k.ResumeInterrupted, k.ScanWorkStatus, k.ExpandCollapseAll, k.ViewSwitch, k.CmdPalette, k.Config, k.Help, k.Quit}
+	return []key.Binding{k.Enter, k.LaunchWindow, k.LaunchTab, k.LaunchPane, k.LaunchAll, k.Search, k.Filter, k.Sort, k.Preview, k.PreviewFullscreen, k.ViewPlan, k.Timeline, k.Compare, k.Hide, k.Star, k.Note, k.Tags, k.Alias, k.CopyID, k.CopyPath, k.CopyResumeCommand, k.CopyPreview, k.Export, k.OpenFile, k.OpenDir, k.JumpNextAttention, k.FilterAttention, k.ResumeInterrupted, k.ScanWorkStatus, k.ExpandCollapseAll, k.ViewSwitch, k.CmdPalette, k.Config, k.Help, k.Quit}
 }
 
 // FullHelp returns grouped key bindings for the expanded help view.
@@ -83,7 +84,7 @@ func (k keyMap) FullHelp() [][]key.Binding {
 		{k.Space, k.LaunchAll, k.SelectAll, k.DeselectAll, k.ShiftUp, k.ShiftDown},
 		{k.Search, k.Escape, k.Filter},
 		{k.Sort, k.SortOrder, k.Pivot, k.PivotOrder, k.ExpandCollapseAll},
-		{k.Preview, k.PreviewPosition, k.PreviewScrollUp, k.PreviewScrollDown, k.ConversationSort, k.ViewPlan, k.Timeline, k.Compare, k.CopyID, k.CopyPath, k.CopyResumeCommand, k.CopyPreview, k.Export, k.OpenFile, k.OpenDir, k.Reindex, k.ScanWorkStatus, k.ViewSwitch, k.Config},
+		{k.Preview, k.PreviewFullscreen, k.PreviewPosition, k.PreviewScrollUp, k.PreviewScrollDown, k.ConversationSort, k.ViewPlan, k.Timeline, k.Compare, k.CopyID, k.CopyPath, k.CopyResumeCommand, k.CopyPreview, k.Export, k.OpenFile, k.OpenDir, k.Reindex, k.ScanWorkStatus, k.ViewSwitch, k.Config},
 		{k.Hide, k.ToggleHidden, k.Star, k.Note, k.Tags, k.Alias, k.JumpNextAttention, k.FilterAttention, k.ResumeInterrupted},
 		{k.TimeRange1, k.TimeRange2, k.TimeRange3, k.TimeRange4},
 		{k.Help, k.CmdPalette, k.Quit},
@@ -112,6 +113,7 @@ func defaultKeyMap() keyMap {
 		Pivot:             key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "cycle pivot")),
 		PivotOrder:        key.NewBinding(key.WithKeys("shift+tab"), key.WithHelp("shift+tab", "reverse pivot order")),
 		Preview:           key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "toggle preview")),
+		PreviewFullscreen: key.NewBinding(key.WithKeys("z"), key.WithHelp("z", "fullscreen preview")),
 		Reindex:           key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "rebuild index")),
 		Help:              key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
 		Config:            key.NewBinding(key.WithKeys(","), key.WithHelp(",", "settings")),
@@ -185,6 +187,7 @@ func keybindingEntries(km *keyMap) []keybindingEntry {
 		{"pivot", &km.Pivot},
 		{"pivot_order", &km.PivotOrder},
 		{"preview", &km.Preview},
+		{"preview_fullscreen", &km.PreviewFullscreen},
 		{"reindex", &km.Reindex},
 		{"help", &km.Help},
 		{"config", &km.Config},

--- a/internal/tui/keys_test.go
+++ b/internal/tui/keys_test.go
@@ -184,9 +184,9 @@ func TestKeybindingActionNames(t *testing.T) {
 }
 
 func TestApplyKeybindingOverrides_MatchesRemappedKey(t *testing.T) {
-	km, _ := applyKeybindingOverrides(defaultKeyMap(), map[string]string{"search": "z"})
-	if !key.Matches(tea.KeyPressMsg{Code: 'z'}, km.Search) {
-		t.Error("remapped search binding should match 'z'")
+	km, _ := applyKeybindingOverrides(defaultKeyMap(), map[string]string{"search": "u"})
+	if !key.Matches(tea.KeyPressMsg{Code: 'u'}, km.Search) {
+		t.Error("remapped search binding should match 'u'")
 	}
 	if key.Matches(tea.KeyPressMsg{Code: '/'}, km.Search) {
 		t.Error("search should no longer match its old '/' key")

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -43,7 +43,12 @@ func (m *Model) recalcLayout() {
 	isHorizontal := pos == config.PreviewPositionRight || pos == config.PreviewPositionLeft
 	isVertical := pos == config.PreviewPositionTop || pos == config.PreviewPositionBottom
 
-	if m.showPreview {
+	if m.previewFullscreen {
+		previewW = m.width
+		previewH = contentH
+		listW = 0
+		listH = 0
+	} else if m.showPreview {
 		if isHorizontal && m.width >= styles.PreviewMinWidth {
 			previewW = int(float64(m.width) * styles.PreviewWidthRatio)
 			previewH = contentH

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -331,19 +331,20 @@ type Model struct {
 	spinner         spinner.Model
 
 	// UI toggles.
-	showPreview     bool
-	previewPosition string // "right", "bottom", "left", "top"
-	showHidden      bool
-	hiddenSet       map[string]struct{} // session ID → struct{} for fast hidden-session lookup
-	favoritedSet    map[string]struct{} // session ID → struct{} for fast favorited-session lookup
-	notesSet        map[string]struct{} // session ID → struct{} for fast note-existence lookup
-	tagsSet         map[string]struct{}
-	showFavorited   bool
-	activeView      string // name of the active named view (empty means Default)
-	reindexing      bool
-	reindexLog      []string                  // log lines streamed from chronicle reindex
-	reindexVP       viewport.Model            // scrollable viewport for reindex overlay
-	reindexCancel   *components.ReindexHandle // cancel handle for running reindex
+	showPreview       bool
+	previewFullscreen bool
+	previewPosition   string // "right", "bottom", "left", "top"
+	showHidden        bool
+	hiddenSet         map[string]struct{} // session ID → struct{} for fast hidden-session lookup
+	favoritedSet      map[string]struct{} // session ID → struct{} for fast favorited-session lookup
+	notesSet          map[string]struct{} // session ID → struct{} for fast note-existence lookup
+	tagsSet           map[string]struct{}
+	showFavorited     bool
+	activeView        string // name of the active named view (empty means Default)
+	reindexing        bool
+	reindexLog        []string                  // log lines streamed from chronicle reindex
+	reindexVP         viewport.Model            // scrollable viewport for reindex overlay
+	reindexCancel     *components.ReindexHandle // cancel handle for running reindex
 
 	// Focused sub-models.
 	click        clickState
@@ -1234,6 +1235,12 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.preview.ExitPlanView()
 			return m, nil
 		}
+		// Exit fullscreen preview back to the split layout.
+		if m.previewFullscreen {
+			m.previewFullscreen = false
+			m.recalcLayout()
+			return m, nil
+		}
 		// Clear active search query when Escape is pressed in the session list.
 		if m.filter.Query != "" || m.searchFilter.HasTokens() {
 			m.filter.Query = ""
@@ -1405,6 +1412,15 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case key.Matches(msg, keys.PreviewFullscreen):
+		m.previewFullscreen = !m.previewFullscreen
+		m.recalcLayout()
+		if m.previewFullscreen {
+			m.detailVersion++
+			return m, m.loadSelectedDetailCmd()
+		}
+		return m, nil
+
 	case key.Matches(msg, keys.PreviewPosition):
 		m.cyclePreviewPosition()
 		m.recalcLayout()
@@ -1419,7 +1435,7 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case key.Matches(msg, keys.PreviewScrollUp):
-		if m.showPreview {
+		if m.showPreview || m.previewFullscreen {
 			before := m.preview.ScrollOffset()
 			m.preview.PageUp()
 			slog.Debug("preview scroll up", "before", before, "after", m.preview.ScrollOffset())
@@ -1427,7 +1443,7 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case key.Matches(msg, keys.PreviewScrollDown):
-		if m.showPreview {
+		if m.showPreview || m.previewFullscreen {
 			before := m.preview.ScrollOffset()
 			m.preview.PageDown()
 			slog.Debug("preview scroll down", "before", before, "after", m.preview.ScrollOffset())
@@ -2586,6 +2602,11 @@ func (m Model) renderMainView() string {
 	// Use pre-computed layout dimensions from recalcLayout() so that
 	// rendering and hit-testing always agree on panel positions/sizes.
 	l := m.layout
+
+	// Fullscreen preview fills the entire content area; the list is hidden.
+	if m.previewFullscreen {
+		return strings.Join([]string{header, badges, sep, m.preview.View(), footer}, "\n")
+	}
 
 	var content string
 	hasPreview := l.previewWidth > 0 && l.previewHeight > 0

--- a/internal/tui/model_preview_fullscreen_test.go
+++ b/internal/tui/model_preview_fullscreen_test.go
@@ -1,0 +1,97 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// TestPreviewFullscreen_ToggleAndLayout verifies that pressing "z" enters a
+// fullscreen preview (list hidden, preview fills the content area) and that
+// pressing "z" again restores the split layout.
+func TestPreviewFullscreen_ToggleAndLayout(t *testing.T) {
+	m := newTestModelWithSize(120, 40)
+	m.showPreview = true
+	m.recalcLayout()
+
+	if m.previewFullscreen {
+		t.Fatal("expected previewFullscreen false initially")
+	}
+
+	res, _ := m.Update(tea.KeyPressMsg{Code: 'z', Text: "z"})
+	rm := res.(Model)
+	if !rm.previewFullscreen {
+		t.Fatal("pressing z should enable fullscreen preview")
+	}
+	if rm.layout.previewWidth != rm.width {
+		t.Errorf("fullscreen preview width = %d, want %d", rm.layout.previewWidth, rm.width)
+	}
+	if rm.layout.listWidth != 0 {
+		t.Errorf("fullscreen list width = %d, want 0", rm.layout.listWidth)
+	}
+	if rm.layout.previewHeight != rm.layout.contentHeight {
+		t.Errorf("fullscreen preview height = %d, want content height %d", rm.layout.previewHeight, rm.layout.contentHeight)
+	}
+
+	res2, _ := rm.Update(tea.KeyPressMsg{Code: 'z', Text: "z"})
+	rm2 := res2.(Model)
+	if rm2.previewFullscreen {
+		t.Fatal("pressing z again should disable fullscreen preview")
+	}
+	if rm2.layout.listWidth == 0 {
+		t.Error("exiting fullscreen should restore the session list width")
+	}
+}
+
+// TestPreviewFullscreen_EscapeExits verifies that Escape leaves fullscreen and
+// restores the split layout.
+func TestPreviewFullscreen_EscapeExits(t *testing.T) {
+	m := newTestModelWithSize(120, 40)
+	m.showPreview = true
+	m.recalcLayout()
+
+	res, _ := m.Update(tea.KeyPressMsg{Code: 'z', Text: "z"})
+	rm := res.(Model)
+	if !rm.previewFullscreen {
+		t.Fatal("expected fullscreen after z")
+	}
+
+	res2, _ := rm.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	rm2 := res2.(Model)
+	if rm2.previewFullscreen {
+		t.Error("esc should exit fullscreen preview")
+	}
+	if rm2.layout.previewWidth == rm2.width {
+		t.Error("esc should restore the split layout (preview no longer full width)")
+	}
+}
+
+// TestPreviewFullscreen_WorksWithPreviewOff verifies that fullscreen can be
+// entered even when the split preview is toggled off, that paging does not exit
+// fullscreen, and that the view renders non-empty content.
+func TestPreviewFullscreen_WorksWithPreviewOff(t *testing.T) {
+	m := newTestModelWithSize(120, 40)
+	m.showPreview = false
+	m.recalcLayout()
+
+	res, _ := m.Update(tea.KeyPressMsg{Code: 'z', Text: "z"})
+	rm := res.(Model)
+	if !rm.previewFullscreen {
+		t.Fatal("expected fullscreen after z even with preview toggled off")
+	}
+	if rm.layout.previewWidth != rm.width {
+		t.Errorf("fullscreen preview width = %d, want %d", rm.layout.previewWidth, rm.width)
+	}
+
+	res2, _ := rm.Update(tea.KeyPressMsg{Code: tea.KeyPgDown})
+	rm2 := res2.(Model)
+	if !rm2.previewFullscreen {
+		t.Error("paging should not exit fullscreen preview")
+	}
+
+	out := rm2.renderMainView()
+	if strings.TrimSpace(out) == "" {
+		t.Error("fullscreen view should render non-empty content")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a fullscreen preview mode to the session list. Press `z` to expand the preview so it fills the entire content area and hides the session list, which makes reading a long conversation, plan, or file list much easier. Press `z` again or `Esc` to return to the split layout.

This addresses #233.

## What changed

- New `z` keybinding (`PreviewFullscreen`) that toggles fullscreen preview from the session list.
- `recalcLayout` gives the preview the full content width and height and collapses the list to zero when fullscreen is active.
- `renderMainView` renders only the preview in fullscreen so the list is fully hidden.
- `Esc` exits fullscreen first and restores the previous split layout.
- Paging with `PgUp` / `PgDn` works in fullscreen, and turning fullscreen on shows the preview even when the split preview was toggled off.
- Help bar, README, and keybindings doc updated.

## Behavior

```mermaid
stateDiagram-v2
    [*] --> Split
    Split --> Fullscreen: press z
    Fullscreen --> Split: press z
    Fullscreen --> Split: press Esc
    Fullscreen --> Fullscreen: PgUp / PgDn scroll
```

## Testing

- `go build ./...`
- `go vet ./...`
- `golangci-lint run ./...` (0 issues)
- `go test ./... -count=1` (all packages pass)
- New tests in `internal/tui/model_preview_fullscreen_test.go` cover entering and exiting via `z`, exiting via `Esc`, layout dimensions in fullscreen, and paging while fullscreen with the split preview off.

Requested by Jon Gallant.
