### PR TITLE
Configurable session-list columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Dispatch reads your local Copilot CLI session store and presents every past sess
 - **Session favorites** (`*`) — star sessions as favorites. Filter to show only favorites via the `!` status picker
 - **Session tags** (`g`) — attach comma-separated tags to sessions and filter to a tag with the `tag:` search token
 - **Session aliases** (`A`) — give a session a short, memorable alias and resume it from the CLI with `dispatch open <alias>` instead of the full session ID
-- **Settings panel** (`,`) — 15 fields: Yolo Mode, Agent, Model, Launch Mode, Pane Direction, Terminal, Shell, Custom Command, Theme, Crash Recovery, Preview Position, Redact Secrets, Excluded Words, Auto Refresh, Notify On Waiting
+- **Settings panel** (`,`) — 19 fields: Yolo Mode, Agent, Model, Launch Mode, Pane Direction, Terminal, Shell, Custom Command, Theme, Crash Recovery, Preview Position, Redact Secrets, Excluded Words, Auto Refresh, Notify On Waiting, and column toggles for Repo, Folder, Turns, and Host
+- **Configurable list columns** (`,` settings) — choose which optional columns (repo, folder, turns, host) appear in the session list. Defaults show every column, and the session name and attention indicator are always visible
 - **Shell picker** — auto-detects installed shells, modal picker when multiple available
 - **5 built-in themes** — Dispatch Dark, Dispatch Light, Campbell, One Half Dark, One Half Light + custom via Windows Terminal JSON
 - **Help overlay** (`?`) — two-column grouped keyboard shortcuts
