### PR TITLE
feat(completion): add fish shell completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Print completion scripts for supported shells:
 ```sh
 dispatch completion bash
 dispatch completion zsh
+dispatch completion fish
 dispatch completion powershell
 ```
 

--- a/cmd/dispatch/cli.go
+++ b/cmd/dispatch/cli.go
@@ -68,7 +68,7 @@ func handleArgs(args []string, origStderr io.Writer, updateCh <-chan *update.Upd
 
 		case "completion":
 			if len(args) < 2 {
-				err := errors.New("completion requires a shell: bash, zsh, or powershell")
+				err := errors.New("completion requires a shell: bash, zsh, fish, or powershell")
 				fmt.Fprintf(os.Stderr, "completion: %v\n", err)
 				return true, cleanup, "", err
 			}
@@ -191,10 +191,12 @@ func runCompletion(w io.Writer, shell string) error {
 		fmt.Fprint(w, bashCompletionScript)
 	case "zsh":
 		fmt.Fprint(w, zshCompletionScript)
+	case "fish":
+		fmt.Fprint(w, fishCompletionScript)
 	case "powershell", "pwsh":
 		fmt.Fprint(w, powershellCompletionScript)
 	default:
-		return fmt.Errorf("unsupported shell %q (want bash, zsh, or powershell)", shell)
+		return fmt.Errorf("unsupported shell %q (want bash, zsh, fish, or powershell)", shell)
 	}
 	return nil
 }
@@ -211,7 +213,7 @@ _dispatch_completion() {
   fi
 
   if [[ "${COMP_WORDS[1]}" == "completion" ]]; then
-    COMPREPLY=( $(compgen -W "bash zsh powershell" -- "${cur}") )
+    COMPREPLY=( $(compgen -W "bash zsh fish powershell" -- "${cur}") )
     return 0
   fi
 
@@ -227,7 +229,7 @@ const zshCompletionScript = `#compdef dispatch disp
 _dispatch_completion() {
   local -a commands shells flags configsubs
   commands=(help version open new doctor update completion stats config export)
-  shells=(bash zsh powershell)
+  shells=(bash zsh fish powershell)
   configsubs=(list get set path)
   flags=(-h --help -v --version --demo --clear-cache --reindex)
 
@@ -249,10 +251,29 @@ _dispatch_completion() {
 _dispatch_completion "$@"
 `
 
+const fishCompletionScript = `# fish completion for dispatch and disp
+function __dispatch_needs_command
+  set -l cmd (commandline -opc)
+  test (count $cmd) -eq 1
+end
+
+function __dispatch_using_completion
+  set -l cmd (commandline -opc)
+  test (count $cmd) -ge 2; and test $cmd[2] = completion
+end
+
+for bin in dispatch disp
+  complete -c $bin -f
+  complete -c $bin -n '__dispatch_needs_command' -a 'help version open new doctor update completion stats config export'
+  complete -c $bin -n '__dispatch_needs_command' -a '-h --help -v --version --demo --clear-cache --reindex'
+  complete -c $bin -n '__dispatch_using_completion' -a 'bash zsh fish powershell'
+end
+`
+
 const powershellCompletionScript = `# PowerShell completion for dispatch
 $script:DispatchCommands = @('help', 'version', 'open', 'new', 'doctor', 'update', 'completion', 'stats', 'config', 'export')
 $script:DispatchFlags = @('-h', '--help', '-v', '--version', '--demo', '--clear-cache', '--reindex')
-$script:DispatchShells = @('bash', 'zsh', 'powershell')
+$script:DispatchShells = @('bash', 'zsh', 'fish', 'powershell')
 $script:DispatchConfigSubcommands = @('list', 'get', 'set', 'path')
 
 Register-ArgumentCompleter -Native -CommandName dispatch, disp -ScriptBlock {

--- a/cmd/dispatch/cli_test.go
+++ b/cmd/dispatch/cli_test.go
@@ -92,6 +92,7 @@ func TestRunCompletion_SupportedShells(t *testing.T) {
 	}{
 		{"bash", "complete -F _dispatch_completion dispatch disp"},
 		{"zsh", "#compdef dispatch disp"},
+		{"fish", "complete -c $bin"},
 		{"powershell", "Register-ArgumentCompleter"},
 		{"pwsh", "Register-ArgumentCompleter"},
 	} {
@@ -109,7 +110,7 @@ func TestRunCompletion_SupportedShells(t *testing.T) {
 
 func TestRunCompletion_UnsupportedShell(t *testing.T) {
 	var buf bytes.Buffer
-	err := runCompletion(&buf, "fish")
+	err := runCompletion(&buf, "tcsh")
 	if err == nil {
 		t.Fatal("expected error for unsupported shell")
 	}

--- a/cmd/dispatch/main.go
+++ b/cmd/dispatch/main.go
@@ -95,7 +95,7 @@ Commands:
                           --print writes the resume command instead of launching
   open --last [--mode M]  Resume the most recently active session
   new [dir] [--mode M]    Start a new session in a directory (default: current)
-  completion <shell>      Print shell completion (bash, zsh, powershell)
+  completion <shell>      Print shell completion (bash, zsh, fish, powershell)
   doctor [--json]         Print environment diagnostics (--json for machine-readable output)
   stats [flags]           Print session totals and breakdowns
   config [get|set|list|path]


### PR DESCRIPTION
## What
Adds `fish` as a supported shell for `dispatch completion`. Today only bash, zsh, and powershell are supported.

## Why
Fish users have no completion script. This closes the gap so `dispatch`/`disp` get command and shell-argument completion in fish.

## How
- New `fish` case in `runCompletion` that prints a fish completion script for both `dispatch` and `disp`.
- The script completes top-level commands and flags when no subcommand is typed yet, and completes shell names after `completion`.
- Updated the bash/zsh/powershell shell lists so tab-completing the `completion` argument now offers `fish` too.
- Updated the completion error message, `printUsage`, and the README completion section.

## Testing
- `go build ./...`
- `go test ./... -count=1`
- `go vet ./...`
- `golangci-lint run`
- Added `fish` to the supported-shells table test and repointed the unsupported-shell test at `tcsh`.

Closes #239