### PR TITLE
Add 'dispatch tags' to list tags with per-tag session counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,17 @@ Flags:
 - `--calendar` adds a GitHub-style activity heatmap of sessions per day, with an intensity legend. It honors the `--repo`, `--branch`, `--since`, and `--until` filters.
 - `--repo`, `--branch`, `--folder`, `--since`, and `--until` narrow which sessions are counted.
 
+### Tags
+
+Run `dispatch tags` to list every tag in use with the number of sessions that carry it, ordered by count.
+
+```sh
+dispatch tags
+dispatch tags --json
+```
+
+Tags come from sessions you have tagged in the TUI. Counts are taken against the current session store, so tags left on sessions that no longer exist are not counted. Use `--json` for scripting.
+
 ### Export
 
 Save a full session (metadata and the complete conversation) to a file with `dispatch export <id>`:

--- a/cmd/dispatch/cli.go
+++ b/cmd/dispatch/cli.go
@@ -111,6 +111,13 @@ func handleArgs(args []string, origStderr io.Writer, updateCh <-chan *update.Upd
 			}
 			return true, cleanup, "", nil
 
+		case "tags":
+			if tErr := runTags(os.Stdout, args); tErr != nil {
+				fmt.Fprintf(os.Stderr, "tags: %v\n", tErr)
+				return true, cleanup, "", tErr
+			}
+			return true, cleanup, "", nil
+
 		case "config":
 			if cErr := runConfig(os.Stdout, args); cErr != nil {
 				fmt.Fprintf(os.Stderr, "config: %v\n", cErr)
@@ -204,7 +211,7 @@ func runCompletion(w io.Writer, shell string) error {
 const bashCompletionScript = `# bash completion for dispatch
 _dispatch_completion() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
-  local commands="help version open new doctor update completion stats config export"
+  local commands="help version open new doctor update completion stats tags config export"
   local flags="-h --help -v --version --demo --clear-cache --reindex"
 
   if [[ "${COMP_CWORD}" -eq 1 ]]; then
@@ -228,7 +235,7 @@ complete -F _dispatch_completion dispatch disp
 const zshCompletionScript = `#compdef dispatch disp
 _dispatch_completion() {
   local -a commands shells flags configsubs
-  commands=(help version open new doctor update completion stats config export)
+  commands=(help version open new doctor update completion stats tags config export)
   shells=(bash zsh fish powershell)
   configsubs=(list get set path)
   flags=(-h --help -v --version --demo --clear-cache --reindex)
@@ -264,14 +271,14 @@ end
 
 for bin in dispatch disp
   complete -c $bin -f
-  complete -c $bin -n '__dispatch_needs_command' -a 'help version open new doctor update completion stats config export'
+  complete -c $bin -n '__dispatch_needs_command' -a 'help version open new doctor update completion stats tags config export'
   complete -c $bin -n '__dispatch_needs_command' -a '-h --help -v --version --demo --clear-cache --reindex'
   complete -c $bin -n '__dispatch_using_completion' -a 'bash zsh fish powershell'
 end
 `
 
 const powershellCompletionScript = `# PowerShell completion for dispatch
-$script:DispatchCommands = @('help', 'version', 'open', 'new', 'doctor', 'update', 'completion', 'stats', 'config', 'export')
+$script:DispatchCommands = @('help', 'version', 'open', 'new', 'doctor', 'update', 'completion', 'stats', 'tags', 'config', 'export')
 $script:DispatchFlags = @('-h', '--help', '-v', '--version', '--demo', '--clear-cache', '--reindex')
 $script:DispatchShells = @('bash', 'zsh', 'fish', 'powershell')
 $script:DispatchConfigSubcommands = @('list', 'get', 'set', 'path')

--- a/cmd/dispatch/main.go
+++ b/cmd/dispatch/main.go
@@ -98,6 +98,7 @@ Commands:
   completion <shell>      Print shell completion (bash, zsh, fish, powershell)
   doctor [--json]         Print environment diagnostics (--json for machine-readable output)
   stats [flags]           Print session totals and breakdowns
+  tags [--json]           List tags in use with per-tag session counts
   config [get|set|list|path]
                           Read or change preferences (see Config commands)
   export <id> [flags]     Export a session as Markdown or JSON

--- a/cmd/dispatch/tags.go
+++ b/cmd/dispatch/tags.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/jongio/dispatch/internal/data"
+)
+
+// tagsListSessionsFn loads sessions for the tags command. It is a package
+// variable so tests can substitute a fixed set of sessions, matching the seam
+// pattern used elsewhere in this package (see stats.go and cli.go).
+var tagsListSessionsFn = defaultStatsListSessions
+
+// tagsOptions holds the parsed flags for the tags command.
+type tagsOptions struct {
+	json bool
+}
+
+// tagCount is one tag and the number of sessions that carry it.
+type tagCount struct {
+	Tag   string `json:"tag"`
+	Count int    `json:"count"`
+}
+
+// tagsReport is the aggregate tag summary produced by the tags command.
+type tagsReport struct {
+	TotalTags      int        `json:"total_tags"`
+	TaggedSessions int        `json:"tagged_sessions"`
+	Tags           []tagCount `json:"tags"`
+}
+
+// runTags prints the tags in use with a per-tag session count. args is the
+// full argument slice with args[0] == "tags".
+func runTags(w io.Writer, args []string) error {
+	if w == nil {
+		w = io.Discard
+	}
+
+	opts, err := parseTagsArgs(args)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := configLoadFn()
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	sessions, err := tagsListSessionsFn(data.FilterOptions{})
+	if err != nil {
+		return err
+	}
+
+	report := buildTagsReport(cfg.SessionTags, sessions)
+	if opts.json {
+		return writeTagsJSON(w, report)
+	}
+	writeTagsText(w, report)
+	return nil
+}
+
+// parseTagsArgs reads the tags subcommand flags. args[0] is expected to be
+// "tags". It rejects positional arguments and unknown flags.
+func parseTagsArgs(args []string) (tagsOptions, error) {
+	var opts tagsOptions
+
+	rest := args
+	if len(rest) > 0 {
+		rest = rest[1:] // drop the "tags" token
+	}
+
+	for _, arg := range rest {
+		switch {
+		case arg == "--json":
+			opts.json = true
+		case strings.HasPrefix(arg, "-"):
+			return tagsOptions{}, fmt.Errorf("unknown flag: %s", arg)
+		default:
+			return tagsOptions{}, fmt.Errorf("tags does not take positional arguments, got %q", arg)
+		}
+	}
+
+	return opts, nil
+}
+
+// buildTagsReport counts how many of the given sessions carry each tag. Tags on
+// sessions that are not present (for example, sessions deleted since they were
+// tagged) are ignored so the counts reflect the current session store.
+func buildTagsReport(sessionTags map[string][]string, sessions []data.Session) tagsReport {
+	report := tagsReport{Tags: []tagCount{}}
+
+	counts := map[string]int{}
+	for _, s := range sessions {
+		tags := sessionTags[s.ID]
+		if len(tags) == 0 {
+			continue
+		}
+		report.TaggedSessions++
+		for _, tag := range tags {
+			counts[tag]++
+		}
+	}
+
+	report.TotalTags = len(counts)
+	report.Tags = sortedTagCounts(counts)
+	return report
+}
+
+// sortedTagCounts converts a tag/count map into a slice ordered by count
+// descending, then tag ascending for stable output.
+func sortedTagCounts(counts map[string]int) []tagCount {
+	entries := make([]tagCount, 0, len(counts))
+	for tag, count := range counts {
+		entries = append(entries, tagCount{Tag: tag, Count: count})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Count != entries[j].Count {
+			return entries[i].Count > entries[j].Count
+		}
+		return entries[i].Tag < entries[j].Tag
+	})
+	return entries
+}
+
+// writeTagsJSON prints the report as a single JSON object.
+func writeTagsJSON(w io.Writer, report tagsReport) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(report)
+}
+
+// writeTagsText prints the report in a plain, human-readable layout.
+func writeTagsText(w io.Writer, report tagsReport) {
+	fmt.Fprintln(w, "Dispatch tags")
+	fmt.Fprintln(w)
+
+	if report.TotalTags == 0 {
+		fmt.Fprintln(w, "No tags found.")
+		return
+	}
+
+	fmt.Fprintf(w, "Tags:     %d\n", report.TotalTags)
+	fmt.Fprintf(w, "Sessions: %d tagged\n", report.TaggedSessions)
+	fmt.Fprintln(w)
+
+	width := 0
+	for _, e := range report.Tags {
+		if len(e.Tag) > width {
+			width = len(e.Tag)
+		}
+	}
+	for _, e := range report.Tags {
+		fmt.Fprintf(w, "  %-*s  %d\n", width, e.Tag, e.Count)
+	}
+}

