### PR TITLE
Add ID-only output to dispatch search

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,13 +256,15 @@ By default the session is written as Markdown to the exports directory. Use `--f
 
 ### Search (JSON)
 
-Query the session store from scripts without opening the TUI. `dispatch search` prints matching sessions as a JSON array:
+Query the session store from scripts without opening the TUI. `dispatch search` prints matching sessions as a JSON array by default:
 
 ```sh
 dispatch search auth
 dispatch search --query "fix login" --repo jongio/dispatch
 dispatch search --branch main --since 2026-01-01 --limit 20
 dispatch search --deep refactor --json
+dispatch search auth --format ids
+dispatch search auth --ids
 ```
 
 The query can be passed as a positional argument or with `--query`. Filters mirror the interactive search and the `stats` command:
@@ -271,8 +273,9 @@ The query can be passed as a positional argument or with `--query`. Filters mirr
 - `--since` / `--until` accept `YYYY-MM-DD` or full RFC3339 timestamps.
 - `--deep` also searches turns, checkpoints, touched files, and refs.
 - `--limit <n>` caps the result count (default 50, `0` for no limit).
+- `--format json|ids` chooses JSON output or one session ID per line. `--ids` is a shortcut for `--format ids`.
 
-Each result includes `id`, `summary`, `cwd`, `repository`, `branch`, `created_at`, `updated_at`, `turn_count`, and `file_count`. No matches prints `[]` and exits 0. Invalid flags or an unreadable store exit non-zero with a message on stderr.
+Each JSON result includes `id`, `summary`, `cwd`, `repository`, `branch`, `created_at`, `updated_at`, `turn_count`, and `file_count`. No JSON matches prints `[]`; no ID matches prints nothing. Both exit 0. Invalid flags or an unreadable store exit non-zero with a message on stderr.
 
 ### Key Bindings
 

--- a/cmd/dispatch/main.go
+++ b/cmd/dispatch/main.go
@@ -139,7 +139,9 @@ Stats flags:
   --until <date>          Only count sessions created on or before a date
 
 Search flags:
-  --json                  Print results as JSON (default and only output)
+  --json                  Print results as JSON (default)
+  --ids                   Print one session ID per line
+  --format json|ids       Choose the output format
   --query <text>          Text to match (also accepted as a positional argument)
   --deep                  Search turns, checkpoints, files, and refs too
   --repo <name>           Only include sessions for a repository

--- a/cmd/dispatch/search.go
+++ b/cmd/dispatch/search.go
@@ -24,10 +24,18 @@ const searchDefaultLimit = 50
 // (--limit 0), mirroring the ceiling the stats command uses.
 const searchAllLimit = 100_000
 
+type searchOutputFormat string
+
+const (
+	searchFormatJSON searchOutputFormat = "json"
+	searchFormatIDs  searchOutputFormat = "ids"
+)
+
 // searchOptions holds the parsed flags for the search command.
 type searchOptions struct {
 	filter data.FilterOptions
 	limit  int
+	format searchOutputFormat
 }
 
 // searchSession is the machine-readable shape emitted for each matching
@@ -67,6 +75,10 @@ func runSearch(w io.Writer, args []string) error {
 		return err
 	}
 
+	if opts.format == searchFormatIDs {
+		return writeSearchIDs(w, sessions)
+	}
+
 	results := make([]searchSession, 0, len(sessions))
 	for _, s := range sessions {
 		results = append(results, searchSession{
@@ -87,11 +99,20 @@ func runSearch(w io.Writer, args []string) error {
 	return enc.Encode(results)
 }
 
+func writeSearchIDs(w io.Writer, sessions []data.Session) error {
+	for _, s := range sessions {
+		if _, err := fmt.Fprintln(w, s.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // parseSearchArgs reads the search subcommand flags. args[0] is expected to be
 // "search". A single leading token that does not start with "-" is treated as
 // the search query, matching how the TUI seeds its search box.
 func parseSearchArgs(args []string) (searchOptions, error) {
-	opts := searchOptions{limit: searchDefaultLimit}
+	opts := searchOptions{limit: searchDefaultLimit, format: searchFormatJSON}
 
 	rest := args
 	if len(rest) > 0 {
@@ -115,8 +136,20 @@ func parseSearchArgs(args []string) (searchOptions, error) {
 
 		switch {
 		case name == "--json":
-			// Accepted for explicitness and forward compatibility; JSON is
-			// the only output mode this command emits.
+			opts.format = searchFormatJSON
+		case name == "--ids":
+			opts.format = searchFormatIDs
+		case name == "--format":
+			v, ni, err := takeValue(i, "--format", inlineOrEmpty(inline, hasInline))
+			if err != nil {
+				return searchOptions{}, err
+			}
+			format, err := parseSearchFormat(v)
+			if err != nil {
+				return searchOptions{}, err
+			}
+			opts.format = format
+			i = ni
 		case name == "--deep":
 			opts.filter.DeepSearch = true
 		case name == "--query" || name == "-q":
@@ -199,6 +232,17 @@ func parseSearchArgs(args []string) (searchOptions, error) {
 	}
 
 	return opts, nil
+}
+
+func parseSearchFormat(v string) (searchOutputFormat, error) {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case string(searchFormatJSON):
+		return searchFormatJSON, nil
+	case string(searchFormatIDs):
+		return searchFormatIDs, nil
+	default:
+		return "", fmt.Errorf("invalid --format value %q (want json or ids)", v)
+	}
 }
 
 // parseSearchLimit parses the --limit value. Zero means "no cap"; negative

--- a/cmd/dispatch/search_test.go
+++ b/cmd/dispatch/search_test.go
@@ -56,6 +56,9 @@ func TestParseSearchArgsQueryAndFilters(t *testing.T) {
 	if opts.limit != 10 {
 		t.Errorf("limit = %d, want 10", opts.limit)
 	}
+	if opts.format != searchFormatJSON {
+		t.Errorf("format = %q, want json", opts.format)
+	}
 	if opts.filter.Since == nil || !opts.filter.Since.Equal(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)) {
 		t.Errorf("Since = %v, want 2026-01-01", opts.filter.Since)
 	}
@@ -75,6 +78,31 @@ func TestParseSearchArgsDefaultLimit(t *testing.T) {
 	if opts.filter.Query != "" {
 		t.Errorf("Query = %q, want empty", opts.filter.Query)
 	}
+	if opts.format != searchFormatJSON {
+		t.Errorf("format = %q, want json", opts.format)
+	}
+}
+
+func TestParseSearchArgsIDFormats(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{name: "ids shortcut", args: []string{"search", "--ids"}},
+		{name: "format ids separate", args: []string{"search", "--format", "ids"}},
+		{name: "format ids inline", args: []string{"search", "--format=ids"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, err := parseSearchArgs(tc.args)
+			if err != nil {
+				t.Fatalf("parseSearchArgs returned error: %v", err)
+			}
+			if opts.format != searchFormatIDs {
+				t.Errorf("format = %q, want ids", opts.format)
+			}
+		})
+	}
 }
 
 func TestParseSearchArgsErrors(t *testing.T) {
@@ -84,6 +112,8 @@ func TestParseSearchArgsErrors(t *testing.T) {
 		{"search", "--limit", "-3"},
 		{"search", "--limit", "abc"},
 		{"search", "--repo"},
+		{"search", "--format"},
+		{"search", "--format", "table"},
 	}
 	for _, args := range cases {
 		if _, err := parseSearchArgs(args); err == nil {
@@ -135,6 +165,39 @@ func TestRunSearchJSONOutput(t *testing.T) {
 	}
 	if out[0].ID != "a" || out[0].Summary != "fix auth bug" || out[0].TurnCount != 5 || out[0].FileCount != 3 {
 		t.Errorf("unexpected result: %+v", out[0])
+	}
+}
+
+func TestRunSearchIDsOutput(t *testing.T) {
+	sessions := []data.Session{
+		{ID: "session-a"},
+		{ID: "session-b"},
+	}
+	withSearchList(t, func(data.FilterOptions, int) ([]data.Session, error) {
+		return sessions, nil
+	})
+
+	var buf bytes.Buffer
+	if err := runSearch(&buf, []string{"search", "--ids"}); err != nil {
+		t.Fatalf("runSearch returned error: %v", err)
+	}
+
+	if got, want := buf.String(), "session-a\nsession-b\n"; got != want {
+		t.Errorf("output = %q, want %q", got, want)
+	}
+}
+
+func TestRunSearchIDsNoMatchesIsEmpty(t *testing.T) {
+	withSearchList(t, func(data.FilterOptions, int) ([]data.Session, error) {
+		return nil, nil
+	})
+
+	var buf bytes.Buffer
+	if err := runSearch(&buf, []string{"search", "--format", "ids"}); err != nil {
+		t.Fatalf("runSearch returned error: %v", err)
+	}
+	if got := buf.String(); got != "" {
+		t.Errorf("output = %q, want empty", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `--format ids` and `--ids` to `dispatch search`
- keep JSON as the default output
- document the new ID-only mode

Closes #262

## Validation
- `go test ./...`
- `go build ./...`
- `go vet ./...`