@@ -318,6 +319,7 @@ Configuration is stored in the platform-specific config directory:
 | `keybindings` | object | `{}` | Remap keyboard shortcuts. Keys are action names, values are comma-separated key lists (see [Customizing Keybindings](#customizing-keybindings)) |
 | `sessionTags` | object | `{}` | Map of session ID to a list of user-defined tags |
 | `sessionAliases` | object | `{}` | Map of session ID to a unique short alias for `dispatch open <alias>` |
+| `hidden_columns` | array | `[]` | Optional session-list columns to hide (`repo`, `folder`, `turns`, `host`); empty shows all |
 
 #### Pane Direction Semantics
 

--- a/internal/config/column_visibility_test.go
+++ b/internal/config/column_visibility_test.go
@@ -1,0 +1,26 @@
+package config
+
+import "testing"
+
+func TestColumnVisible(t *testing.T) {
+	c := &Config{}
+	for _, key := range ToggleableColumns {
+		if !c.ColumnVisible(key) {
+			t.Errorf("empty HiddenColumns: column %q should be visible", key)
+		}
+	}
+
+	c.HiddenColumns = []string{ColumnRepo, ColumnTurns}
+	if c.ColumnVisible(ColumnRepo) {
+		t.Error("repo column should be hidden")
+	}
+	if c.ColumnVisible(ColumnTurns) {
+		t.Error("turns column should be hidden")
+	}
+	if !c.ColumnVisible(ColumnFolder) {
+		t.Error("folder column should remain visible")
+	}
+	if !c.ColumnVisible(ColumnHost) {
+		t.Error("host column should remain visible")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -216,6 +216,11 @@ type Config struct {
 	// Aliases are unique and let "dispatch open <alias>" resume a session
 	// without typing the full ID.
 	SessionAliases map[string]string `json:"sessionAliases,omitempty"`
+	// HiddenColumns lists optional session-list columns the user has chosen
+	// to hide (for example "repo", "folder", "turns", "host"). When empty
+	// (the default), every column is shown. The session name and attention
+	// indicator are always visible and cannot be hidden.
+	HiddenColumns []string `json:"hidden_columns,omitempty"`
 
 	// AISearch enables Copilot SDK-powered AI search. When false (the
 	// default), only the local FTS5 index is used.  Set to true to also
@@ -482,6 +487,32 @@ func (c *Config) EffectiveLaunchMode() string {
 		return LaunchModeInPlace
 	}
 	return LaunchModeTab
+}
+
+// Session-list column keys used by HiddenColumns to control which optional
+// columns appear in the session list.
+const (
+	ColumnRepo   = "repo"
+	ColumnFolder = "folder"
+	ColumnTurns  = "turns"
+	ColumnHost   = "host"
+)
+
+// ToggleableColumns lists the optional session-list columns that can be
+// shown or hidden. The session name and attention indicator are always
+// shown and are not included here.
+var ToggleableColumns = []string{ColumnRepo, ColumnFolder, ColumnTurns, ColumnHost}
+
+// ColumnVisible reports whether the given session-list column should be
+// shown. A column is visible unless its key is present in HiddenColumns, so
+// the default (empty HiddenColumns) shows every column.
+func (c *Config) ColumnVisible(key string) bool {
+	for _, h := range c.HiddenColumns {
+		if h == key {
+			return false
+		}
+	}
+	return true
 }
 
 // Default returns a Config populated with sensible default values.

--- a/internal/tui/components/configpanel.go
+++ b/internal/tui/components/configpanel.go
@@ -35,6 +35,10 @@ const (
 	cfgExcludedWords
 	cfgAutoRefresh
 	cfgNotifyOnWaiting
+	cfgColRepo
+	cfgColFolder
+	cfgColTurns
+	cfgColHost
 	cfgFieldCount
 )
 
@@ -60,6 +64,10 @@ type ConfigPanel struct {
 	excludedWords     string // comma-separated list of filter words
 	autoRefresh       string // session-list auto-refresh seconds ("" default, "0" off)
 	notifyOnWaiting   bool
+	colRepo           bool // show the repository column in the session list
+	colFolder         bool // show the folder column in the session list
+	colTurns          bool // show the turn-count column in the session list
+	colHost           bool // show the host indicator in the session list
 
 	// Available options for cycling.
 	terminals  []string
@@ -107,6 +115,10 @@ type ConfigValues struct {
 	ExcludedWords     string // comma-separated filter words
 	AutoRefresh       string // auto-refresh seconds ("" default, "0" off)
 	NotifyOnWaiting   bool
+	ShowRepoColumn    bool
+	ShowFolderColumn  bool
+	ShowTurnsColumn   bool
+	ShowHostColumn    bool
 }
 
 // SetValues loads the config panel state from external values.
@@ -126,6 +138,10 @@ func (c *ConfigPanel) SetValues(v ConfigValues) {
 	c.excludedWords = v.ExcludedWords
 	c.autoRefresh = v.AutoRefresh
 	c.notifyOnWaiting = v.NotifyOnWaiting
+	c.colRepo = v.ShowRepoColumn
+	c.colFolder = v.ShowFolderColumn
+	c.colTurns = v.ShowTurnsColumn
+	c.colHost = v.ShowHostColumn
 }
 
 // Values returns the current state of all editable fields.
@@ -146,6 +162,10 @@ func (c *ConfigPanel) Values() ConfigValues {
 		ExcludedWords:     c.excludedWords,
 		AutoRefresh:       c.autoRefresh,
 		NotifyOnWaiting:   c.notifyOnWaiting,
+		ShowRepoColumn:    c.colRepo,
+		ShowFolderColumn:  c.colFolder,
+		ShowTurnsColumn:   c.colTurns,
+		ShowHostColumn:    c.colHost,
 	}
 }
 
@@ -250,6 +270,14 @@ func (c *ConfigPanel) HandleEnter() tea.Cmd {
 		c.redactSecrets = !c.redactSecrets
 	case cfgNotifyOnWaiting:
 		c.notifyOnWaiting = !c.notifyOnWaiting
+	case cfgColRepo:
+		c.colRepo = !c.colRepo
+	case cfgColFolder:
+		c.colFolder = !c.colFolder
+	case cfgColTurns:
+		c.colTurns = !c.colTurns
+	case cfgColHost:
+		c.colHost = !c.colHost
 	default:
 		// cfgFieldCount is a sentinel; no action needed.
 	}
@@ -330,6 +358,10 @@ func (c ConfigPanel) View() string {
 		{"Excluded Words", stringDisplay(c.excludedWords), false},
 		{"Auto Refresh", autoRefreshDisplay(c.autoRefresh), false},
 		{"Notify On Waiting", boolDisplay(c.notifyOnWaiting), false},
+		{"Column: Repo", boolDisplay(c.colRepo), false},
+		{"Column: Folder", boolDisplay(c.colFolder), false},
+		{"Column: Turns", boolDisplay(c.colTurns), false},
+		{"Column: Host", boolDisplay(c.colHost), false},
 	}
 
 	var body strings.Builder

--- a/internal/tui/components/sessionlist.go
+++ b/internal/tui/components/sessionlist.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+	"github.com/jongio/dispatch/internal/config"
 	"github.com/jongio/dispatch/internal/data"
 	"github.com/jongio/dispatch/internal/platform"
 	"github.com/jongio/dispatch/internal/tui/styles"
@@ -40,6 +41,7 @@ type SessionList struct {
 	gitStateMap    map[string]platform.GitState     // session ID → git workspace state
 	notesSet       map[string]struct{}              // session ID → has a user note
 	tagsSet        map[string]struct{}              // session ID → has tags
+	hiddenColumns  map[string]bool                  // optional column key → hidden
 	selected       map[string]struct{}              // session ID → selected for multi-open
 	treeMode       bool                             // true when showing grouped/tree view
 	pivotField     string                           // current pivot mode (e.g. "folder", "repo")
@@ -135,6 +137,25 @@ func (s *SessionList) SetNoteSessions(set map[string]struct{}) {
 // used to render those sessions with a tag marker.
 func (s *SessionList) SetTagSessions(set map[string]struct{}) {
 	s.tagsSet = set
+}
+
+// SetHiddenColumns records which optional session-list columns should be
+// hidden. An empty or nil slice shows every column.
+func (s *SessionList) SetHiddenColumns(keys []string) {
+	if len(keys) == 0 {
+		s.hiddenColumns = nil
+		return
+	}
+	hs := make(map[string]bool, len(keys))
+	for _, k := range keys {
+		hs[k] = true
+	}
+	s.hiddenColumns = hs
+}
+
+// columnHidden reports whether the given optional column key is hidden.
+func (s SessionList) columnHidden(key string) bool {
+	return s.hiddenColumns[key]
 }
 
 // SetAISessions updates the set of AI-found session IDs, used to
@@ -786,11 +807,15 @@ func (s SessionList) renderSessionRow(sess data.Session, selected bool, hidden b
 	// Status dots — each is a fixed 2 chars (icon + space) for alignment.
 	attDot := s.attentionDot(sess.ID, selected)
 
+	showHost := !s.columnHidden(config.ColumnHost)
 	hostDot := styles.IconHostType(sess.HostType)
 	if hostDot != "" {
 		hostDot += " "
 	} else {
 		hostDot = "  "
+	}
+	if !showHost {
+		hostDot = ""
 	}
 
 	plnDot := s.planDot(sess.ID, selected)
@@ -808,15 +833,23 @@ func (s SessionList) renderSessionRow(sess data.Session, selected bool, hidden b
 
 	const selectorW = 2
 	const dotW = 2     // attention dot + space
-	const hostDotW = 2 // host icon + space (always reserved)
 	const planDotW = 2 // plan dot + space
 	const noteDotW = 2 // note dot + space
 	const tagDotW = 2  // tag dot + space
 	const wrkDotW = 2  // work status dot + space
 	const gitDotW = 2  // git state dot + space
 	const timeW = 9
-	const turnsW = 5
 	const spacing = 2
+
+	hostDotW := 2 // host icon + space
+	if !showHost {
+		hostDotW = 0
+	}
+	showTurns := !s.columnHidden(config.ColumnTurns)
+	turnsW := 5
+	if !showTurns {
+		turnsW = 0
+	}
 
 	// Very narrow terminal: summary + time only.
 	if w < 50 {
@@ -825,16 +858,27 @@ func (s SessionList) renderSessionRow(sess data.Session, selected bool, hidden b
 		return s.applyRowStyle(line, selected, hidden, favorited)
 	}
 
-	// Show folder/repo columns at wider terminals.
+	// Show folder/repo columns at wider terminals, honouring column visibility.
+	showFolder := !s.columnHidden(config.ColumnFolder)
+	showRepo := !s.columnHidden(config.ColumnRepo)
 	var folderW, repoW int
 	if w >= 120 {
-		folderW = 22
-		repoW = 18
+		if showFolder {
+			folderW = 22
+		}
+		if showRepo {
+			repoW = 18
+		}
 	} else if w >= 90 {
-		folderW = 18
+		if showFolder {
+			folderW = 18
+		}
 	}
 
-	summaryW := w - selectorW - dotW - hostDotW - planDotW - noteDotW - tagDotW - wrkDotW - gitDotW - timeW - turnsW - 2*spacing
+	summaryW := w - selectorW - dotW - hostDotW - planDotW - noteDotW - tagDotW - wrkDotW - gitDotW - timeW - spacing
+	if showTurns {
+		summaryW -= turnsW + spacing
+	}
 	if folderW > 0 {
 		summaryW -= folderW + spacing
 	}
@@ -870,8 +914,10 @@ func (s SessionList) renderSessionRow(sess data.Session, selected bool, hidden b
 	}
 	b.WriteString("  ")
 	b.WriteString(PadLeft(relTime, timeW))
-	b.WriteString("  ")
-	b.WriteString(PadLeft(turns, turnsW))
+	if showTurns {
+		b.WriteString("  ")
+		b.WriteString(PadLeft(turns, turnsW))
+	}
 
 	return s.applyRowStyle(b.String(), selected, hidden, favorited)
 }

--- a/internal/tui/components/sessionlist_columns_test.go
+++ b/internal/tui/components/sessionlist_columns_test.go
@@ -1,0 +1,82 @@
+package components
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jongio/dispatch/internal/config"
+	"github.com/jongio/dispatch/internal/data"
+)
+
+func columnTestSession() data.Session {
+	return data.Session{
+		ID:           "sess-colcheck",
+		Cwd:          `D:\code\projectZ`,
+		Repository:   "octo/repo-xyz",
+		Summary:      "ColumnVisibilityFixture",
+		UpdatedAt:    "2025-01-15T10:00:00Z",
+		LastActiveAt: "2025-01-15T10:00:00Z",
+		TurnCount:    7,
+	}
+}
+
+func renderColumnRow(t *testing.T, hidden []string) string {
+	t.Helper()
+	sl := NewSessionList()
+	sl.SetSessions([]data.Session{columnTestSession()})
+	sl.SetSize(120, 10)
+	sl.SetHiddenColumns(hidden)
+	return sl.View()
+}
+
+func TestSessionList_Columns_DefaultShowsAll(t *testing.T) {
+	out := renderColumnRow(t, nil)
+	if !strings.Contains(out, "ColumnVisibilityFixture") {
+		t.Fatal("summary (session name) should always be shown")
+	}
+	if !strings.Contains(out, "octo/repo-xyz") {
+		t.Error("repo column should be shown by default")
+	}
+	if !strings.Contains(out, "7t") {
+		t.Error("turns column should be shown by default")
+	}
+	if !strings.Contains(out, "projectZ") {
+		t.Error("folder column should be shown by default")
+	}
+}
+
+func TestSessionList_Columns_HideRepo(t *testing.T) {
+	out := renderColumnRow(t, []string{config.ColumnRepo})
+	if strings.Contains(out, "octo/repo-xyz") {
+		t.Error("repo column should be hidden")
+	}
+	if !strings.Contains(out, "ColumnVisibilityFixture") {
+		t.Error("summary should remain visible after hiding repo")
+	}
+	if !strings.Contains(out, "7t") {
+		t.Error("turns column should remain visible after hiding repo")
+	}
+}
+
+func TestSessionList_Columns_HideTurns(t *testing.T) {
+	out := renderColumnRow(t, []string{config.ColumnTurns})
+	if strings.Contains(out, "7t") {
+		t.Error("turns column should be hidden")
+	}
+	if !strings.Contains(out, "ColumnVisibilityFixture") {
+		t.Error("summary should remain visible after hiding turns")
+	}
+	if !strings.Contains(out, "octo/repo-xyz") {
+		t.Error("repo column should remain visible after hiding turns")
+	}
+}
+
+func TestSessionList_Columns_HideFolder(t *testing.T) {
+	out := renderColumnRow(t, []string{config.ColumnFolder})
+	if strings.Contains(out, "projectZ") {
+		t.Error("folder column should be hidden")
+	}
+	if !strings.Contains(out, "ColumnVisibilityFixture") {
+		t.Error("summary should remain visible after hiding folder")
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -436,6 +436,10 @@ func NewModel() Model {
 		ExcludedWords:     strings.Join(cfg.ExcludedWords, ", "),
 		AutoRefresh:       autoRefreshFieldValue(cfg.AutoRefreshSeconds),
 		NotifyOnWaiting:   cfg.NotifyOnWaiting,
+		ShowRepoColumn:    cfg.ColumnVisible(config.ColumnRepo),
+		ShowFolderColumn:  cfg.ColumnVisible(config.ColumnFolder),
+		ShowTurnsColumn:   cfg.ColumnVisible(config.ColumnTurns),
+		ShowHostColumn:    cfg.ColumnVisible(config.ColumnHost),
 	})
 
 	// Build the list of available theme names for the config panel.
@@ -524,6 +528,7 @@ func NewModel() Model {
 	m.filter.ExcludedDirs = cfg.ExcludedDirs
 	m.filter.ExcludedWords = cfg.ExcludedWords
 	m.preview.SetConversationSort(cfg.ConversationNewestFirst)
+	m.sessionList.SetHiddenColumns(cfg.HiddenColumns)
 	m.preview.SetRedactSecrets(cfg.RedactPreviewSecrets)
 
 	// Named views: populate picker and apply the persisted active view.
@@ -1285,6 +1290,10 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			ExcludedWords:     strings.Join(m.cfg.ExcludedWords, ", "),
 			AutoRefresh:       autoRefreshFieldValue(m.cfg.AutoRefreshSeconds),
 			NotifyOnWaiting:   m.cfg.NotifyOnWaiting,
+			ShowRepoColumn:    m.cfg.ColumnVisible(config.ColumnRepo),
+			ShowFolderColumn:  m.cfg.ColumnVisible(config.ColumnFolder),
+			ShowTurnsColumn:   m.cfg.ColumnVisible(config.ColumnTurns),
+			ShowHostColumn:    m.cfg.ColumnVisible(config.ColumnHost),
 		})
 		m.state = stateConfigPanel
 		return m, nil
@@ -2104,6 +2113,8 @@ func (m *Model) saveConfigFromPanel() {
 	m.filter.ExcludedWords = m.cfg.ExcludedWords
 	m.cfg.AutoRefreshSeconds = parseAutoRefresh(v.AutoRefresh)
 	m.cfg.NotifyOnWaiting = v.NotifyOnWaiting
+	m.cfg.HiddenColumns = hiddenColumnsFromPanel(v)
+	m.sessionList.SetHiddenColumns(m.cfg.HiddenColumns)
 	resolveTheme(m.cfg)
 	// If the user switched back to "auto", re-apply with the detected
 	// terminal brightness so colours adapt immediately.
@@ -2115,6 +2126,26 @@ func (m *Model) saveConfigFromPanel() {
 	if err := config.Save(m.cfg); err != nil {
 		m.statusErr = "config save: " + err.Error()
 	}
+}
+
+// hiddenColumnsFromPanel builds the config's HiddenColumns list from the
+// settings panel's per-column visibility flags. Only disabled columns are
+// recorded, so the default (all columns shown) is an empty list.
+func hiddenColumnsFromPanel(v components.ConfigValues) []string {
+	var hidden []string
+	if !v.ShowRepoColumn {
+		hidden = append(hidden, config.ColumnRepo)
+	}
+	if !v.ShowFolderColumn {
+		hidden = append(hidden, config.ColumnFolder)
+	}
+	if !v.ShowTurnsColumn {
+		hidden = append(hidden, config.ColumnTurns)
+	}
+	if !v.ShowHostColumn {
+		hidden = append(hidden, config.ColumnHost)
+	}
+	return hidden
 }
 
 // parseExcludedWords splits a comma-separated string into trimmed, non-empty words.


### PR DESCRIPTION
## Summary

Adds configurable session-list columns. The set of columns shown per session row was fixed, which crowds narrow terminals and shows fields some people never read. This adds toggles in the settings panel (`,`) so you can choose which optional columns appear: repository, folder, turn count, and host.

Defaults show every column, so existing setups look identical. The session name and attention indicator are always visible so rows stay usable.

This addresses #234.

## What changed

- New `HiddenColumns` config field (persisted in `config.json` as `hidden_columns`). Empty means every column is shown, matching the existing `hiddenSessions` pattern so defaults are unambiguous.
- `config.ColumnVisible` helper plus column-key constants (`repo`, `folder`, `turns`, `host`).
- Settings panel gains four toggles: Column: Repo, Folder, Turns, Host.
- The session row renderer skips hidden columns and reflows the remaining ones to reclaim the freed width.
- Column visibility is applied on startup and whenever settings are saved.
- README config table and settings-panel description updated.

## Flow

```mermaid
flowchart TD
  A[Settings panel] --> B[Column toggles]
  B --> C[config.json hidden_columns]
  C --> D[Session list renderer]
  D --> E{Column visible?}
  E -- yes --> F[Render and reflow]
  E -- no --> G[Skip and reclaim width]
```

## Testing

- `go build ./...`
- `go vet ./...`
- `golangci-lint run ./...` (0 issues)
- `go test ./... -count=1` (all packages pass)
- New tests: `internal/config/column_visibility_test.go` covers `ColumnVisible`, and `internal/tui/components/sessionlist_columns_test.go` covers rendering with each column shown and hidden while the session name stays visible.

Requested by Jon Gallant.
