### PR TITLE
Add 'config edit' to open the config file in your editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,10 +384,11 @@ dispatch config list            # print every setting and its value
 dispatch config list --json     # same, as a single JSON object
 dispatch config get launch_mode # print one value
 dispatch config set launch_mode window
+dispatch config edit            # open the config file in your editor
 dispatch config path            # print the config file path
 ```
 
-`set` validates the value and writes through the same save path the TUI uses, so migrations and checks still run. Unknown keys and invalid values exit non-zero with a clear message. The keys match the option names in the table below. Set `auto_refresh_seconds` to `default` to clear it back to unset.
+`set` validates the value and writes through the same save path the TUI uses, so migrations and checks still run. Unknown keys and invalid values exit non-zero with a clear message. The keys match the option names in the table below. Set `auto_refresh_seconds` to `default` to clear it back to unset. `edit` opens the file in `$VISUAL` or `$EDITOR` (falling back to a platform default) and re-checks it after you save, which is handy for list and map settings that `set` does not cover.
 
 ### Options
 

--- a/cmd/dispatch/cli.go
+++ b/cmd/dispatch/cli.go
@@ -218,7 +218,7 @@ _dispatch_completion() {
   fi
 
   if [[ "${COMP_WORDS[1]}" == "config" ]]; then
-    COMPREPLY=( $(compgen -W "list get set path" -- "${cur}") )
+    COMPREPLY=( $(compgen -W "list get set edit path" -- "${cur}") )
     return 0
   fi
 }
@@ -230,7 +230,7 @@ _dispatch_completion() {
   local -a commands shells flags configsubs
   commands=(help version open new doctor update completion stats config export)
   shells=(bash zsh fish powershell)
-  configsubs=(list get set path)
+  configsubs=(list get set edit path)
   flags=(-h --help -v --version --demo --clear-cache --reindex)
 
   if (( CURRENT == 2 )); then
@@ -274,7 +274,7 @@ const powershellCompletionScript = `# PowerShell completion for dispatch
 $script:DispatchCommands = @('help', 'version', 'open', 'new', 'doctor', 'update', 'completion', 'stats', 'config', 'export')
 $script:DispatchFlags = @('-h', '--help', '-v', '--version', '--demo', '--clear-cache', '--reindex')
 $script:DispatchShells = @('bash', 'zsh', 'fish', 'powershell')
-$script:DispatchConfigSubcommands = @('list', 'get', 'set', 'path')
+$script:DispatchConfigSubcommands = @('list', 'get', 'set', 'edit', 'path')
 
 Register-ArgumentCompleter -Native -CommandName dispatch, disp -ScriptBlock {
     param($wordToComplete, $commandAst, $cursorPosition)

--- a/cmd/dispatch/config.go
+++ b/cmd/dispatch/config.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"os/exec"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -20,6 +24,10 @@ var (
 	configSaveFn = config.Save
 	configPathFn = config.ConfigPath
 )
+
+// editorLauncher opens the given file in the user's editor and waits for it to
+// exit. It is a package variable so tests can substitute the launch.
+var editorLauncher = launchEditor
 
 // configFieldKind labels the value type of a settable preference so list and
 // JSON output can render it correctly and set can parse the value.
@@ -243,10 +251,12 @@ func runConfig(w io.Writer, args []string) error {
 		return runConfigGet(w, rest)
 	case "set":
 		return runConfigSet(w, rest)
+	case "edit":
+		return runConfigEdit(w, rest)
 	case "path":
 		return runConfigPath(w, rest)
 	default:
-		return fmt.Errorf("unknown config subcommand %q (want list, get, set, or path)", sub)
+		return fmt.Errorf("unknown config subcommand %q (want list, get, set, edit, or path)", sub)
 	}
 }
 
@@ -355,6 +365,71 @@ func runConfigPath(w io.Writer, args []string) error {
 	}
 	fmt.Fprintln(w, path)
 	return nil
