### PR TITLE
Add after:/before: date filter tokens to search

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,27 @@ Add `--json` (`dispatch doctor --json`) to print the same checks as a single JSO
 | `Esc` | Clear search / close overlay |
 | `f` | Open filter panel |
 
+Search tokens narrow results without opening the filter panel. Type them in the
+search bar alongside free text:
+
+| Token | Matches |
+|---|---|
+| `repo:<name>` | Sessions in a repository (use quotes for names with spaces: `repo:"my repo"`) |
+| `branch:<name>` | Sessions on a branch |
+| `folder:<path>` | Sessions under a working directory |
+| `host:<type>` | Sessions by host type (cli, cloud, actions) |
+| `status:<state>` | Sessions by attention state (waiting, active, stale, idle, interrupted, working, thinking, compacting) |
+| `has:plan` | Sessions that have a plan |
+| `is:favorite` | Favorited sessions |
+| `is:hidden` | Hidden sessions |
+| `after:<date>` | Sessions active on or after a date |
+| `before:<date>` | Sessions active on or before a date |
+
+Dates accept `YYYY-MM-DD` or full RFC3339 timestamps (e.g. `after:2024-01-15` or
+`before:2024-03-01T12:00:00Z`), matching the `--since` / `--until` flags on
+`dispatch stats`. While an `after:` token is active it takes precedence over the
+`1`-`4` time-range shortcuts. Clearing the search restores the selected range.
+
 #### View & Sorting
 
 | Key | Action |

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3473,7 +3473,11 @@ func (m *Model) setTimeRange(tr string) tea.Cmd {
 	m.timeRange = tr
 	m.cfg.DefaultTimeRange = tr
 	m.saveConfig()
-	m.filter.Since = timeRangeToSince(tr)
+	// An after: date token in the search bar takes precedence over the
+	// time-range selector; only apply the selector when no token is active.
+	if m.searchFilter.After == nil {
+		m.filter.Since = timeRangeToSince(tr)
+	}
 	return m.loadSessionsCmd()
 }
 

--- a/internal/tui/searchtoken.go
+++ b/internal/tui/searchtoken.go
@@ -1,6 +1,9 @@
 package tui
 
-import "strings"
+import (
+	"strings"
+	"time"
+)
 
 // SearchFilter holds structured filter tokens extracted from the search bar input.
 // Each field corresponds to a supported token prefix (e.g., "repo:dispatch").
@@ -15,6 +18,15 @@ type SearchFilter struct {
 	IsFav    bool   // is:favorite
 	IsHidden bool   // is:hidden
 	Tag      string // tag:<value>
+
+	// After and Before bound the session's last-active time. They are parsed
+	// from after:<date> and before:<date> tokens. AfterText and BeforeText
+	// keep the raw value as typed so the badge row can echo it back.
+	After      *time.Time
+	Before     *time.Time
+	AfterText  string
+	BeforeText string
+
 	FreeText string // remaining non-token words
 }
 
@@ -28,7 +40,9 @@ func (sf SearchFilter) HasTokens() bool {
 		sf.HasPlan ||
 		sf.IsFav ||
 		sf.IsHidden ||
-		sf.Tag != ""
+		sf.Tag != "" ||
+		sf.After != nil ||
+		sf.Before != nil
 }
 
 // TokenSummary returns a short description of active tokens suitable for