--- a/cmd/dispatch/tags_test.go
+++ b/cmd/dispatch/tags_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jongio/dispatch/internal/config"
+	"github.com/jongio/dispatch/internal/data"
+)
+
+func withTagsList(t *testing.T, fn func(data.FilterOptions) ([]data.Session, error)) {
+	t.Helper()
+	prev := tagsListSessionsFn
+	tagsListSessionsFn = fn
+	t.Cleanup(func() { tagsListSessionsFn = prev })
+}
+
+func taggedSessions() []data.Session {
+	return []data.Session{
+		{ID: "a"},
+		{ID: "b"},
+		{ID: "c"},
+		{ID: "d"}, // untagged
+	}
+}
+
+func taggedConfig() *config.Config {
+	cfg := config.Default()
+	cfg.SessionTags = map[string][]string{
+		"a": {"work", "urgent"},
+		"b": {"work"},
+		"c": {"personal"},
+		// "z" is an orphan: tagged but not in the session store.
+		"z": {"work", "stale"},
+	}
+	return cfg
+}
+
+func TestBuildTagsReportCounts(t *testing.T) {
+	report := buildTagsReport(taggedConfig().SessionTags, taggedSessions())
+
+	if report.TaggedSessions != 3 {
+		t.Fatalf("TaggedSessions = %d, want 3", report.TaggedSessions)
+	}
+	if report.TotalTags != 3 {
+		t.Fatalf("TotalTags = %d, want 3 (work, urgent, personal)", report.TotalTags)
+	}
+
+	// work=2 (a, b), personal=1 (c), urgent=1 (a). Orphan "z" is ignored.
+	want := []tagCount{
+		{Tag: "work", Count: 2},
+		{Tag: "personal", Count: 1},
+		{Tag: "urgent", Count: 1},
+	}
+	if len(report.Tags) != len(want) {
+		t.Fatalf("Tags len = %d, want %d: %+v", len(report.Tags), len(want), report.Tags)
+	}
+	for i, w := range want {
+		if report.Tags[i] != w {
+			t.Errorf("Tags[%d] = %+v, want %+v", i, report.Tags[i], w)
+		}
+	}
+}
+
+func TestBuildTagsReportEmpty(t *testing.T) {
+	report := buildTagsReport(map[string][]string{}, taggedSessions())
+	if report.TotalTags != 0 || report.TaggedSessions != 0 {
+		t.Fatalf("empty report = %+v, want zero counts", report)
+	}
+	if report.Tags == nil {
+		t.Error("Tags should be non-nil so JSON renders [] not null")
+	}
+}
+
+func TestParseTagsArgs(t *testing.T) {
+	opts, err := parseTagsArgs([]string{"tags", "--json"})
+	if err != nil {
+		t.Fatalf("parseTagsArgs: %v", err)
+	}
+	if !opts.json {
+		t.Error("--json not parsed")
+	}
+
+	opts, err = parseTagsArgs([]string{"tags"})
+	if err != nil {
+		t.Fatalf("parseTagsArgs bare: %v", err)
+	}
+	if opts.json {
+		t.Error("json should default to false")
+	}
+}
+
+func TestParseTagsArgsErrors(t *testing.T) {
+	if _, err := parseTagsArgs([]string{"tags", "--nope"}); err == nil {
+		t.Error("expected error for unknown flag")
+	}
+	if _, err := parseTagsArgs([]string{"tags", "work"}); err == nil {
+		t.Error("expected error for positional argument")
+	}
+}
+
+func TestRunTagsText(t *testing.T) {
+	withConfigSeams(t, taggedConfig())
+	withTagsList(t, func(data.FilterOptions) ([]data.Session, error) {
+		return taggedSessions(), nil
+	})
+
+	var buf bytes.Buffer
+	if err := runTags(&buf, []string{"tags"}); err != nil {
+		t.Fatalf("runTags: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"Tags:     3", "3 tagged", "work", "personal", "urgent"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "stale") {
+		t.Errorf("orphan tag should not appear:\n%s", out)
+	}
+}
+
+func TestRunTagsEmptyText(t *testing.T) {
+	cfg := config.Default()
+	cfg.SessionTags = map[string][]string{}
+	withConfigSeams(t, cfg)
+	withTagsList(t, func(data.FilterOptions) ([]data.Session, error) {
+		return taggedSessions(), nil
+	})
+
+	var buf bytes.Buffer
+	if err := runTags(&buf, []string{"tags"}); err != nil {
+		t.Fatalf("runTags: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No tags found.") {
+		t.Errorf("expected empty notice, got:\n%s", buf.String())
+	}
+}
+
+func TestRunTagsJSON(t *testing.T) {
+	withConfigSeams(t, taggedConfig())
+	withTagsList(t, func(data.FilterOptions) ([]data.Session, error) {
+		return taggedSessions(), nil
+	})
+
+	var buf bytes.Buffer
+	if err := runTags(&buf, []string{"tags", "--json"}); err != nil {
+		t.Fatalf("runTags json: %v", err)
+	}
+
+	var report tagsReport
+	if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+	if report.TotalTags != 3 || report.TaggedSessions != 3 {
+		t.Fatalf("json report = %+v, want 3 tags / 3 sessions", report)
+	}
+	if len(report.Tags) == 0 || report.Tags[0].Tag != "work" || report.Tags[0].Count != 2 {
+		t.Fatalf("first tag = %+v, want work=2", report.Tags)
+	}
+}
+
+func TestRunTagsListError(t *testing.T) {
+	withConfigSeams(t, taggedConfig())
+	withTagsList(t, func(data.FilterOptions) ([]data.Session, error) {
+		return nil, errors.New("boom")
+	})
+	if err := runTags(&bytes.Buffer{}, []string{"tags"}); err == nil {
+		t.Error("expected error from session loader to propagate")
+	}
+}
+
+func TestHandleArgsTags(t *testing.T) {
+	withConfigSeams(t, taggedConfig())
+	withTagsList(t, func(data.FilterOptions) ([]data.Session, error) {
+		return taggedSessions(), nil
+	})
+
+	done, _, _, err := handleArgs([]string{"tags"}, &bytes.Buffer{}, nil)
+	if err != nil {
+		t.Fatalf("handleArgs tags: %v", err)
+	}
+	if !done {
+		t.Error("handleArgs should report done for tags")
+	}
+}


### PR DESCRIPTION
## What

Adds a headless `dispatch tags` command that lists every tag in use with the
number of sessions that carry it.

```
dispatch tags
dispatch tags --json
```

Text output:

```
Dispatch tags

Tags:     3
Sessions: 3 tagged

  work      2
  personal  1
  urgent    1
```

Tags are ordered by count (then name), so your busiest buckets come first.

## Why

You can tag sessions in the TUI and filter the list by a tag, but there was no
way to see the full set of tags you have used or how many sessions each covers.
Once you have more than a few tags it is hard to keep track of which exist,
which are used once and could be retired, and which are your busiest. There was
also no scriptable way to read tags from outside the TUI. `--json` closes that
gap and matches the shape of `dispatch stats --json`.

## Behavior notes

- Counts are taken against the current session store, so tags left on sessions
  that no longer exist are not counted. This keeps the taxonomy honest.
- Unknown flags and positional arguments are rejected with a clear error.

## Changes

- New `cmd/dispatch/tags.go`: `runTags`, `parseTagsArgs`, `buildTagsReport`, and text/JSON writers
- Command wired into `handleArgs` in `cmd/dispatch/cli.go`
- Help text updated in `cmd/dispatch/main.go`
- Shell completions (bash, zsh, fish, powershell) list the command
- README section added
- Tests in `cmd/dispatch/tags_test.go` cover report building, orphan filtering, text output, JSON output, argument parsing, loader errors, and the arg dispatch path

## Testing

- `go build ./...`
- `go test ./... -count=1`
- `go vet ./...`
- `golangci-lint run`

All green.

Closes #256
