### PR TITLE
Detect and surface missing session workspaces

### DIFF
--- a/internal/tui/components/attentionpicker.go
+++ b/internal/tui/components/attentionpicker.go
@@ -55,18 +55,20 @@ func attentionDotStyle(status data.AttentionStatus) lipgloss.Style {
 	}
 }
 
-// totalRows returns the number of rows in the picker
-// (attention entries + plan row + favorites row + separator + 2 work status rows + git dirty row).
-func totalRows() int { return len(attentionEntries) + 1 + 1 + 1 + 2 + 1 } // +1 plan, +1 favorites, +1 separator, +2 work, +1 git
+// totalRows returns the number of rows in the picker (attention entries + plan
+// row + favorites row + separator + 2 work status rows + git dirty row +
+// missing workspace row).
+func totalRows() int { return len(attentionEntries) + 1 + 1 + 1 + 2 + 1 + 1 } // +1 plan, +1 favorites, +1 separator, +2 work, +1 git, +1 missing
 
 // Row indices for non-attention entries.
 var (
-	planRowIndex          = len(attentionEntries)
-	favoritesRowIndex     = planRowIndex + 1
-	workSeparatorRowIndex = favoritesRowIndex + 1
-	workIncompleteIndex   = workSeparatorRowIndex + 1
-	workCompleteIndex     = workIncompleteIndex + 1
-	gitDirtyRowIndex      = workCompleteIndex + 1
+	planRowIndex             = len(attentionEntries)
+	favoritesRowIndex        = planRowIndex + 1
+	workSeparatorRowIndex    = favoritesRowIndex + 1
+	workIncompleteIndex      = workSeparatorRowIndex + 1
+	workCompleteIndex        = workIncompleteIndex + 1
+	gitDirtyRowIndex         = workCompleteIndex + 1
+	missingWorkspaceRowIndex = gitDirtyRowIndex + 1
 )
 
 // AttentionPicker renders a compact overlay for selecting which attention
