### PR TITLE
Add a non-interactive search command with JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,26 @@ dispatch export 0a1b2c3d --out ./exports
 
 By default the session is written as Markdown to the exports directory. Use `--format json` for machine-readable output, `--stdout` to print to the terminal instead of writing a file, and `--out <dir>` to choose the destination directory. `--stdout` and `--out` cannot be combined.
 
+### Search (JSON)
+
+Query the session store from scripts without opening the TUI. `dispatch search` prints matching sessions as a JSON array:
+
+```sh
+dispatch search auth
+dispatch search --query "fix login" --repo jongio/dispatch
+dispatch search --branch main --since 2026-01-01 --limit 20
+dispatch search --deep refactor --json
+```
+
+The query can be passed as a positional argument or with `--query`. Filters mirror the interactive search and the `stats` command:
+
+- `--repo`, `--branch`, `--folder`, `--host` narrow by session metadata.
+- `--since` / `--until` accept `YYYY-MM-DD` or full RFC3339 timestamps.
+- `--deep` also searches turns, checkpoints, touched files, and refs.
+- `--limit <n>` caps the result count (default 50, `0` for no limit).
+
+Each result includes `id`, `summary`, `cwd`, `repository`, `branch`, `created_at`, `updated_at`, `turn_count`, and `file_count`. No matches prints `[]` and exits 0. Invalid flags or an unreadable store exit non-zero with a message on stderr.
+
 ### Key Bindings
 
 #### Navigation

--- a/cmd/dispatch/cli.go
+++ b/cmd/dispatch/cli.go
@@ -111,6 +111,13 @@ func handleArgs(args []string, origStderr io.Writer, updateCh <-chan *update.Upd
 			}
 			return true, cleanup, "", nil
 
