### PR TITLE
Add g/G and Home/End jump navigation to the session list

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Dispatch reads your local Copilot CLI session store and presents every past sess
 - **Work status detection** — analyzes `plan.md` files to identify sessions with incomplete planned work. Colored dots show completion status in the session list and preview panel. Press `R` to explicitly scan work status. Filter by work completion via the `!` status picker. Supports AI-powered analysis via Copilot SDK `analyze_completion` tool
 - **Session hiding** (`h` / `H`) — hide sessions from the list, toggle visibility of hidden sessions, persistent state
 - **Session favorites** (`*`) — star sessions as favorites. Filter to show only favorites via the `!` status picker
-- **Session tags** (`g`) — attach comma-separated tags to sessions and filter to a tag with the `tag:` search token
+- **Session tags** (`#`) — attach comma-separated tags to sessions and filter to a tag with the `tag:` search token
 - **Session aliases** (`A`) — give a session a short, memorable alias and resume it from the CLI with `dispatch open <alias>` instead of the full session ID
 - **Settings panel** (`,`) — 19 fields: Yolo Mode, Agent, Model, Launch Mode, Pane Direction, Terminal, Shell, Custom Command, Theme, Crash Recovery, Preview Position, Redact Secrets, Excluded Words, Auto Refresh, Notify On Waiting, and column toggles for Repo, Folder, Turns, and Host
 - **Configurable list columns** (`,` settings) — choose which optional columns (repo, folder, turns, host) appear in the session list. Defaults show every column, and the session name and attention indicator are always visible
@@ -165,6 +165,8 @@ Add `--json` (`dispatch doctor --json`) to print the same checks as a single JSO
 |---|---|
 | `↑` / `k` | Move up |
 | `↓` / `j` | Move down |
+| `g` / `Home` | Jump to top |
+| `G` / `End` | Jump to bottom |
 | `←` | Collapse group |
 | `→` | Expand group |
 
@@ -199,7 +201,7 @@ Add `--json` (`dispatch doctor --json`) to print the same checks as a single JSO
 | `h` | Hide/unhide current session |
 | `H` | Toggle visibility of hidden sessions |
 | `*` | Toggle favorite on current session |
-| `g` | Add or edit tags on current session |
+| `#` | Add or edit tags on current session |
 | `A` | Set or clear a short alias on current session |
 
 #### Search & Filter

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -35,6 +35,20 @@
    - Behavior: Moves selection down, loads detail for selected item
    - Condition: Only in session list view
 
+3a. **g** or **Home** → Jump to Top of List
+   - File: internal\tui\keys.go (JumpTop binding)
+   - Code: key.NewBinding(key.WithKeys("g", "home"))
+   - Handler: internal\tui\model.go (JumpTop case in the list key switch)
+   - Behavior: Moves selection to the first item and loads its detail. Resets any active shift-selection.
+   - Condition: Only in session list view, when the search bar is not focused
+
+3b. **G** or **End** → Jump to Bottom of List
+   - File: internal\tui\keys.go (JumpBottom binding)
+   - Code: key.NewBinding(key.WithKeys("G", "end"))
+   - Handler: internal\tui\model.go (JumpBottom case in the list key switch)
+   - Behavior: Moves selection to the last item and loads its detail. Resets any active shift-selection.
+   - Condition: Only in session list view, when the search bar is not focused
+
 4. **← (Left Arrow)** → Collapse Folder (if selected item is a folder)
    - File: internal\tui\keys.go (line 60)
    - Code: key.NewBinding(key.WithKeys("left"))
@@ -262,9 +276,9 @@
 
     Note: Favorites filter was previously on `F` — now toggled via the `!` status picker "Favorites only" row.
 
-26b. **g** — Add or Edit Tags on Current Session
+26b. **#** — Add or Edit Tags on Current Session
     - File: internal\tui\keys.go
-    - Code: key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "edit tags"))
+    - Code: key.NewBinding(key.WithKeys("#"), key.WithHelp("#", "edit tags"))
     - Handler: internal\tui\model.go (handleEditTags)
     - Behavior: Opens an inline input to edit comma-separated tags (persisted to config as sessionTags); filter with the tag: search token
     - Condition: Only when a session is selected (not a folder)

--- a/internal/tui/components/sessionlist.go
+++ b/internal/tui/components/sessionlist.go
@@ -234,6 +234,16 @@ func (s *SessionList) MoveTo(idx int) {
 	}
 }
 