@@ -90,6 +92,10 @@ type AttentionPicker struct {
 	// Git workspace state filter row.
 	filterGitDirty bool // "Git changes" row checked
 	gitDirtyCount  int  // sessions with local git changes
+
+	// Missing workspace filter row.
+	filterMissingWorkspace bool // "Missing workspace" row checked
+	missingWorkspaceCount  int  // sessions whose cwd no longer exists
 
 	width  int
 	height int
@@ -158,6 +164,8 @@ func (p *AttentionPicker) Toggle() {
 		}
 	case gitDirtyRowIndex:
 		p.filterGitDirty = !p.filterGitDirty
+	case missingWorkspaceRowIndex:
+		p.filterMissingWorkspace = !p.filterMissingWorkspace
 	default:
 		// Attention status row.
 		if p.cursor < len(attentionEntries) {
@@ -196,7 +204,7 @@ func (p *AttentionPicker) SetCounts(counts map[data.AttentionStatus]int) {
 
 // HasSelection returns true when at least one filter is active.
 func (p *AttentionPicker) HasSelection() bool {
-	return len(p.selected) > 0 || p.filterPlans || p.filterFavorites || len(p.workStatusFilter) > 0 || p.filterGitDirty
+	return len(p.selected) > 0 || p.filterPlans || p.filterFavorites || len(p.workStatusFilter) > 0 || p.filterGitDirty || p.filterMissingWorkspace
 }
 
 // FilterPlans returns whether the "Has plan" row is checked.
@@ -269,6 +277,22 @@ func (p *AttentionPicker) SetFilterGitDirty(v bool) {
 // SetGitDirtyCount sets the session count shown beside the "Git changes" row.
 func (p *AttentionPicker) SetGitDirtyCount(n int) {
 	p.gitDirtyCount = n
+}
+
+// FilterMissingWorkspace returns whether the "Missing workspace" row is checked.
+func (p *AttentionPicker) FilterMissingWorkspace() bool {
+	return p.filterMissingWorkspace
+}
+
+// SetFilterMissingWorkspace sets the "Missing workspace" row state.
+func (p *AttentionPicker) SetFilterMissingWorkspace(v bool) {
+	p.filterMissingWorkspace = v
+}
+
+// SetMissingWorkspaceCount sets the session count shown beside the
+// "Missing workspace" row.
+func (p *AttentionPicker) SetMissingWorkspaceCount(n int) {
+	p.missingWorkspaceCount = n
 }
 
 // View renders the attention picker overlay.
@@ -378,6 +402,20 @@ func (p AttentionPicker) View() string {
 		dot := styles.GitDirtyStyle.Render(styles.IconGitDirty())
 		line := fmt.Sprintf("  %s %s %-16s (%d)", check, dot, "Git changes", p.gitDirtyCount)
 		if p.cursor == gitDirtyRowIndex {
+			line = styles.SelectedStyle.Render(line)
+		}
+		body.WriteString(line + "\n")
+	}
+
+	// Git workspace: missing directory.
+	{
+		check := checkboxOff
+		if p.filterMissingWorkspace {
+			check = checkboxOn
+		}
+		dot := styles.GitMissingStyle.Render(styles.IconGitMissing())
+		line := fmt.Sprintf("  %s %s %-16s (%d)", check, dot, "Missing workspace", p.missingWorkspaceCount)
+		if p.cursor == missingWorkspaceRowIndex {
 			line = styles.SelectedStyle.Render(line)
 		}
 		body.WriteString(line + "\n")

--- a/internal/tui/components/attentionpicker_test.go
+++ b/internal/tui/components/attentionpicker_test.go
@@ -123,16 +123,27 @@ func TestAttentionPicker_MoveUpDown(t *testing.T) {
 		t.Errorf("after 9th MoveDown cursor = %d, want %d (git dirty)", p.cursor, gitDirtyRowIndex)
 	}
 
+	// Next: missing workspace row.
+	p.MoveDown()
+	if p.cursor != missingWorkspaceRowIndex {
+		t.Errorf("after 10th MoveDown cursor = %d, want %d (missing workspace)", p.cursor, missingWorkspaceRowIndex)
+	}
+
 	// Wrap to top.
 	p.MoveDown()
 	if p.cursor != 0 {
 		t.Errorf("MoveDown should wrap: cursor = %d, want 0", p.cursor)
 	}
 
-	// Wrap to bottom.
+	// Wrap to bottom (missing workspace row).
+	p.MoveUp()
+	if p.cursor != missingWorkspaceRowIndex {
+		t.Errorf("MoveUp should wrap: cursor = %d, want %d", p.cursor, missingWorkspaceRowIndex)
+	}
+
 	p.MoveUp()
 	if p.cursor != gitDirtyRowIndex {
-		t.Errorf("MoveUp should wrap: cursor = %d, want %d", p.cursor, gitDirtyRowIndex)
+		t.Errorf("after MoveUp from missing workspace cursor = %d, want %d", p.cursor, gitDirtyRowIndex)
 	}
 
 	p.MoveUp()
@@ -657,5 +668,100 @@ func TestAttentionPicker_View_ContainsSeparator(t *testing.T) {
 	view := p.View()
 	if !strings.Contains(view, "───") {
 		t.Error("View should contain separator line")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Missing workspace filter row
+// ---------------------------------------------------------------------------
+
+func TestAttentionPicker_FilterMissingWorkspace_DefaultFalse(t *testing.T) {
+	t.Parallel()
+	p := NewAttentionPicker()
+	if p.FilterMissingWorkspace() {
+		t.Error("FilterMissingWorkspace should default to false")
+	}
+}
+
+func TestAttentionPicker_SetFilterMissingWorkspace(t *testing.T) {
+	t.Parallel()
+	p := NewAttentionPicker()
+	p.SetFilterMissingWorkspace(true)
+	if !p.FilterMissingWorkspace() {
+		t.Error("FilterMissingWorkspace should be true after SetFilterMissingWorkspace(true)")
+	}
+	p.SetFilterMissingWorkspace(false)
+	if p.FilterMissingWorkspace() {
+		t.Error("FilterMissingWorkspace should be false after SetFilterMissingWorkspace(false)")
+	}
+}
+
+func TestAttentionPicker_ToggleMissingWorkspaceRow(t *testing.T) {
+	t.Parallel()
+	p := NewAttentionPicker()
+
+	// Move cursor to the missing workspace row.
+	p.cursor = missingWorkspaceRowIndex
+
+	// Toggle on.
+	p.Toggle()
+	if !p.FilterMissingWorkspace() {
+		t.Error("FilterMissingWorkspace should be true after toggling missing workspace row")
+	}
+
+	// Toggle off.
+	p.Toggle()
+	if p.FilterMissingWorkspace() {
+		t.Error("FilterMissingWorkspace should be false after toggling missing workspace row again")
+	}
+}
+
+func TestAttentionPicker_ToggleMissingWorkspaceDoesNotAffectGitDirty(t *testing.T) {
+	t.Parallel()
+	p := NewAttentionPicker()
+
+	p.cursor = missingWorkspaceRowIndex
+	p.Toggle()
+
+	if p.FilterGitDirty() {
+		t.Error("toggling missing workspace should not set the git changes filter")
+	}
+	if !p.FilterMissingWorkspace() {
+		t.Error("missing workspace filter should be set")
+	}
+}
+
+func TestAttentionPicker_HasSelection_IncludesMissingWorkspace(t *testing.T) {
+	t.Parallel()
+	p := NewAttentionPicker()
+	if p.HasSelection() {
+		t.Error("empty picker should have no selection")
+	}
+	p.SetFilterMissingWorkspace(true)
+	if !p.HasSelection() {
+		t.Error("HasSelection should be true when filterMissingWorkspace is set")
+	}
+}
+
+func TestAttentionPicker_SetMissingWorkspaceCount(t *testing.T) {
+	t.Parallel()
+	p := NewAttentionPicker()
+	p.SetMissingWorkspaceCount(3)
+	if p.missingWorkspaceCount != 3 {
+		t.Errorf("missingWorkspaceCount = %d, want 3", p.missingWorkspaceCount)
+	}
+}
+
+func TestAttentionPicker_View_ContainsMissingWorkspaceRow(t *testing.T) {
+	t.Parallel()
+	p := NewAttentionPicker()
+	p.SetSize(80, 40)
+	p.SetMissingWorkspaceCount(2)
+	view := p.View()
+	if !strings.Contains(view, "Missing workspace") {
+		t.Error("View should contain 'Missing workspace' label")
+	}
+	if !strings.Contains(view, "(2)") {
+		t.Error("View should contain missing workspace count (2)")
 	}
 }

--- a/internal/tui/components/preview.go
+++ b/internal/tui/components/preview.go
@@ -15,22 +15,23 @@ import (
 
 // PreviewPanel renders a detail panel for the selected session.
 type PreviewPanel struct {
-	detail          *data.SessionDetail
-	attentionStatus data.AttentionStatus
-	note            string // user note for the current session
-	alias           string // user-chosen alias for the current session
-	width           int
-	height          int
-	scroll          int
-	totalLines      int                   // cached line count for scroll clamping
-	newestFirst     bool                  // conversation turn display order
-	redactSecrets   bool                  // mask common secret patterns in turn text
-	convHeaderLine  int                   // content line where "Conversation" label is rendered (-1 = none)
-	idFieldLine     int                   // content line where "ID: ..." is rendered (-1 = none)
-	planContent     string                // plan.md content (empty when no plan)
-	planViewMode    bool                  // when true, render plan instead of session detail
-	hasPlan         bool                  // whether the session has a plan.md file
-	workStatus      data.WorkStatusResult // current session's work status
+	detail           *data.SessionDetail
+	attentionStatus  data.AttentionStatus
+	note             string // user note for the current session
+	alias            string // user-chosen alias for the current session
+	width            int
+	height           int
+	scroll           int
+	totalLines       int                   // cached line count for scroll clamping
+	newestFirst      bool                  // conversation turn display order
+	redactSecrets    bool                  // mask common secret patterns in turn text
+	convHeaderLine   int                   // content line where "Conversation" label is rendered (-1 = none)
+	idFieldLine      int                   // content line where "ID: ..." is rendered (-1 = none)
+	planContent      string                // plan.md content (empty when no plan)
+	planViewMode     bool                  // when true, render plan instead of session detail
+	hasPlan          bool                  // whether the session has a plan.md file
+	workStatus       data.WorkStatusResult // current session's work status
+	workspaceMissing bool                  // true when the session cwd no longer exists on disk
 
 	timelineMode bool // when true, render activity timeline instead of session detail
 
@@ -102,6 +103,13 @@ func (p *PreviewPanel) SetAlias(alias string) {
 // SetAttentionStatus updates the attention status shown in the preview.
 func (p *PreviewPanel) SetAttentionStatus(status data.AttentionStatus) {
 	p.attentionStatus = status
+	p.updateTotalLines()
+}
+
+// SetWorkspaceMissing sets whether the current session's working directory is
+// missing from disk. When true, the preview shows a Missing workspace badge.
+func (p *PreviewPanel) SetWorkspaceMissing(missing bool) {
+	p.workspaceMissing = missing
 	p.updateTotalLines()
 }
 
@@ -613,6 +621,10 @@ func (p PreviewPanel) renderContent() (string, int, int) {
 	idLine := strings.Count(b.String(), "\n")
 	field("ID", s.ID)
 	field("Folder", AbbrevPath(s.Cwd))
+	if p.workspaceMissing {
+		wl := styles.PreviewLabelStyle.Render("Workspace: ")
+		b.WriteString(wl + styles.GitMissingStyle.Render(styles.IconGitMissing()+" Missing") + "\n")
+	}
 
 	if s.Repository != "" {
 		field("Repo", s.Repository)

--- a/internal/tui/components/preview_test.go
+++ b/internal/tui/components/preview_test.go
@@ -382,6 +382,38 @@ func TestPreviewPanelViewWithDetail(t *testing.T) {
 	}
 }
 
+func TestPreviewPanelViewWorkspaceMissingBadge(t *testing.T) {
+	t.Parallel()
+	p := NewPreviewPanel()
+	p.SetSize(80, 40)
+
+	detail := &data.SessionDetail{
+		Session: data.Session{ID: "abc123", Cwd: "/home/user/gone", TurnCount: 1},
+		Turns:   []data.Turn{{UserMessage: "hi", AssistantResponse: "hello"}},
+	}
+	p.SetDetail(detail)
+
+	// Without the flag, no workspace badge.
+	if strings.Contains(p.View(), "Workspace:") {
+		t.Error("View should not show a Workspace badge before SetWorkspaceMissing(true)")
+	}
+
+	p.SetWorkspaceMissing(true)
+	got := p.View()
+	if !strings.Contains(got, "Workspace:") {
+		t.Error("View should show a Workspace label when the workspace is missing")
+	}
+	if !strings.Contains(got, "Missing") {
+		t.Error("View should show 'Missing' when the workspace is missing")
+	}
+
+	// Clearing the flag removes the badge again.
+	p.SetWorkspaceMissing(false)
+	if strings.Contains(p.View(), "Workspace:") {
+		t.Error("View should not show a Workspace badge after SetWorkspaceMissing(false)")
+	}
+}
+
 func TestPreviewPanelViewShowsAllTurns(t *testing.T) {
 	t.Parallel()
 	p := NewPreviewPanel()

--- a/internal/tui/handlers.go
+++ b/internal/tui/handlers.go
@@ -298,6 +298,7 @@ func (m Model) handleSessionDetail(msg sessionDetailMsg) (Model, tea.Cmd) {
 	}
 	m.preview.SetAlias(m.cfg.AliasFor(m.detail.Session.ID))
 	m.preview.SetAttentionStatus(m.attentionStatusForSession(m.detail.Session.ID))
+	m.syncPreviewWorkspaceMissing()
 	m.preview.SetHasPlan(m.planMap[m.detail.Session.ID])
 	if result, ok := m.workStatus.workStatusMap[m.detail.Session.ID]; ok {
 		m.preview.SetWorkStatus(result)
@@ -615,9 +616,10 @@ func (m Model) handleContinuationPlanCreated(msg continuationPlanCreatedMsg) (Mo
 func (m Model) handleGitStateScanned(msg gitStateScannedMsg) (Model, tea.Cmd) {
 	m.gitStateMap = msg.states
 	m.sessionList.SetGitStates(m.gitStateMap)
-	// When the git-dirty filter is active, reload sessions so the list
+	m.syncPreviewWorkspaceMissing()
+	// When a git-state filter is active, reload sessions so the list
 	// reflects the detected states.
-	if m.filterGitDirty {
+	if m.filterGitDirty || m.filterMissingWorkspace {
 		return m, m.loadSessionsCmd()
 	}
 	return m, nil

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -390,6 +390,9 @@ type Model struct {
 	// Git workspace state tracking — scanned from session directories.
 	gitStateMap    map[string]platform.GitState
 	filterGitDirty bool // when true, only show sessions with local git changes
+	// filterMissingWorkspace, when true, shows only sessions whose working
+	// directory no longer exists on disk.
+	filterMissingWorkspace bool
 
 	// DB watcher — monitors session-store.db for external modifications.
 	dbWatcher *data.DBWatcher
@@ -929,6 +932,7 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.sessionList.SetFavoritedSessions(m.favoritedSet)
 			m.workStatus.filterWorkStatus = m.attentionPicker.WorkStatusFilter()
 			m.filterGitDirty = m.attentionPicker.FilterGitDirty()
+			m.filterMissingWorkspace = m.attentionPicker.FilterMissingWorkspace()
 			m.state = stateSessionList
 			return m, m.loadSessionsCmd()
 		}
@@ -1578,6 +1582,8 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.attentionPicker.SetWorkStatusScanned(m.workStatus.workStatusScanned)
 		m.attentionPicker.SetFilterGitDirty(m.filterGitDirty)
 		m.attentionPicker.SetGitDirtyCount(m.gitDirtySessionCount())
+		m.attentionPicker.SetFilterMissingWorkspace(m.filterMissingWorkspace)
+		m.attentionPicker.SetMissingWorkspaceCount(m.missingWorkspaceSessionCount())
 		m.attentionPicker.SetSize(m.width, m.height)
 		m.state = stateAttentionPicker
 		return m, nil
@@ -2467,6 +2473,8 @@ func (m Model) handleFooterClick(x int) (tea.Model, tea.Cmd) {
 		m.attentionPicker.SetWorkStatusScanned(m.workStatus.workStatusScanned)
 		m.attentionPicker.SetFilterGitDirty(m.filterGitDirty)
 		m.attentionPicker.SetGitDirtyCount(m.gitDirtySessionCount())
+		m.attentionPicker.SetFilterMissingWorkspace(m.filterMissingWorkspace)
+		m.attentionPicker.SetMissingWorkspaceCount(m.missingWorkspaceSessionCount())
 		m.attentionPicker.SetSize(m.width, m.height)
 		m.state = stateAttentionPicker
 		return m, nil
@@ -2879,6 +2887,9 @@ func (m Model) renderFooter() string {
 	if m.filterGitDirty {
 		left += "  " + styles.ActiveBadgeStyle.Render("! git changes")
 	}
+	if m.filterMissingWorkspace {
+		left += "  " + styles.ActiveBadgeStyle.Render("! missing workspace")
+	}
 	if len(m.workStatus.filterWorkStatus) > 0 {
 		var wsNames []string
 		if _, ok := m.workStatus.filterWorkStatus[data.WorkStatusIncomplete]; ok {
@@ -3075,6 +3086,17 @@ func filterGroupsWhere(groups []data.SessionGroup, pred func(data.Session) bool)
 // Session list synchronisation helpers
 // ---------------------------------------------------------------------------
 
+// syncPreviewWorkspaceMissing updates the preview's missing-workspace badge from
+// the currently loaded detail and the most recent git-state scan. Safe to call
+// when no detail is loaded.
+func (m *Model) syncPreviewWorkspaceMissing() {
+	if m.detail == nil {
+		m.preview.SetWorkspaceMissing(false)
+		return
+	}
+	m.preview.SetWorkspaceMissing(m.gitStateMap[m.detail.Session.ID] == platform.GitStateMissing)
+}
+
 // syncSessionListStatuses pushes all current status maps (hidden, favorited,
 // attention, plan, work status) to the sessionList component. Call this after
 // loading or filtering sessions/groups to keep the list's decorations in sync.
@@ -3108,6 +3130,7 @@ func (m *Model) applySessionFilters(sessions []data.Session) []data.Session {
 	sessions = m.filterPlanSessions(sessions)
 	sessions = m.filterWorkStatusSessions(sessions)
 	sessions = m.filterGitDirtySessions(sessions)
+	sessions = m.filterMissingWorkspaceSessions(sessions)
 	sessions = m.filterTaggedSessions(sessions)
 	return sessions
 }
@@ -3121,6 +3144,7 @@ func (m *Model) applyGroupFilters(groups []data.SessionGroup) []data.SessionGrou
 	groups = m.filterPlanGroups(groups)
 	groups = m.filterWorkStatusGroups(groups)
 	groups = m.filterGitDirtyGroups(groups)
+	groups = m.filterMissingWorkspaceGroups(groups)
 	groups = m.filterTaggedGroups(groups)
 	return groups
 }
@@ -3334,6 +3358,29 @@ func (m *Model) filterGitDirtyGroups(groups []data.SessionGroup) []data.SessionG
 	})
 }
 
+// filterMissingWorkspaceSessions keeps only sessions whose working directory no
+// longer exists on disk (GitStateMissing) when filterMissingWorkspace is active.
+func (m *Model) filterMissingWorkspaceSessions(sessions []data.Session) []data.Session {
+	if !m.filterMissingWorkspace || len(m.gitStateMap) == 0 {
+		return sessions
+	}
+	return filterSessionsWhere(sessions, func(s data.Session) bool {
+		return m.gitStateMap[s.ID] == platform.GitStateMissing
+	})
+}
+
+// filterMissingWorkspaceGroups removes sessions whose working directory still
+// exists from grouped results when filterMissingWorkspace is active. Empty
+// groups are dropped.
+func (m *Model) filterMissingWorkspaceGroups(groups []data.SessionGroup) []data.SessionGroup {
+	if !m.filterMissingWorkspace || len(m.gitStateMap) == 0 {
+		return groups
+	}
+	return filterGroupsWhere(groups, func(s data.Session) bool {
+		return m.gitStateMap[s.ID] == platform.GitStateMissing
+	})
+}
+
 // sortByAttention re-sorts the session slice by attention status when the
 // current sort field is SortByAttention. Attention priority is:
 // Waiting (3) > Active (2) > Stale (1) > Idle (0). Sessions with higher
@@ -3514,6 +3561,14 @@ func (m *Model) launchSelected() tea.Cmd {
 	return m.launchWithMode(m.cfg.EffectiveLaunchMode())
 }
 
+// sessionWorkspaceMissing reports whether the given session's working directory
+// was detected as missing on disk by the most recent git-state scan. When no
+// scan has run yet the session is treated as present so launches are not
+// blocked spuriously.
+func (m *Model) sessionWorkspaceMissing(id string) bool {
+	return m.gitStateMap[id] == platform.GitStateMissing
+}
+
 // launchMultiple opens multiple sessions at once. It resolves which sessions
 // to open based on the current state:
 //  1. If sessions are explicitly selected (checkmarked), open those.
@@ -3569,7 +3624,12 @@ func (m *Model) batchLaunchSessions(sessions []data.Session, mode string) tea.Cm
 		m.statusInfo = fmt.Sprintf("Launching first %d sessions (limit)", maxBatchLaunch)
 	}
 	var cmds []tea.Cmd
+	skipped := 0
 	for _, sess := range sessions {
+		if m.sessionWorkspaceMissing(sess.ID) {
+			skipped++
+			continue
+		}
 		cmd := m.resolveShellAndLaunchDirect(sess.ID, sess.Cwd, mode)
 		if cmd != nil {
 			cmds = append(cmds, cmd)
@@ -3578,6 +3638,9 @@ func (m *Model) batchLaunchSessions(sessions []data.Session, mode string) tea.Cm
 
 	// Keep selections intact after launch — user can deselect with 'd'.
 	m.statusInfo = ""
+	if skipped > 0 {
+		m.statusErr = fmt.Sprintf("Skipped %d session(s): workspace folder no longer exists", skipped)
+	}
 
 	if len(cmds) == 0 {
 		return nil
@@ -3598,6 +3661,10 @@ func (m *Model) updateSelectionStatus() {
 func (m *Model) launchWithMode(mode string) tea.Cmd {
 	sess, ok := m.sessionList.Selected()
 	if !ok {
+		return nil
+	}
+	if m.sessionWorkspaceMissing(sess.ID) {
+		m.statusErr = "Cannot launch: workspace folder no longer exists"
 		return nil
 	}
 	if mode == config.LaunchModeInPlace {
@@ -4323,6 +4390,18 @@ func (m Model) gitDirtySessionCount() int {
 			n++
 		case platform.GitStateUnknown, platform.GitStateClean, platform.GitStateMissing:
 			// Not counted as "dirty".
+		}
+	}
+	return n
+}
+
+// missingWorkspaceSessionCount returns the number of sessions whose working
+// directory no longer exists on disk.
+func (m Model) missingWorkspaceSessionCount() int {
+	n := 0
+	for _, state := range m.gitStateMap {
+		if state == platform.GitStateMissing {
+			n++
 		}
 	}
 	return n

--- a/internal/tui/model_missing_workspace_test.go
+++ b/internal/tui/model_missing_workspace_test.go
@@ -1,0 +1,222 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/jongio/dispatch/internal/config"
+	"github.com/jongio/dispatch/internal/data"
+	"github.com/jongio/dispatch/internal/platform"
+)
+
+const missingWorkspaceLaunchErr = "Cannot launch: workspace folder no longer exists"
+
+// ---------------------------------------------------------------------------
+// sessionWorkspaceMissing — reads the scanned git-state map.
+// ---------------------------------------------------------------------------
+
+func TestSessionWorkspaceMissing(t *testing.T) {
+	m := newTestModel()
+	m.gitStateMap = map[string]platform.GitState{
+		"missing": platform.GitStateMissing,
+		"clean":   platform.GitStateClean,
+		"dirty":   platform.GitStateDirty,
+	}
+
+	if !m.sessionWorkspaceMissing("missing") {
+		t.Error("session with GitStateMissing should be reported missing")
+	}
+	if m.sessionWorkspaceMissing("clean") {
+		t.Error("session with GitStateClean should not be reported missing")
+	}
+	if m.sessionWorkspaceMissing("dirty") {
+		t.Error("session with GitStateDirty should not be reported missing")
+	}
+	if m.sessionWorkspaceMissing("unknown") {
+		t.Error("session absent from the map should not be reported missing")
+	}
+}
+
+func TestSessionWorkspaceMissing_NilMap(t *testing.T) {
+	m := newTestModel()
+	// gitStateMap is nil before any scan has run.
+	if m.sessionWorkspaceMissing("anything") {
+		t.Error("with no scan yet, no session should be reported missing")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// missingWorkspaceSessionCount
+// ---------------------------------------------------------------------------
+
+func TestMissingWorkspaceSessionCount(t *testing.T) {
+	m := newTestModel()
+	if got := m.missingWorkspaceSessionCount(); got != 0 {
+		t.Errorf("count with nil map = %d, want 0", got)
+	}
+
+	m.gitStateMap = map[string]platform.GitState{
+		"a": platform.GitStateMissing,
+		"b": platform.GitStateMissing,
+		"c": platform.GitStateClean,
+		"d": platform.GitStateDirty,
+	}
+	if got := m.missingWorkspaceSessionCount(); got != 2 {
+		t.Errorf("count = %d, want 2", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// filterMissingWorkspaceSessions / Groups
+// ---------------------------------------------------------------------------
+
+func TestFilterMissingWorkspaceSessions(t *testing.T) {
+	m := newTestModel()
+	sessions := []data.Session{
+		{ID: "gone", Cwd: "/removed"},
+		{ID: "here", Cwd: "/present"},
+		{ID: "empty", Cwd: ""},
+	}
+	m.gitStateMap = map[string]platform.GitState{
+		"gone": platform.GitStateMissing,
+		"here": platform.GitStateClean,
+	}
+
+	// Filter inactive: input returned unchanged.
+	if got := m.filterMissingWorkspaceSessions(sessions); len(got) != 3 {
+		t.Errorf("inactive filter returned %d sessions, want 3", len(got))
+	}
+
+	// Filter active: only the missing session survives.
+	m.filterMissingWorkspace = true
+	got := m.filterMissingWorkspaceSessions(sessions)
+	if len(got) != 1 {
+		t.Fatalf("active filter returned %d sessions, want 1", len(got))
+	}
+	if got[0].ID != "gone" {
+		t.Errorf("active filter kept %q, want %q", got[0].ID, "gone")
+	}
+}
+
+func TestFilterMissingWorkspaceSessions_ActiveEmptyMap(t *testing.T) {
+	m := newTestModel()
+	m.filterMissingWorkspace = true
+	sessions := []data.Session{{ID: "a", Cwd: "/a"}}
+	// No scan has populated the map yet; return sessions unchanged rather
+	// than hiding everything.
+	if got := m.filterMissingWorkspaceSessions(sessions); len(got) != 1 {
+		t.Errorf("active filter with empty map returned %d, want 1", len(got))
+	}
+}
+
+func TestFilterMissingWorkspaceGroups(t *testing.T) {
+	m := newTestModel()
+	m.filterMissingWorkspace = true
+	m.gitStateMap = map[string]platform.GitState{
+		"gone": platform.GitStateMissing,
+		"here": platform.GitStateClean,
+	}
+	groups := []data.SessionGroup{
+		{
+			Label: "/repo",
+			Sessions: []data.Session{
+				{ID: "gone", Cwd: "/removed"},
+				{ID: "here", Cwd: "/present"},
+			},
+		},
+		{
+			Label: "/other",
+			Sessions: []data.Session{
+				{ID: "here", Cwd: "/present"},
+			},
+		},
+	}
+
+	got := m.filterMissingWorkspaceGroups(groups)
+	if len(got) != 1 {
+		t.Fatalf("filtered groups = %d, want 1", len(got))
+	}
+	if len(got[0].Sessions) != 1 || got[0].Sessions[0].ID != "gone" {
+		t.Errorf("filtered group should keep only the missing session, got %+v", got[0].Sessions)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Launch guard — single and batch.
+// ---------------------------------------------------------------------------
+
+func TestLaunchWithMode_BlocksMissingWorkspace(t *testing.T) {
+	m := newTestModelWithSize(120, 30)
+	m.sessions = []data.Session{{ID: "s1", Cwd: "/removed"}}
+	m.sessionList.SetSessions(m.sessions)
+	m.gitStateMap = map[string]platform.GitState{"s1": platform.GitStateMissing}
+
+	cmd := m.launchWithMode(config.LaunchModeTab)
+	if cmd != nil {
+		t.Error("launchWithMode should return nil for a missing workspace")
+	}
+	if m.statusErr != missingWorkspaceLaunchErr {
+		t.Errorf("statusErr = %q, want %q", m.statusErr, missingWorkspaceLaunchErr)
+	}
+}
+
+func TestLaunchWithMode_AllowsPresentWorkspace(t *testing.T) {
+	m := newTestModelWithSize(120, 30)
+	m.sessions = []data.Session{{ID: "s1", Cwd: "/present"}}
+	m.sessionList.SetSessions(m.sessions)
+	m.gitStateMap = map[string]platform.GitState{"s1": platform.GitStateClean}
+
+	m.launchWithMode(config.LaunchModeTab)
+	// The missing-workspace guard must not fire for a present workspace.
+	if m.statusErr == missingWorkspaceLaunchErr {
+		t.Error("present workspace should not trigger the missing-workspace guard")
+	}
+}
+
+func TestLaunchWithMode_EmptyCwdNotBlocked(t *testing.T) {
+	m := newTestModelWithSize(120, 30)
+	m.sessions = []data.Session{{ID: "s1", Cwd: ""}}
+	m.sessionList.SetSessions(m.sessions)
+	// Empty-cwd sessions are skipped by the scan and never flagged missing.
+	m.gitStateMap = map[string]platform.GitState{}
+
+	m.launchWithMode(config.LaunchModeTab)
+	if m.statusErr == missingWorkspaceLaunchErr {
+		t.Error("empty cwd should not trigger the missing-workspace guard")
+	}
+}
+
+func TestBatchLaunchSessions_SkipsMissingWorkspaces(t *testing.T) {
+	m := newTestModelWithSize(120, 30)
+	sessions := []data.Session{
+		{ID: "gone", Cwd: "/removed"},
+		{ID: "here", Cwd: "/present"},
+	}
+	m.gitStateMap = map[string]platform.GitState{
+		"gone": platform.GitStateMissing,
+		"here": platform.GitStateClean,
+	}
+
+	m.batchLaunchSessions(sessions, config.LaunchModeTab)
+	if m.statusErr == "" {
+		t.Fatal("batchLaunchSessions should report skipped missing workspaces")
+	}
+	if want := "Skipped 1 session(s): workspace folder no longer exists"; m.statusErr != want {
+		t.Errorf("statusErr = %q, want %q", m.statusErr, want)
+	}
+}
+
+func TestBatchLaunchSessions_AllMissingReturnsNil(t *testing.T) {
+	m := newTestModelWithSize(120, 30)
+	sessions := []data.Session{
+		{ID: "a", Cwd: "/removed-a"},
+		{ID: "b", Cwd: "/removed-b"},
+	}
+	m.gitStateMap = map[string]platform.GitState{
+		"a": platform.GitStateMissing,
+		"b": platform.GitStateMissing,
+	}
+
+	if cmd := m.batchLaunchSessions(sessions, config.LaunchModeTab); cmd != nil {
+		t.Error("batchLaunchSessions should return nil when every session is missing")
+	}
+}


### PR DESCRIPTION
## What

Surface sessions whose working directory no longer exists on disk, and stop launches from starting a terminal in a path that is gone.

This happens often with git worktrees: you remove a worktree, but the session that pointed at it stays in the list. Selecting it and pressing Enter used to try to start a shell in a directory that no longer exists.

Closes #184.

## Changes

- **Filter row**: added a "Missing workspace" row to the session status filter picker (next to "Git changes"), with a live count. Toggle it to show only sessions whose folder is gone.
- **Preview badge**: the detail preview now shows a `Workspace: Missing` line for the selected session when its folder no longer exists.
- **Launch guard**:
  - Single launch (Enter) is blocked with the message `Cannot launch: workspace folder no longer exists`.
  - Batch launch skips missing sessions and reports `Skipped N session(s): workspace folder no longer exists`, so the rest still open.

All four surfaces read the existing async git-state scan (`GitStateMissing`), which already powers the session-list badge. That keeps everything consistent and means the state refreshes on reload. Sessions with an empty working directory are treated as present, so folder-only launches are unaffected.

## Tests

- Picker: default-off, toggle, accessors, `HasSelection`, count, and view rendering for the new row.
- Model: `sessionWorkspaceMissing`, `missingWorkspaceSessionCount`, `filterMissingWorkspaceSessions`/`Groups`, and the launch guards (single blocked, present allowed, empty cwd allowed, batch skip count, all-missing returns nil).
- Preview: the `Workspace: Missing` badge shows only when the flag is set.

## Verification

- `go build ./...`
- `go test ./... -count=1`
- `go vet ./...`
- `golangci-lint run` (v2.12.2)

All pass.
