### PR TITLE
feat(open): add --print to output resume command without launching

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ Both accept `--mode` to override the launch mode for that one resume (`inplace`,
 dispatch open --last --mode window
 ```
 
+Use `--print` to write the resume command to stdout instead of launching it. This is handy for scripting, dry runs, or piping the command elsewhere:
+
+```sh
+dispatch open <session-id> --print
+```
+
 ### Start a New Session
 
 Start a brand-new Copilot session from the command line without opening the TUI:
@@ -167,6 +173,7 @@ dispatch new --mode tab   # override the launch mode (inplace, tab, window, pane
 ```
 
 The session uses the same agent, model, and launch settings as the TUI. When no directory is given, the current working directory is used.
+
 
 ### Shell Completion
 

--- a/cmd/dispatch/main.go
+++ b/cmd/dispatch/main.go
@@ -92,6 +92,7 @@ Commands:
   help                    Show this help message
   version                 Print the version
   open <id> [--mode M]    Resume a session by ID (M: inplace, tab, window, pane)
+                          --print writes the resume command instead of launching
   open --last [--mode M]  Resume the most recently active session
   new [dir] [--mode M]    Start a new session in a directory (default: current)
   completion <shell>      Print shell completion (bash, zsh, powershell)

--- a/cmd/dispatch/open.go
+++ b/cmd/dispatch/open.go
@@ -21,17 +21,19 @@ var (
 	openGetSessionFn     = defaultOpenGetSession
 	openGetLastSessionFn = defaultOpenGetLastSession
 	openLaunchFn         = defaultOpenLaunch
+	openResumeCmdFn      = platform.BuildResumeCommandString
 )
 
 // runOpen resumes a session using the same launch path the TUI uses. It
 // resumes the session named by ID, or the most recently active session when
-// --last is passed. args is the full argument slice with args[0] == "open".
+// --last is passed. With --print it writes the resolved resume command to w
+// and does not launch. args is the full argument slice with args[0] == "open".
 func runOpen(w io.Writer, args []string) error {
 	if w == nil {
 		w = io.Discard
 	}
 
-	id, modeFlag, last, err := parseOpenArgs(args)
+	id, modeFlag, last, printCmd, err := parseOpenArgs(args)
 	if err != nil {
 		return err
 	}
@@ -40,8 +42,6 @@ func runOpen(w io.Writer, args []string) error {
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
 	}
-
-	mode := resolveOpenMode(modeFlag, cfg)
 
 	var sess *data.Session
 	if last {
@@ -67,12 +67,36 @@ func runOpen(w io.Writer, args []string) error {
 		}
 	}
 
+	if printCmd {
+		cmdStr, err := openResumeCmdFn(sess.ID, openResumeConfig(cfg, sess))
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(w, cmdStr)
+		return nil
+	}
+
+	mode := resolveOpenMode(modeFlag, cfg)
 	return openLaunchFn(w, cfg, sess, mode)
 }
 
-// parseOpenArgs extracts the session ID, optional launch mode, and the --last
-// flag from the "open" subcommand arguments. args[0] is expected to be "open".
-func parseOpenArgs(args []string) (id, mode string, last bool, err error) {
+// openResumeConfig builds the resume config used to launch or print a
+// session's resume command. Terminal, launch style, and pane direction are
+// omitted because they affect terminal placement, not the copilot invocation.
+func openResumeConfig(cfg *config.Config, sess *data.Session) platform.ResumeConfig {
+	return platform.ResumeConfig{
+		YoloMode:      cfg.YoloMode,
+		Agent:         cfg.Agent,
+		Model:         cfg.Model,
+		CustomCommand: cfg.CustomCommand,
+		Cwd:           sess.Cwd,
+	}
+}
+
+// parseOpenArgs extracts the session ID, optional launch mode, the --last
+// flag, and the --print flag from the "open" subcommand arguments. args[0] is
+// expected to be "open".
+func parseOpenArgs(args []string) (id, mode string, last, printCmd bool, err error) {
 	rest := args
 	if len(rest) > 0 {
 		rest = rest[1:] // drop the "open" token
@@ -86,14 +110,16 @@ func parseOpenArgs(args []string) (id, mode string, last bool, err error) {
 			last = true
 		case arg == "--mode" || arg == "-m":
 			if i+1 >= len(rest) {
-				return "", "", false, errors.New("--mode requires a value: inplace, tab, window, or pane")
+				return "", "", false, false, errors.New("--mode requires a value: inplace, tab, window, or pane")
 			}
 			mode = rest[i+1]
 			i++
 		case strings.HasPrefix(arg, "--mode="):
 			mode = strings.TrimPrefix(arg, "--mode=")
+		case arg == "--print":
+			printCmd = true
 		case strings.HasPrefix(arg, "-"):
-			return "", "", false, fmt.Errorf("unknown flag: %s", arg)
+			return "", "", false, false, fmt.Errorf("unknown flag: %s", arg)
 		default:
 			positionals = append(positionals, arg)
 		}
@@ -101,25 +127,25 @@ func parseOpenArgs(args []string) (id, mode string, last bool, err error) {
 
 	if last {
 		if len(positionals) > 0 {
-			return "", "", false, errors.New("open --last does not take a session ID")
+			return "", "", false, false, errors.New("open --last does not take a session ID")
 		}
 	} else {
 		switch len(positionals) {
 		case 0:
-			return "", "", false, errors.New("open requires a session ID (or use --last)")
+			return "", "", false, false, errors.New("open requires a session ID (or use --last)")
 		case 1:
 			id = positionals[0]
 		default:
-			return "", "", false, fmt.Errorf("open accepts a single session ID, got %d arguments", len(positionals))
+			return "", "", false, false, fmt.Errorf("open accepts a single session ID, got %d arguments", len(positionals))
 		}
 	}
 
 	if mode != "" {
 		if _, mErr := normalizeLaunchMode(mode); mErr != nil {
-			return "", "", false, mErr
+			return "", "", false, false, mErr
 		}
 	}
-	return id, mode, last, nil
+	return id, mode, last, printCmd, nil
 }
 
 // normalizeLaunchMode maps a user-facing mode string to a config launch mode.
@@ -198,14 +224,7 @@ func defaultOpenGetLastSession() (*data.Session, error) {
 // launcher, matching the behavior of launching from the TUI.
 func defaultOpenLaunch(w io.Writer, cfg *config.Config, sess *data.Session, mode string) error {
 	if mode == config.LaunchModeInPlace {
-		rc := platform.ResumeConfig{
-			YoloMode:      cfg.YoloMode,
-			Agent:         cfg.Agent,
-			Model:         cfg.Model,
-			CustomCommand: cfg.CustomCommand,
-			Cwd:           sess.Cwd,
-		}
-		cmd, err := platform.NewResumeCmd(sess.ID, rc)
+		cmd, err := platform.NewResumeCmd(sess.ID, openResumeConfig(cfg, sess))
 		if err != nil {
 			return err
 		}

--- a/cmd/dispatch/open_test.go
+++ b/cmd/dispatch/open_test.go
@@ -1,23 +1,27 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/jongio/dispatch/internal/config"
 	"github.com/jongio/dispatch/internal/data"
+	"github.com/jongio/dispatch/internal/platform"
 	"github.com/jongio/dispatch/internal/update"
 )
 
 func TestParseOpenArgs(t *testing.T) {
 	tests := []struct {
-		name     string
-		args     []string
-		wantID   string
-		wantMode string
-		wantLast bool
-		wantErr  bool
+		name      string
+		args      []string
+		wantID    string
+		wantMode  string
+		wantLast  bool
+		wantPrint bool
+		wantErr   bool
 	}{
 		{name: "id only", args: []string{"open", "abc123"}, wantID: "abc123"},
 		{name: "mode space", args: []string{"open", "abc", "--mode", "window"}, wantID: "abc", wantMode: "window"},
@@ -27,6 +31,9 @@ func TestParseOpenArgs(t *testing.T) {
 		{name: "last", args: []string{"open", "--last"}, wantLast: true},
 		{name: "last short", args: []string{"open", "-l"}, wantLast: true},
 		{name: "last with mode", args: []string{"open", "--last", "--mode", "window"}, wantLast: true, wantMode: "window"},
+		{name: "print flag", args: []string{"open", "abc", "--print"}, wantID: "abc", wantPrint: true},
+		{name: "print before id", args: []string{"open", "--print", "abc"}, wantID: "abc", wantPrint: true},
+		{name: "print with mode", args: []string{"open", "abc", "--print", "--mode", "tab"}, wantID: "abc", wantMode: "tab", wantPrint: true},
 		{name: "missing id", args: []string{"open"}, wantErr: true},
 		{name: "missing id with mode", args: []string{"open", "--mode", "tab"}, wantErr: true},
 		{name: "two ids", args: []string{"open", "a", "b"}, wantErr: true},
@@ -37,7 +44,7 @@ func TestParseOpenArgs(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			id, mode, last, err := parseOpenArgs(tc.args)
+			id, mode, last, printCmd, err := parseOpenArgs(tc.args)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got id=%q mode=%q last=%v", id, mode, last)
@@ -55,6 +62,9 @@ func TestParseOpenArgs(t *testing.T) {
 			}
 			if last != tc.wantLast {
 				t.Errorf("last = %v, want %v", last, tc.wantLast)
+			}
+			if printCmd != tc.wantPrint {
+				t.Errorf("print = %v, want %v", printCmd, tc.wantPrint)
 			}
 		})
 	}
@@ -185,6 +195,43 @@ func TestRunOpen_UnknownAliasFallsBackToID(t *testing.T) {
 	}
 	if capture.gotID != "raw-id" {
 		t.Errorf("id = %q, want raw-id (fallback)", capture.gotID)
+	}
+}
+
+func TestRunOpen_Print(t *testing.T) {
+	cfg := config.Default()
+	sess := &data.Session{ID: "sess-1", Cwd: "/tmp/project"}
+	capture := withOpenStubs(t, cfg, sess, nil)
+
+	origResume := openResumeCmdFn
+	openResumeCmdFn = func(id string, _ platform.ResumeConfig) (string, error) {
+		return "copilot --resume " + id, nil
+	}
+	t.Cleanup(func() { openResumeCmdFn = origResume })
+
+	var buf bytes.Buffer
+	if err := runOpen(&buf, []string{"open", "sess-1", "--print"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capture.launched {
+		t.Error("expected --print to skip launching")
+	}
+	if got := strings.TrimSpace(buf.String()); got != "copilot --resume sess-1" {
+		t.Errorf("output = %q, want %q", got, "copilot --resume sess-1")
+	}
+}
+
+func TestRunOpen_PrintError(t *testing.T) {
+	withOpenStubs(t, config.Default(), &data.Session{ID: "s"}, nil)
+
+	origResume := openResumeCmdFn
+	openResumeCmdFn = func(string, platform.ResumeConfig) (string, error) {
+		return "", errors.New("no cli")
+	}
+	t.Cleanup(func() { openResumeCmdFn = origResume })
+
+	if err := runOpen(io.Discard, []string{"open", "s", "--print"}); err == nil {
+		t.Fatal("expected resume command error to propagate")
 	}
 }
 


### PR DESCRIPTION
## What
Adds a `--print` flag to `dispatch open` that writes the session's resume command to stdout instead of launching it.

## Why
There is no way to get the exact resume command for a session from a script without launching Copilot CLI. `--print` gives you the command so you can dry-run, log it, or pipe it into another tool.

## How
- `parseOpenArgs` now recognizes `--print` alongside `--mode`.
- When set, `runOpen` resolves the session and calls the same resume-command builder the TUI copy-resume path uses, then prints the result and returns without launching.
- Extracted a small `openResumeConfig` helper so the in-place launch path and the print path build the resume config the same way.

## Testing
- `go build ./...`
- `go test ./... -count=1`
- `go vet ./...`
- `golangci-lint run`
- Added parse cases for `--print` (before/after id, combined with `--mode`) and `runOpen` tests covering the print output and error propagation.

Closes #242