+		case "search":
+			if sErr := runSearch(os.Stdout, args); sErr != nil {
+				fmt.Fprintf(os.Stderr, "search: %v\n", sErr)
+				return true, cleanup, "", sErr
+			}
+			return true, cleanup, "", nil
+
 		case "config":
 			if cErr := runConfig(os.Stdout, args); cErr != nil {
 				fmt.Fprintf(os.Stderr, "config: %v\n", cErr)
@@ -204,7 +211,7 @@ func runCompletion(w io.Writer, shell string) error {
 const bashCompletionScript = `# bash completion for dispatch
 _dispatch_completion() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
-  local commands="help version open new doctor update completion stats config export"
+  local commands="help version open new doctor update completion stats search config export"
   local flags="-h --help -v --version --demo --clear-cache --reindex"
 
   if [[ "${COMP_CWORD}" -eq 1 ]]; then
@@ -228,7 +235,7 @@ complete -F _dispatch_completion dispatch disp
 const zshCompletionScript = `#compdef dispatch disp
 _dispatch_completion() {
   local -a commands shells flags configsubs
-  commands=(help version open new doctor update completion stats config export)
+  commands=(help version open new doctor update completion stats search config export)
   shells=(bash zsh fish powershell)
   configsubs=(list get set path)
   flags=(-h --help -v --version --demo --clear-cache --reindex)
@@ -264,14 +271,14 @@ end
 
 for bin in dispatch disp
   complete -c $bin -f
-  complete -c $bin -n '__dispatch_needs_command' -a 'help version open new doctor update completion stats config export'
+  complete -c $bin -n '__dispatch_needs_command' -a 'help version open new doctor update completion stats search config export'
   complete -c $bin -n '__dispatch_needs_command' -a '-h --help -v --version --demo --clear-cache --reindex'
   complete -c $bin -n '__dispatch_using_completion' -a 'bash zsh fish powershell'
 end
 `
 
 const powershellCompletionScript = `# PowerShell completion for dispatch
-$script:DispatchCommands = @('help', 'version', 'open', 'new', 'doctor', 'update', 'completion', 'stats', 'config', 'export')
+$script:DispatchCommands = @('help', 'version', 'open', 'new', 'doctor', 'update', 'completion', 'stats', 'search', 'config', 'export')
 $script:DispatchFlags = @('-h', '--help', '-v', '--version', '--demo', '--clear-cache', '--reindex')
 $script:DispatchShells = @('bash', 'zsh', 'fish', 'powershell')
 $script:DispatchConfigSubcommands = @('list', 'get', 'set', 'path')

--- a/cmd/dispatch/main.go
+++ b/cmd/dispatch/main.go
@@ -98,6 +98,7 @@ Commands:
   completion <shell>      Print shell completion (bash, zsh, fish, powershell)
   doctor [--json]         Print environment diagnostics (--json for machine-readable output)
   stats [flags]           Print session totals and breakdowns
+  search [query] [flags]  Print matching sessions as JSON (no TUI)
   config [get|set|list|path]
                           Read or change preferences (see Config commands)
   export <id> [flags]     Export a session as Markdown or JSON
@@ -111,6 +112,18 @@ Stats flags:
   --folder <path>         Only count sessions under a folder
   --since <date>          Only count sessions created on or after a date
   --until <date>          Only count sessions created on or before a date
+
+Search flags:
+  --json                  Print results as JSON (default and only output)
+  --query <text>          Text to match (also accepted as a positional argument)
+  --deep                  Search turns, checkpoints, files, and refs too
+  --repo <name>           Only include sessions for a repository
+  --branch <name>         Only include sessions on a branch
+  --folder <path>         Only include sessions under a folder
+  --host <type>           Only include sessions by host type (cli, cloud, actions)
+  --since <date>          Only include sessions active on or after a date
+  --until <date>          Only include sessions active on or before a date
+  --limit <n>             Cap the number of results (default 50, 0 for no limit)
 
 Config commands:
   config list [--json]    Print every setting and its value

--- a/cmd/dispatch/search.go
+++ b/cmd/dispatch/search.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/jongio/dispatch/internal/data"
+)
+
+// searchListSessionsFn loads sessions for the search command. It is a package
+// variable so tests can substitute a fixed set of sessions, matching the seam
+// pattern used elsewhere in this package (see stats.go and cli.go).
+var searchListSessionsFn = defaultSearchListSessions
+
+// searchDefaultLimit caps how many matches the search command returns unless
+// the caller overrides it with --limit. A limit of 0 means no cap.
+const searchDefaultLimit = 50
+
+// searchAllLimit is a high ceiling used when the caller requests every match
+// (--limit 0), mirroring the ceiling the stats command uses.
+const searchAllLimit = 100_000
+
+// searchOptions holds the parsed flags for the search command.
+type searchOptions struct {
+	filter data.FilterOptions
+	limit  int
+}
+
+// searchSession is the machine-readable shape emitted for each matching
+// session. It is a dedicated struct (rather than data.Session) so the output
+// contract stays stable regardless of internal model changes.
+type searchSession struct {
+	ID         string `json:"id"`
+	Summary    string `json:"summary"`
+	Cwd        string `json:"cwd"`
+	Repository string `json:"repository"`
+	Branch     string `json:"branch"`
+	CreatedAt  string `json:"created_at"`
+	UpdatedAt  string `json:"updated_at"`
+	TurnCount  int    `json:"turn_count"`
+	FileCount  int    `json:"file_count"`
+}
+
+// runSearch prints matching sessions as JSON without starting the TUI. args is
+// the full argument slice with args[0] == "search".
+func runSearch(w io.Writer, args []string) error {
+	if w == nil {
+		w = io.Discard
+	}
+
+	opts, err := parseSearchArgs(args)
+	if err != nil {
+		return err
+	}
+
+	limit := opts.limit
+	if limit <= 0 {
+		limit = searchAllLimit
+	}
+
+	sessions, err := searchListSessionsFn(opts.filter, limit)
+	if err != nil {
+		return err
+	}
+
+	results := make([]searchSession, 0, len(sessions))
+	for _, s := range sessions {
+		results = append(results, searchSession{
+			ID:         s.ID,
+			Summary:    s.Summary,
+			Cwd:        s.Cwd,
+			Repository: s.Repository,
+			Branch:     s.Branch,
+			CreatedAt:  s.CreatedAt,
+			UpdatedAt:  s.UpdatedAt,
+			TurnCount:  s.TurnCount,
+			FileCount:  s.FileCount,
+		})
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(results)
+}
+
+// parseSearchArgs reads the search subcommand flags. args[0] is expected to be
+// "search". A single leading token that does not start with "-" is treated as
+// the search query, matching how the TUI seeds its search box.
+func parseSearchArgs(args []string) (searchOptions, error) {
+	opts := searchOptions{limit: searchDefaultLimit}
+
+	rest := args
+	if len(rest) > 0 {
+		rest = rest[1:] // drop the "search" token
+	}
+
+	takeValue := func(i int, name, inline string) (string, int, error) {
+		if inline != "" {
+			return inline, i, nil
+		}
+		if i+1 >= len(rest) {
+			return "", i, fmt.Errorf("%s requires a value", name)
+		}
+		return rest[i+1], i + 1, nil
+	}
+
+	var queryParts []string
+	for i := 0; i < len(rest); i++ {
+		arg := rest[i]
+		name, inline, hasInline := splitFlag(arg)
+
+		switch {
+		case name == "--json":
+			// Accepted for explicitness and forward compatibility; JSON is
+			// the only output mode this command emits.
+		case name == "--deep":
+			opts.filter.DeepSearch = true
+		case name == "--query" || name == "-q":
+			v, ni, err := takeValue(i, "--query", inlineOrEmpty(inline, hasInline))
+			if err != nil {
+				return searchOptions{}, err
+			}
+			queryParts = append(queryParts, v)
+			i = ni
+		case name == "--repo" || name == "--repository":
+			v, ni, err := takeValue(i, "--repo", inlineOrEmpty(inline, hasInline))
+			if err != nil {
+				return searchOptions{}, err
+			}
+			opts.filter.Repository = v
+			i = ni
+		case name == "--branch":
+			v, ni, err := takeValue(i, "--branch", inlineOrEmpty(inline, hasInline))
+			if err != nil {
+				return searchOptions{}, err
+			}
+			opts.filter.Branch = v
+			i = ni
+		case name == "--folder":
+			v, ni, err := takeValue(i, "--folder", inlineOrEmpty(inline, hasInline))
+			if err != nil {
+				return searchOptions{}, err
+			}
+			opts.filter.Folder = v
+			i = ni
+		case name == "--host":
+			v, ni, err := takeValue(i, "--host", inlineOrEmpty(inline, hasInline))
+			if err != nil {
+				return searchOptions{}, err
+			}
+			opts.filter.HostType = v
+			i = ni
+		case name == "--since":
+			v, ni, err := takeValue(i, "--since", inlineOrEmpty(inline, hasInline))
+			if err != nil {
+				return searchOptions{}, err
+			}
+			t, ok := parseStatsTime(v)
+			if !ok {
+				return searchOptions{}, fmt.Errorf("invalid --since value %q (want YYYY-MM-DD or RFC3339)", v)
+			}
+			opts.filter.Since = &t
+			i = ni
+		case name == "--until":
+			v, ni, err := takeValue(i, "--until", inlineOrEmpty(inline, hasInline))
+			if err != nil {
+				return searchOptions{}, err
+			}
+			t, ok := parseStatsTime(v)
+			if !ok {
+				return searchOptions{}, fmt.Errorf("invalid --until value %q (want YYYY-MM-DD or RFC3339)", v)
+			}
+			opts.filter.Until = &t
+			i = ni
+		case name == "--limit" || name == "-n":
+			v, ni, err := takeValue(i, "--limit", inlineOrEmpty(inline, hasInline))
+			if err != nil {
+				return searchOptions{}, err
+			}
+			n, err := parseSearchLimit(v)
+			if err != nil {
+				return searchOptions{}, err
+			}
+			opts.limit = n
+			i = ni
+		case strings.HasPrefix(arg, "-"):
+			return searchOptions{}, fmt.Errorf("unknown flag: %s", arg)
+		default:
+			queryParts = append(queryParts, arg)
+		}
+	}
+
+	if len(queryParts) > 0 {
+		opts.filter.Query = strings.Join(queryParts, " ")
+	}
+
+	return opts, nil
+}
+
+// parseSearchLimit parses the --limit value. Zero means "no cap"; negative
+// values are rejected.
+func parseSearchLimit(v string) (int, error) {
+	n, err := strconv.Atoi(strings.TrimSpace(v))
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("invalid --limit value %q (want a whole number, 0 for no limit)", v)
+	}
+	return n, nil
+}
+
+// defaultSearchListSessions loads sessions matching the filter from the default
+// session store, ordered by most recent activity first.
+func defaultSearchListSessions(filter data.FilterOptions, limit int) ([]data.Session, error) {
+	store, err := data.Open()
+	if err != nil {
+		return nil, fmt.Errorf("opening session store: %w", err)
+	}
+	defer store.Close() //nolint:errcheck // read-only, best-effort close
+
+	sortOpts := data.SortOptions{Field: data.SortByUpdated, Order: data.Descending}
+	sessions, err := store.ListSessions(context.Background(), filter, sortOpts, limit)
+	if err != nil {
+		return nil, fmt.Errorf("listing sessions: %w", err)
+	}
+	return sessions, nil
+}

--- a/cmd/dispatch/search_test.go
+++ b/cmd/dispatch/search_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jongio/dispatch/internal/data"
+)
+
+// withSearchList swaps the search command's session loader for a test double
+// and restores it afterward, matching the seam helper used by the stats tests.
+func withSearchList(t *testing.T, fn func(data.FilterOptions, int) ([]data.Session, error)) {
+	t.Helper()
+	prev := searchListSessionsFn
+	searchListSessionsFn = fn
+	t.Cleanup(func() { searchListSessionsFn = prev })
+}
+
+func TestParseSearchArgsQueryAndFilters(t *testing.T) {
+	opts, err := parseSearchArgs([]string{
+		"search", "--json", "auth", "bug",
+		"--repo", "jongio/dispatch",
+		"--branch=main",
+		"--folder", "/code",
+		"--host", "cli",
+		"--deep",
+		"--limit", "10",
+		"--since", "2026-01-01",
+		"--until", "2026-12-31",
+	})
+	if err != nil {
+		t.Fatalf("parseSearchArgs returned error: %v", err)
+	}
+	if opts.filter.Query != "auth bug" {
+		t.Errorf("Query = %q, want %q", opts.filter.Query, "auth bug")
+	}
+	if opts.filter.Repository != "jongio/dispatch" {
+		t.Errorf("Repository = %q, want jongio/dispatch", opts.filter.Repository)
+	}
+	if opts.filter.Branch != "main" {
+		t.Errorf("Branch = %q, want main", opts.filter.Branch)
+	}
+	if opts.filter.Folder != "/code" {
+		t.Errorf("Folder = %q, want /code", opts.filter.Folder)
+	}
+	if opts.filter.HostType != "cli" {
+		t.Errorf("HostType = %q, want cli", opts.filter.HostType)
+	}
+	if !opts.filter.DeepSearch {
+		t.Error("DeepSearch = false, want true")
+	}
+	if opts.limit != 10 {
+		t.Errorf("limit = %d, want 10", opts.limit)
+	}
+	if opts.filter.Since == nil || !opts.filter.Since.Equal(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("Since = %v, want 2026-01-01", opts.filter.Since)
+	}
+	if opts.filter.Until == nil {
+		t.Error("Until = nil, want 2026-12-31")
+	}
+}
+
+func TestParseSearchArgsDefaultLimit(t *testing.T) {
+	opts, err := parseSearchArgs([]string{"search"})
+	if err != nil {
+		t.Fatalf("parseSearchArgs returned error: %v", err)
+	}
+	if opts.limit != searchDefaultLimit {
+		t.Errorf("limit = %d, want default %d", opts.limit, searchDefaultLimit)
+	}
+	if opts.filter.Query != "" {
+		t.Errorf("Query = %q, want empty", opts.filter.Query)
+	}
+}
+
+func TestParseSearchArgsErrors(t *testing.T) {
+	cases := [][]string{
+		{"search", "--bogus"},
+		{"search", "--since", "not-a-date"},
+		{"search", "--limit", "-3"},
+		{"search", "--limit", "abc"},
+		{"search", "--repo"},
+	}
+	for _, args := range cases {
+		if _, err := parseSearchArgs(args); err == nil {
+			t.Errorf("parseSearchArgs(%v) = nil error, want error", args)
+		}
+	}
+}
+
+func TestRunSearchJSONOutput(t *testing.T) {
+	sessions := []data.Session{
+		{
+			ID:         "a",
+			Summary:    "fix auth bug",
+			Cwd:        "/code/app",
+			Repository: "jongio/dispatch",
+			Branch:     "main",
+			CreatedAt:  "2026-01-05T10:00:00Z",
+			UpdatedAt:  "2026-01-06T10:00:00Z",
+			TurnCount:  5,
+			FileCount:  3,
+		},
+	}
+	var gotFilter data.FilterOptions
+	var gotLimit int
+	withSearchList(t, func(f data.FilterOptions, limit int) ([]data.Session, error) {
+		gotFilter = f
+		gotLimit = limit
+		return sessions, nil
+	})
+
+	var buf bytes.Buffer
+	if err := runSearch(&buf, []string{"search", "auth", "--limit", "5"}); err != nil {
+		t.Fatalf("runSearch returned error: %v", err)
+	}
+
+	if gotFilter.Query != "auth" {
+		t.Errorf("filter.Query = %q, want auth", gotFilter.Query)
+	}
+	if gotLimit != 5 {
+		t.Errorf("limit = %d, want 5", gotLimit)
+	}
+
+	var out []searchSession
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, buf.String())
+	}
+	if len(out) != 1 {
+		t.Fatalf("got %d results, want 1", len(out))
+	}
+	if out[0].ID != "a" || out[0].Summary != "fix auth bug" || out[0].TurnCount != 5 || out[0].FileCount != 3 {
+		t.Errorf("unexpected result: %+v", out[0])
+	}
+}
+
+func TestRunSearchEmptyIsEmptyArray(t *testing.T) {
+	withSearchList(t, func(data.FilterOptions, int) ([]data.Session, error) {
+		return nil, nil
+	})
+
+	var buf bytes.Buffer
+	if err := runSearch(&buf, []string{"search", "nomatch"}); err != nil {
+		t.Fatalf("runSearch returned error: %v", err)
+	}
+	if got := strings.TrimSpace(buf.String()); got != "[]" {
+		t.Errorf("output = %q, want []", got)
+	}
+}
+
+func TestRunSearchNoLimitUsesCeiling(t *testing.T) {
+	var gotLimit int
+	withSearchList(t, func(_ data.FilterOptions, limit int) ([]data.Session, error) {
+		gotLimit = limit
+		return nil, nil
+	})
+
+	var buf bytes.Buffer
+	if err := runSearch(&buf, []string{"search", "--limit", "0"}); err != nil {
+		t.Fatalf("runSearch returned error: %v", err)
+	}
+	if gotLimit != searchAllLimit {
+		t.Errorf("limit = %d, want ceiling %d", gotLimit, searchAllLimit)
+	}
+}
+
+func TestRunSearchPropagatesStoreError(t *testing.T) {
+	withSearchList(t, func(data.FilterOptions, int) ([]data.Session, error) {
+		return nil, errors.New("store boom")
+	})
+
+	var buf bytes.Buffer
+	err := runSearch(&buf, []string{"search"})
+	if err == nil {
+		t.Fatal("runSearch returned nil error, want store error")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a headless `dispatch search` command that queries the session store and prints matching sessions as JSON, without starting the TUI. This makes session data usable from scripts, status bars, and local reports.

Closes #182

## What it does

```sh
dispatch search auth
dispatch search --query "fix login" --repo jongio/dispatch
dispatch search --branch main --since 2026-01-01 --limit 20
dispatch search --deep refactor --json
```

- Query is a positional argument or `--query`.
- Filters reuse the existing data filter and sort code: `--repo`, `--branch`, `--folder`, `--host`, `--since`, `--until`, `--deep`.
- `--limit <n>` caps results (default 50, `0` for no limit).
- Results are ordered by most recent activity first.

Each result carries `id`, `summary`, `cwd`, `repository`, `branch`, `created_at`, `updated_at`, `turn_count`, and `file_count`.

## Acceptance criteria

- [x] `dispatch search --json` returns matching sessions without starting the TUI.
- [x] Supports query, repo, branch, folder, since, until, and limit flags using existing filter code.
- [x] JSON output includes id, summary, cwd, repository, branch, created_at, updated_at, turn_count, and file_count.
- [x] Empty results exit with code 0 and print an empty JSON array.
- [x] Invalid flags or unreadable stores return a non-zero exit code with an error on stderr.

## Notes

- New command wired into `handleArgs`, `printUsage`, and all four shell completion scripts.
- README gains a "Search (JSON)" section.
- Output uses a dedicated struct so the JSON contract stays stable regardless of internal model changes.

## Testing

- `go build ./...`
- `go test ./cmd/dispatch/`
- `go vet ./...`
- `golangci-lint run`