+// JumpToTop moves the cursor to the first visible item.
+func (s *SessionList) JumpToTop() {
+	s.MoveTo(0)
+}
+
+// JumpToBottom moves the cursor to the last visible item.
+func (s *SessionList) JumpToBottom() {
+	s.MoveTo(len(s.visItems) - 1)
+}
+
 // ScrollBy adjusts the scroll offset by delta lines (positive = down).
 func (s *SessionList) ScrollBy(delta int) {
 	maxOffset := len(s.visItems) - s.height

--- a/internal/tui/components/sessionlist_test.go
+++ b/internal/tui/components/sessionlist_test.go
@@ -409,6 +409,37 @@ func TestSelectionCount(t *testing.T) {
 	}
 }
 
+func TestJumpToTopBottom(t *testing.T) {
+	t.Parallel()
+	sl := NewSessionList()
+	sl.SetSessions(makeSessions(10))
+	sl.SetSize(80, 5)
+
+	sl.MoveTo(4)
+	sl.JumpToTop()
+	if sl.cursor != 0 {
+		t.Errorf("after JumpToTop cursor = %d, want 0", sl.cursor)
+	}
+	if sl.scrollOffset != 0 {
+		t.Errorf("after JumpToTop scrollOffset = %d, want 0", sl.scrollOffset)
+	}
+
+	sl.JumpToBottom()
+	if want := sl.VisibleCount() - 1; sl.cursor != want {
+		t.Errorf("after JumpToBottom cursor = %d, want %d", sl.cursor, want)
+	}
+}
+
+func TestJumpToTopBottom_EmptyList(t *testing.T) {
+	t.Parallel()
+	sl := NewSessionList()
+	sl.JumpToTop()
+	sl.JumpToBottom()
+	if sl.cursor != 0 {
+		t.Errorf("empty list cursor = %d, want 0", sl.cursor)
+	}
+}
+
 func TestFolderSessions(t *testing.T) {
 	t.Parallel()
 	sl := NewSessionList()

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -13,6 +13,8 @@ import (
 type keyMap struct {
 	Up                key.Binding
 	Down              key.Binding
+	JumpTop           key.Binding
+	JumpBottom        key.Binding
 	Left              key.Binding
 	Right             key.Binding
 	Enter             key.Binding
@@ -80,7 +82,7 @@ func (k keyMap) ShortHelp() []key.Binding {
 // FullHelp returns grouped key bindings for the expanded help view.
 func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
-		{k.Up, k.Down, k.Left, k.Right, k.Enter, k.LaunchWindow, k.LaunchTab, k.LaunchPane},
+		{k.Up, k.Down, k.JumpTop, k.JumpBottom, k.Left, k.Right, k.Enter, k.LaunchWindow, k.LaunchTab, k.LaunchPane},
 		{k.Space, k.LaunchAll, k.SelectAll, k.DeselectAll, k.ShiftUp, k.ShiftDown},
 		{k.Search, k.Escape, k.Filter},
 		{k.Sort, k.SortOrder, k.Pivot, k.PivotOrder, k.ExpandCollapseAll},
@@ -99,6 +101,8 @@ func defaultKeyMap() keyMap {
 	return keyMap{
 		Up:                key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("↑/k", "up")),
 		Down:              key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("↓/j", "down")),
+		JumpTop:           key.NewBinding(key.WithKeys("g", "home"), key.WithHelp("g/home", "jump to top")),
+		JumpBottom:        key.NewBinding(key.WithKeys("G", "end"), key.WithHelp("G/end", "jump to bottom")),
 		Left:              key.NewBinding(key.WithKeys("left"), key.WithHelp("←", "collapse")),
 		Right:             key.NewBinding(key.WithKeys("right"), key.WithHelp("→", "expand")),
 		Enter:             key.NewBinding(key.WithKeys("enter"), key.WithHelp("⏎", "launch/toggle")),
@@ -146,7 +150,7 @@ func defaultKeyMap() keyMap {
 		ScanWorkStatus:    key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "scan work status")),
 		Export:            key.NewBinding(key.WithKeys("X"), key.WithHelp("X", "export markdown")),
 		Note:              key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "edit note")),
-		Tags:              key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "edit tags")),
+		Tags:              key.NewBinding(key.WithKeys("#"), key.WithHelp("#", "edit tags")),
 		Alias:             key.NewBinding(key.WithKeys("A"), key.WithHelp("A", "edit alias")),
 		ShiftUp:           key.NewBinding(key.WithKeys("shift+up"), key.WithHelp("shift+\u2191", "extend select up")),
 		ShiftDown:         key.NewBinding(key.WithKeys("shift+down"), key.WithHelp("shift+\u2193", "extend select down")),