+}
+
+// runConfigEdit opens the config file in the user's editor. It writes the
+// current values first so the editor always opens a real file (the file may
+// not exist yet on a fresh install), then re-reads the file after the editor
+// exits so an unparseable edit is reported instead of silently breaking the
+// config.
+func runConfigEdit(w io.Writer, args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("config edit does not take arguments, got %q", args[0])
+	}
+
+	cfg, err := configLoadFn()
+	if err != nil {
+		return err
+	}
+	if err := configSaveFn(cfg); err != nil {
+		return err
+	}
+
+	path, err := configPathFn()
+	if err != nil {
+		return err
+	}
+
+	if err := editorLauncher(path); err != nil {
+		return fmt.Errorf("running editor: %w", err)
+	}
+
+	if _, err := configLoadFn(); err != nil {
+		return fmt.Errorf("config is no longer valid after editing: %w", err)
+	}
+
+	fmt.Fprintf(w, "Saved %s\n", path)
+	return nil
+}
+
+// resolveEditorArgv returns the editor command and any leading arguments,
+// preferring $VISUAL, then $EDITOR, then a platform default. The value is split
+// on whitespace so entries like "code --wait" keep their flags.
+func resolveEditorArgv(getenv func(string) string) []string {
+	for _, key := range []string{"VISUAL", "EDITOR"} {
+		if v := strings.TrimSpace(getenv(key)); v != "" {
+			return strings.Fields(v)
+		}
+	}
+	if runtime.GOOS == "windows" {
+		return []string{"notepad"}
+	}
+	return []string{"vi"}
+}
+
+// launchEditor runs the resolved editor against path, wired to the current
+// terminal, and waits for it to exit.
+func launchEditor(path string) error {
+	argv := resolveEditorArgv(os.Getenv)
+	cmdArgs := make([]string, 0, len(argv))
+	cmdArgs = append(cmdArgs, argv[1:]...)
+	cmdArgs = append(cmdArgs, path)
+
+	cmd := exec.CommandContext(context.Background(), argv[0], cmdArgs...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }
 
 // fieldJSONValue returns the setting value typed for JSON output: bool as a

--- a/cmd/dispatch/config_test.go
+++ b/cmd/dispatch/config_test.go
@@ -279,6 +279,95 @@ func TestRunConfig_UnknownSubcommand(t *testing.T) {
 	}
 }
 