@@ -61,6 +75,12 @@ func (sf SearchFilter) TokenSummary() string {
 	}
 	if sf.Tag != "" {
 		parts = append(parts, "tag:"+sf.Tag)
+	}
+	if sf.After != nil {
+		parts = append(parts, "after:"+sf.AfterText)
+	}
+	if sf.Before != nil {
+		parts = append(parts, "before:"+sf.BeforeText)
 	}
 	if len(parts) == 0 {
 		return ""
@@ -97,6 +117,21 @@ func ParseSearchTokens(input string) SearchFilter {
 			sf.Status = value
 		case "tag":
 			sf.Tag = value
+		case "after":
+			if t, ok := parseSearchDate(value); ok {
+				sf.After = &t
+				sf.AfterText = value
+			} else {
+				// Malformed date; keep the token as free text.
+				freeWords = append(freeWords, w)
+			}
+		case "before":
+			if t, ok := parseSearchDate(value); ok {
+				sf.Before = &t
+				sf.BeforeText = value
+			} else {
+				freeWords = append(freeWords, w)
+			}
 		case "has":
 			if value == "plan" {
 				sf.HasPlan = true
@@ -121,6 +156,24 @@ func ParseSearchTokens(input string) SearchFilter {
 
 	sf.FreeText = strings.Join(freeWords, " ")
 	return sf
+}
+
+// parseSearchDate parses a date token value in RFC3339 or common date-only
+// forms. It mirrors the CLI stats parser so after:/before: behave the same as
+// --since/--until. Returns false when the value is not a recognized date.
+func parseSearchDate(s string) (time.Time, bool) {
+	layouts := []string{
+		time.RFC3339,
+		"2006-01-02T15:04:05.000Z",
+		"2006-01-02T15:04:05",
+		"2006-01-02",
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
 }
 
 // tokenize splits input into words, respecting quoted values attached to

--- a/internal/tui/searchtoken_apply.go
+++ b/internal/tui/searchtoken_apply.go
@@ -36,6 +36,17 @@ func (m *Model) applySearchTokens() {
 	m.filterPlans = sf.HasPlan
 	m.showFavorited = sf.IsFav
 	m.showHidden = sf.IsHidden
+
+	// Date tokens bound the last-active window and take precedence over the
+	// time-range selector. When no after: token is present, fall back to the
+	// selector's window. before: has no selector equivalent, so it is cleared
+	// whenever the token is absent.
+	if sf.After != nil {
+		m.filter.Since = sf.After
+	} else {
+		m.filter.Since = timeRangeToSince(m.timeRange)
+	}
+	m.filter.Until = sf.Before
 }
 
 // clearSearchTokenFilters resets the filter fields that may have been set
@@ -50,6 +61,10 @@ func (m *Model) clearSearchTokenFilters() {
 	m.filterPlans = false
 	m.showFavorited = false
 	m.showHidden = false
+	// Date tokens override the time-range selector while active; restore the
+	// selector's window and drop the upper bound when the tokens are cleared.
+	m.filter.Since = timeRangeToSince(m.timeRange)
+	m.filter.Until = nil
 }
 
 // parseAttentionStatus converts a status token value string to a

--- a/internal/tui/searchtoken_test.go
+++ b/internal/tui/searchtoken_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"testing"
+	"time"
 
 	"github.com/jongio/dispatch/internal/data"
 )
@@ -278,5 +279,129 @@ func TestParseSearchTokens_StatusValues(t *testing.T) {
 		if sf.Status != s {
 			t.Errorf("status:%s: Status = %q, want %q", s, sf.Status, s)
 		}
+	}
+}
+
+func TestParseSearchTokens_DateTokens(t *testing.T) {
+	sf := ParseSearchTokens("after:2024-01-15 before:2024-03-01 hello")
+	if sf.After == nil {
+		t.Fatal("After should be set")
+	}
+	if got := sf.After.Format("2006-01-02"); got != "2024-01-15" {
+		t.Errorf("After = %q, want 2024-01-15", got)
+	}
+	if sf.AfterText != "2024-01-15" {
+		t.Errorf("AfterText = %q, want 2024-01-15", sf.AfterText)
+	}
+	if sf.Before == nil {
+		t.Fatal("Before should be set")
+	}
+	if got := sf.Before.Format("2006-01-02"); got != "2024-03-01" {
+		t.Errorf("Before = %q, want 2024-03-01", got)
+	}
+	if sf.FreeText != "hello" {
+		t.Errorf("FreeText = %q, want %q", sf.FreeText, "hello")
+	}
+	if !sf.HasTokens() {
+		t.Error("expected HasTokens = true")
+	}
+}
+
+func TestParseSearchTokens_DateTokenRFC3339(t *testing.T) {
+	sf := ParseSearchTokens("after:2024-01-15T09:30:00Z")
+	if sf.After == nil {
+		t.Fatal("After should be set for an RFC3339 value")
+	}
+	if sf.After.Hour() != 9 || sf.After.Minute() != 30 {
+		t.Errorf("After time = %v, want 09:30", sf.After)
+	}
+}
+
+func TestParseSearchTokens_MalformedDateIsFreeText(t *testing.T) {
+	sf := ParseSearchTokens("after:notadate before:2024-13-99")
+	if sf.After != nil {
+		t.Errorf("After should be nil for a malformed value, got %v", sf.After)
+	}
+	if sf.Before != nil {
+		t.Errorf("Before should be nil for a malformed value, got %v", sf.Before)
+	}
+	if sf.FreeText != "after:notadate before:2024-13-99" {
+		t.Errorf("FreeText = %q, want the malformed tokens kept as free text", sf.FreeText)
+	}
+}
+
+func TestSearchFilter_TokenSummaryWithDates(t *testing.T) {
+	sf := ParseSearchTokens("after:2024-01-15 before:2024-03-01")
+	got := sf.TokenSummary()
+	want := "after:2024-01-15 before:2024-03-01"
+	if got != want {
+		t.Errorf("TokenSummary() = %q, want %q", got, want)
+	}
+}
+
+func TestApplySearchTokens_DateTokensSetSinceUntil(t *testing.T) {
+	m := newTestModel()
+	m.searchFilter = ParseSearchTokens("after:2024-01-15 before:2024-03-01")
+	m.applySearchTokens()
+
+	if m.filter.Since == nil {
+		t.Fatal("filter.Since should be set from after: token")
+	}
+	if got := m.filter.Since.Format("2006-01-02"); got != "2024-01-15" {
+		t.Errorf("filter.Since = %q, want 2024-01-15", got)
+	}
+	if m.filter.Until == nil {
+		t.Fatal("filter.Until should be set from before: token")
+	}
+	if got := m.filter.Until.Format("2006-01-02"); got != "2024-03-01" {
+		t.Errorf("filter.Until = %q, want 2024-03-01", got)
+	}
+}
+
+func TestApplySearchTokens_AfterTokenOverridesTimeRange(t *testing.T) {
+	m := newTestModel()
+	m.timeRange = "1h"
+	m.searchFilter = ParseSearchTokens("after:2020-01-01")
+	m.applySearchTokens()
+
+	if m.filter.Since == nil {
+		t.Fatal("filter.Since should be set")
+	}
+	// The after: token (2020) must win over the 1h time range.
+	if got := m.filter.Since.Year(); got != 2020 {
+		t.Errorf("filter.Since year = %d, want 2020 (after: token should override time range)", got)
+	}
+}
+
+func TestApplySearchTokens_NoDateTokenFallsBackToTimeRange(t *testing.T) {
+	m := newTestModel()
+	m.timeRange = "all"
+	m.searchFilter = ParseSearchTokens("repo:dispatch")
+	m.applySearchTokens()
+
+	// "all" maps to a nil Since; no upper bound either.
+	if m.filter.Since != nil {
+		t.Errorf("filter.Since = %v, want nil for the 'all' range", m.filter.Since)
+	}
+	if m.filter.Until != nil {
+		t.Errorf("filter.Until = %v, want nil when no before: token is present", m.filter.Until)
+	}
+}
+
+func TestClearSearchTokenFilters_ResetsDateBounds(t *testing.T) {
+	m := newTestModel()
+	m.timeRange = "all"
+	now := time.Now()
+	m.filter.Since = &now
+	m.filter.Until = &now
+
+	m.clearSearchTokenFilters()
+
+	if m.filter.Until != nil {
+		t.Errorf("filter.Until should be nil after clear, got %v", m.filter.Until)
+	}
+	// Since falls back to the time-range selector ("all" -> nil).
+	if m.filter.Since != nil {
+		t.Errorf("filter.Since should fall back to the 'all' range (nil), got %v", m.filter.Since)
 	}
 }


### PR DESCRIPTION
## Summary

Adds `after:` and `before:` date tokens to the search bar so you can narrow the session list to a date window without leaving the keyboard. These mirror the `--since` / `--until` flags already on `dispatch stats`.

- `after:<date>` sets an inclusive lower bound on a session's last-active time
- `before:<date>` sets an inclusive upper bound

Dates accept `YYYY-MM-DD` or full RFC3339 timestamps, for example:

```
after:2024-01-15
before:2024-03-01T12:00:00Z
after:2024-01-15 before:2024-03-01 refactor
```

They combine with the existing tokens (`repo:`, `branch:`, `status:`, and so on) and with free text.

## Behavior

- A malformed date (e.g. `after:notadate`) is left as free text instead of silently dropping the query, so you notice the typo.
- While an `after:` token is active it takes precedence over the `1`-`4` time-range shortcuts. Pressing a time-range key does not override the token.
- Clearing the search (Esc) restores the previously selected time range and drops the `before:` upper bound.
- The active tokens show up in the badge row like the other tokens.

## Changes

- `internal/tui/searchtoken.go`: `After` / `Before` fields, parsing for `after:` / `before:`, a date parser matching the stats layouts, and badge output
- `internal/tui/searchtoken_apply.go`: map the tokens onto `filter.Since` / `filter.Until` with time-range precedence; reset both on clear
- `internal/tui/model.go`: `setTimeRange` respects an active `after:` token
- `README.md`: new search token reference table

## Tests

- Parsing (date-only, RFC3339, malformed-as-free-text), badge summary, apply-to-filter, time-range precedence, and clear-resets-bounds
- `go build ./...`, `go test ./... -count=1`, `go vet ./...`, and `golangci-lint run` all pass

Closes #241