@@ -173,6 +177,8 @@ func keybindingEntries(km *keyMap) []keybindingEntry {
 	return []keybindingEntry{
 		{"up", &km.Up},
 		{"down", &km.Down},
+		{"jump_top", &km.JumpTop},
+		{"jump_bottom", &km.JumpBottom},
 		{"left", &km.Left},
 		{"right", &km.Right},
 		{"enter", &km.Enter},

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1330,6 +1330,18 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.detailVersion++
 		return m, m.loadSelectedDetailCmd()
 
+	case key.Matches(msg, keys.JumpTop):
+		m.sessionList.ResetShift()
+		m.sessionList.JumpToTop()
+		m.detailVersion++
+		return m, m.loadSelectedDetailCmd()
+
+	case key.Matches(msg, keys.JumpBottom):
+		m.sessionList.ResetShift()
+		m.sessionList.JumpToBottom()
+		m.detailVersion++
+		return m, m.loadSelectedDetailCmd()
+
 	case key.Matches(msg, keys.Enter):
 		if m.sessionList.IsFolderSelected() {
 			cmd := m.launchNewInFolder(m.cfg.EffectiveLaunchMode())

--- a/internal/tui/model_update_test.go
+++ b/internal/tui/model_update_test.go
@@ -1215,6 +1215,60 @@ func TestSelectedSessionCwd_WithSelection(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Jump navigation: g / G / Home / End
+// ---------------------------------------------------------------------------
+
+func jumpNavSessions(n int) []data.Session {
+	sessions := make([]data.Session, n)
+	for i := range sessions {
+		sessions[i] = data.Session{ID: "s" + strconv.Itoa(i), Cwd: "/x"}
+	}
+	return sessions
+}
+
+func TestHandleKey_JumpTop_g(t *testing.T) {
+	m := newTestModelWithSize(120, 40)
+	m.sessionList.SetSessions(jumpNavSessions(10))
+	m.sessionList.MoveTo(5)
+
+	result, _ := m.Update(runeKeyMsg('g'))
+	rm := result.(Model)
+	if got := rm.sessionList.Cursor(); got != 0 {
+		t.Errorf("after 'g' cursor = %d, want 0", got)
+	}
+}
+
+func TestHandleKey_JumpBottom_G(t *testing.T) {
+	m := newTestModelWithSize(120, 40)
+	m.sessionList.SetSessions(jumpNavSessions(10))
+	m.sessionList.MoveTo(0)
+
+	result, _ := m.Update(runeKeyMsg('G'))
+	rm := result.(Model)
+	if got := rm.sessionList.Cursor(); got != 9 {
+		t.Errorf("after 'G' cursor = %d, want 9", got)
+	}
+}
+
+func TestHandleKey_JumpHomeEnd(t *testing.T) {
+	m := newTestModelWithSize(120, 40)
+	m.sessionList.SetSessions(jumpNavSessions(10))
+	m.sessionList.MoveTo(4)
+
+	result, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnd})
+	rm := result.(Model)
+	if got := rm.sessionList.Cursor(); got != 9 {
+		t.Errorf("after End cursor = %d, want 9", got)
+	}
+
+	result, _ = rm.Update(tea.KeyPressMsg{Code: tea.KeyHome})
+	rm = result.(Model)
+	if got := rm.sessionList.Cursor(); got != 0 {
+		t.Errorf("after Home cursor = %d, want 0", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // closeStore
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds `g` / `G` and `Home` / `End` shortcuts to jump straight to the top or bottom of the session list. Today the only way to reach the ends of a long list is holding the arrow keys, which is slow when you have dozens of sessions.

- `g` or `Home` jumps to the first session
- `G` or `End` jumps to the last session

Both jumps load the newly selected session's detail and reset any active shift-selection, matching the behavior of the existing up/down handlers. The shortcuts are inert while the search bar is focused, so typing `g` into a query still works as expected.

## Changes

- `internal/tui/keys.go`: new `JumpTop` (`g`/`home`) and `JumpBottom` (`G`/`end`) bindings, added to the help view
- `internal/tui/components/sessionlist.go`: `JumpToTop()` and `JumpToBottom()` methods (reuse `MoveTo`, which clamps to valid range)
- `internal/tui/model.go`: handler cases in the session-list key switch
- Docs: README key table and `docs/keybindings.md`

## Tests

- Component tests for `JumpToTop`/`JumpToBottom`, including empty-list safety
- Model handler tests for `g`, `G`, `Home`, and `End`
- `go build ./...`, `go test ./... -count=1`, `go vet ./...`, and `golangci-lint run` all pass

Closes #243
