### PR TITLE
feat(doctor): report Copilot CLI version and stored session count

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ dispatch completion powershell
 
 ### Diagnostics
 
-Run `dispatch doctor` to print setup checks for the config file, session store, session-state directory, and Copilot CLI binary.
+Run `dispatch doctor` to print setup checks for the config file, session store, session-state directory, and Copilot CLI binary. It also reports the detected Copilot CLI version and the number of stored sessions.
 
 Add `--json` (`dispatch doctor --json`) to print the same checks as a single JSON object for scripts and CI.
 

--- a/cmd/dispatch/cli.go
+++ b/cmd/dispatch/cli.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/jongio/dispatch/internal/config"
 	"github.com/jongio/dispatch/internal/data"
@@ -35,6 +37,12 @@ var (
 	maintainFn         = data.Maintain
 	runUpdateFn        = update.RunUpdate
 	configResetFn      = config.Reset
+
+	// doctorCopilotVersionFn resolves the Copilot CLI version string for the
+	// doctor report; doctorSessionCountFn counts stored sessions. Both are
+	// seams so tests can substitute them without touching the environment.
+	doctorCopilotVersionFn = defaultCopilotVersion
+	doctorSessionCountFn   = defaultSessionCount
 )
 
 func handleArgs(args []string, origStderr io.Writer, updateCh <-chan *update.UpdateInfo) (done bool, cleanup func(), query string, err error) {
@@ -248,12 +256,14 @@ type doctorEntry struct {
 // Both the text and JSON renderers consume this struct so their outputs stay
 // in sync.
 type doctorReport struct {
-	Version      string      `json:"version"`
-	OS           string      `json:"os"`
-	Config       doctorEntry `json:"config"`
-	SessionStore doctorEntry `json:"session_store"`
-	SessionState doctorEntry `json:"session_state"`
-	CopilotCLI   doctorEntry `json:"copilot_cli"`
+	Version        string      `json:"version"`
+	OS             string      `json:"os"`
+	Config         doctorEntry `json:"config"`
+	SessionStore   doctorEntry `json:"session_store"`
+	SessionState   doctorEntry `json:"session_state"`
+	CopilotCLI     doctorEntry `json:"copilot_cli"`
+	CopilotVersion string      `json:"copilot_version"`
+	SessionCount   int         `json:"session_count"`
 }
 
 // collectDoctorReport gathers the environment diagnostics once so they can be
@@ -286,9 +296,52 @@ func collectDoctorReport() doctorReport {
 		r.CopilotCLI = doctorEntry{Status: statusMissing}
 	} else {
 		r.CopilotCLI = doctorEntry{Path: p, Status: statusFound}
+		r.CopilotVersion = doctorCopilotVersionFn(p)
 	}
 
+	r.SessionCount = doctorSessionCountFn()
+
 	return r
+}
+
+// defaultCopilotVersion runs the Copilot CLI binary with --version and returns
+// the first line of its output. It returns "unknown" when the binary cannot be
+// run, keeping the doctor command non-fatal when the CLI misbehaves.
+func defaultCopilotVersion(binary string) string {
+	if binary == "" {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, binary, "--version").Output()
+	if err != nil {
+		return "unknown"
+	}
+	line := strings.TrimSpace(string(out))
+	if i := strings.IndexByte(line, '\n'); i >= 0 {
+		line = strings.TrimSpace(line[:i])
+	}
+	if line == "" {
+		return "unknown"
+	}
+	return line
+}
+
+// defaultSessionCount returns the number of stored sessions, degrading to 0
+// when the store cannot be opened or queried so the doctor command stays
+// non-fatal.
+func defaultSessionCount() int {
+	store, err := data.Open()
+	if err != nil {
+		return 0
+	}
+	defer store.Close() //nolint:errcheck // read-only, best-effort close
+
+	n, err := store.CountSessions(context.Background())
+	if err != nil {
+		return 0
+	}
+	return n
 }
 
 // pathStatus stats a path and reports whether it is found, missing, or the
@@ -320,6 +373,13 @@ func runDoctor(w io.Writer) {
 	writeDoctorLine(w, "Session store", r.SessionStore, false)
 	writeDoctorLine(w, "Session state", r.SessionState, true)
 	writeDoctorLine(w, "Copilot CLI", r.CopilotCLI, false)
+
+	if r.CopilotVersion != "" {
+		fmt.Fprintf(w, "Copilot CLI version: %s\n", r.CopilotVersion)
+	} else {
+		fmt.Fprintf(w, "Copilot CLI version: not detected\n")
+	}
+	fmt.Fprintf(w, "Stored sessions: %d\n", r.SessionCount)
 }
 
 // runDoctorJSON writes the diagnostics as a single JSON object followed by a

--- a/cmd/dispatch/cli_test.go
+++ b/cmd/dispatch/cli_test.go
@@ -154,6 +154,11 @@ func TestRunDoctor_PrintsDiagnostics(t *testing.T) {
 	t.Setenv("DISPATCH_DB", db)
 	t.Setenv("DISPATCH_SESSION_STATE", stateDir)
 
+	origCount, origVer := doctorSessionCountFn, doctorCopilotVersionFn
+	doctorSessionCountFn = func() int { return 7 }
+	doctorCopilotVersionFn = func(string) string { return "1.2.3" }
+	t.Cleanup(func() { doctorSessionCountFn, doctorCopilotVersionFn = origCount, origVer })
+
 	var buf bytes.Buffer
 	runDoctor(&buf)
 	out := buf.String()
@@ -165,6 +170,7 @@ func TestRunDoctor_PrintsDiagnostics(t *testing.T) {
 		"Session store: found",
 		"Session state: found",
 		"Copilot CLI:",
+		"Stored sessions: 7",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("doctor output missing %q:\n%s", want, out)
@@ -180,6 +186,10 @@ func TestRunDoctorJSON_Shape(t *testing.T) {
 	stateDir := t.TempDir()
 	t.Setenv("DISPATCH_DB", db)
 	t.Setenv("DISPATCH_SESSION_STATE", stateDir)
+
+	origCount := doctorSessionCountFn
+	doctorSessionCountFn = func() int { return 3 }
+	t.Cleanup(func() { doctorSessionCountFn = origCount })
 
 	var buf bytes.Buffer
 	if err := runDoctorJSON(&buf); err != nil {
@@ -202,8 +212,17 @@ func TestRunDoctorJSON_Shape(t *testing.T) {
 	if r.SessionState.Status != statusFound {
 		t.Errorf("session_state status = %q, want %q", r.SessionState.Status, statusFound)
 	}
+	if r.SessionCount != 3 {
+		t.Errorf("session_count = %d, want 3", r.SessionCount)
+	}
 	if !strings.HasSuffix(buf.String(), "}\n") {
 		t.Errorf("JSON output should end with a single newline, got:\n%q", buf.String())
+	}
+}
+
+func TestDefaultCopilotVersion_EmptyBinary(t *testing.T) {
+	if got := defaultCopilotVersion(""); got != "" {
+		t.Errorf("defaultCopilotVersion(\"\") = %q, want empty", got)
 	}
 }
 

--- a/internal/data/store.go
+++ b/internal/data/store.go
@@ -999,6 +999,15 @@ func (s *Store) ListBranches(ctx context.Context, repository string) ([]string, 
 	return s.distinctStrings(ctx, "SELECT DISTINCT branch FROM sessions WHERE branch IS NOT NULL AND branch != '' ORDER BY branch")
 }
 
+// CountSessions returns the total number of sessions stored.
+func (s *Store) CountSessions(ctx context.Context) (int, error) {
+	var n int
+	if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM sessions").Scan(&n); err != nil {
+		return 0, fmt.Errorf("counting sessions: %w", err)
+	}
+	return n, nil
+}
+
 // GroupSessions groups sessions by the specified pivot field, applying the
 // given filter and sort order within each group.
 func (s *Store) GroupSessions(ctx context.Context, pivot PivotField, filter FilterOptions, sort SortOptions, limit int) ([]SessionGroup, error) {

--- a/internal/data/store_test.go
+++ b/internal/data/store_test.go
@@ -2845,3 +2845,25 @@ func TestLastActive_StaleTurnsVisibleInDayFilter(t *testing.T) {
 		t.Errorf("expected s1, got %s", sessions[0].ID)
 	}
 }
+
+func TestCountSessions(t *testing.T) {
+	s := newTestStore(t)
+	defer func() { _ = s.Close() }()
+
+	if n, err := s.CountSessions(context.Background()); err != nil {
+		t.Fatalf("CountSessions on empty store: %v", err)
+	} else if n != 0 {
+		t.Fatalf("empty store count = %d, want 0", n)
+	}
+
+	seedSession(t, s.db, "c1", "/tmp/a", "owner/repo", "main", "one", "2024-01-01T00:00:00Z", "2024-01-01T00:00:00Z")
+	seedSession(t, s.db, "c2", "/tmp/b", "owner/repo", "main", "two", "2024-01-02T00:00:00Z", "2024-01-02T00:00:00Z")
+
+	n, err := s.CountSessions(context.Background())
+	if err != nil {
+		t.Fatalf("CountSessions: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("count = %d, want 2", n)
+	}
+}


### PR DESCRIPTION
## What
`dispatch doctor` now reports the detected Copilot CLI version and the number of stored sessions, in both text and `--json` output.

## Why
Today doctor tells you whether the Copilot CLI is found and where the store lives, but not which CLI version is installed or how much history the store holds. Those two facts are the first things you want when triaging "why does my session list look wrong" or filing a bug.

## How
- Added `copilot_version` and `session_count` to the `doctorReport` struct so text and JSON stay in sync.
- The version probe runs the resolved CLI binary with `--version` (3s timeout) and takes the first line. It falls back to `unknown` if the binary cannot run, and the text output prints `not detected` when no CLI is found.
- The session count uses a new `Store.CountSessions` (`SELECT COUNT(*)`), degrading to 0 when the store cannot be opened or queried. Doctor stays non-fatal in all cases.
- Both probes are behind package seams so tests do not touch the environment.

## Testing
- `go build ./...`
- `go test ./... -count=1`
- `go vet ./...`
- `golangci-lint run`
- Updated the doctor text/JSON tests to assert the new fields via stubbed seams, added a version-probe edge case, and added a `CountSessions` store test.

Closes #240