+// withEditorLauncher substitutes the editor-launch seam for a test.
+func withEditorLauncher(t *testing.T, fn func(string) error) {
+	t.Helper()
+	prev := editorLauncher
+	editorLauncher = fn
+	t.Cleanup(func() { editorLauncher = prev })
+}
+
+func TestRunConfigEdit_Success(t *testing.T) {
+	withConfigSeams(t, config.Default())
+	launched := ""
+	withEditorLauncher(t, func(path string) error {
+		launched = path
+		return nil
+	})
+
+	var buf bytes.Buffer
+	if err := runConfig(&buf, []string{"config", "edit"}); err != nil {
+		t.Fatalf("runConfig edit: %v", err)
+	}
+	if launched != "/tmp/dispatch/config.json" {
+		t.Errorf("editor launched with %q, want the config path", launched)
+	}
+	if !strings.Contains(buf.String(), "Saved /tmp/dispatch/config.json") {
+		t.Errorf("output missing Saved line: %q", buf.String())
+	}
+}
+
+func TestRunConfigEdit_RejectsArgs(t *testing.T) {
+	withConfigSeams(t, config.Default())
+	withEditorLauncher(t, func(string) error { return nil })
+	err := runConfig(&bytes.Buffer{}, []string{"config", "edit", "extra"})
+	if err == nil || !strings.Contains(err.Error(), "does not take arguments") {
+		t.Fatalf("error = %v, want arguments rejected", err)
+	}
+}
+
+func TestRunConfigEdit_EditorError(t *testing.T) {
+	withConfigSeams(t, config.Default())
+	withEditorLauncher(t, func(string) error { return errors.New("boom") })
+	err := runConfig(&bytes.Buffer{}, []string{"config", "edit"})
+	if err == nil || !strings.Contains(err.Error(), "running editor") {
+		t.Fatalf("error = %v, want running editor error", err)
+	}
+}
+
+func TestRunConfigEdit_InvalidAfterEdit(t *testing.T) {
+	prevLoad, prevSave, prevPath := configLoadFn, configSaveFn, configPathFn
+	calls := 0
+	configLoadFn = func() (*config.Config, error) {
+		calls++
+		if calls >= 2 {
+			return nil, errors.New("parsing config: unexpected end of JSON input")
+		}
+		return config.Default(), nil
+	}
+	configSaveFn = func(*config.Config) error { return nil }
+	configPathFn = func() (string, error) { return "/tmp/dispatch/config.json", nil }
+	t.Cleanup(func() { configLoadFn, configSaveFn, configPathFn = prevLoad, prevSave, prevPath })
+	withEditorLauncher(t, func(string) error { return nil })
+
+	err := runConfig(&bytes.Buffer{}, []string{"config", "edit"})
+	if err == nil || !strings.Contains(err.Error(), "no longer valid") {
+		t.Fatalf("error = %v, want no longer valid error", err)
+	}
+}
+
+func TestResolveEditorArgv(t *testing.T) {
+	// VISUAL wins over EDITOR and is split into command + args.
+	env := map[string]string{"VISUAL": "code --wait", "EDITOR": "nano"}
+	got := resolveEditorArgv(func(k string) string { return env[k] })
+	if len(got) != 2 || got[0] != "code" || got[1] != "--wait" {
+		t.Errorf("VISUAL argv = %v, want [code --wait]", got)
+	}
+
+	// EDITOR is used when VISUAL is unset.
+	env = map[string]string{"EDITOR": "nano"}
+	got = resolveEditorArgv(func(k string) string { return env[k] })
+	if len(got) != 1 || got[0] != "nano" {
+		t.Errorf("EDITOR argv = %v, want [nano]", got)
+	}
+
+	// A platform default is returned when neither is set.
+	got = resolveEditorArgv(func(string) string { return "" })
+	if len(got) == 0 || got[0] == "" {
+		t.Errorf("default argv = %v, want a non-empty editor", got)
+	}
+}
+
 func TestConfigFields_RoundTrip(t *testing.T) {
 	// Every field's get must return a value its own set accepts, so a
 	// list -> set loop never rejects a value dispatch itself produced.

--- a/cmd/dispatch/main.go
+++ b/cmd/dispatch/main.go
@@ -98,7 +98,7 @@ Commands:
   completion <shell>      Print shell completion (bash, zsh, fish, powershell)
   doctor [--json]         Print environment diagnostics (--json for machine-readable output)
   stats [flags]           Print session totals and breakdowns
-  config [get|set|list|path]
+  config [get|set|list|edit|path]
                           Read or change preferences (see Config commands)
   export <id> [flags]     Export a session as Markdown or JSON
   update                  Update dispatch to the latest release
@@ -116,6 +116,7 @@ Config commands:
   config list [--json]    Print every setting and its value
   config get <key>        Print one setting value
   config set <key> <val>  Validate and save one setting
+  config edit             Open the config file in your editor
   config path             Print the config file path
 
 Export flags:


### PR DESCRIPTION
## What

Adds a `dispatch config edit` subcommand that opens the config file in your editor.

```
dispatch config edit
```

It writes the current config to disk first (so the file always exists, even on a
fresh install), opens it in your editor, and then re-reads the file after the
editor exits. If the edit left the file unparseable, the error is reported
instead of being silently applied.

## Why

Today the only way to change settings is one `config set key value` call at a
time, or hunting down the file path with `config path` and opening it by hand.
For anyone who wants to review or change several settings at once, opening the
file directly is faster. This lines up with how tools like `git config --edit`
and `gh config` behave.

## Editor resolution

1. `$VISUAL`
2. `$EDITOR`
3. Platform default: `notepad` on Windows, `vi` elsewhere

The editor value is split on whitespace, so entries like `code --wait` keep
their flags.

## Changes

- New `runConfigEdit` handler plus `resolveEditorArgv` / `launchEditor` helpers in `cmd/dispatch/config.go`
- Help text updated in `cmd/dispatch/main.go`
- Shell completions (bash, zsh, powershell) updated in `cmd/dispatch/cli.go`
- README example added
- Tests covering success, argument rejection, editor failure, post-edit validation, and editor resolution

## Testing

- `go build ./...`
- `go test ./... -count=1`
- `go vet ./...`
- `golangci-lint run`

All green.

Closes #254
