### PR TITLE
Allow disabling background update checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,7 +614,7 @@ Add custom color schemes using Windows Terminal JSON format in the `schemes` arr
 | `--branch <name>` | Filter to a branch |
 | `--query <text>` | Pre-fill the search box with free text |
 
-A background update check runs on every launch and notifies you when a new version is available.
+A background update check runs on every launch and notifies you when a new version is available. Set `DISPATCH_NO_UPDATE_CHECK=1` to skip that check.
 
 Unknown flags print an error message with usage help and exit with code 1.
 
@@ -624,6 +624,7 @@ Unknown flags print an error message with usage help and exit with code 1.
 |---|---|
 | `DISPATCH_DB` | Override the path to the Copilot CLI session store database |
 | `DISPATCH_LOG` | Path to a log file (enables debug logging) |
+| `DISPATCH_NO_UPDATE_CHECK` | Skip the background release check when set to `1`, `true`, `yes`, or `on` |
 
 ## Shell Aliases
 

--- a/cmd/dispatch/main.go
+++ b/cmd/dispatch/main.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/jongio/dispatch/internal/tui"
@@ -16,14 +17,12 @@ import (
 )
 
 const demoDBRel = "internal/data/testdata/fake_sessions.db"
+const noUpdateCheckEnv = "DISPATCH_NO_UPDATE_CHECK"
+
+var checkForUpdateFn = update.CheckForUpdate
 
 func main() {
-	// Start background update check early so it can run concurrently
-	// with argument parsing and TUI startup.
-	updateCh := make(chan *update.UpdateInfo, 1)
-	go func() {
-		updateCh <- update.CheckForUpdate(context.Background(), version.Version)
-	}()
+	updateCh := startUpdateCheck(context.Background(), version.Version)
 
 	origStderr := captureOriginalStderr()
 	if origStderr == nil {
@@ -78,6 +77,28 @@ func main() {
 	// After TUI exits, show update notification if the background
 	// check found a newer release.
 	showUpdateNotification(origStderr, updateCh)
+}
+
+func startUpdateCheck(ctx context.Context, currentVersion string) <-chan *update.UpdateInfo {
+	ch := make(chan *update.UpdateInfo, 1)
+	if updateCheckDisabled() {
+		return ch
+	}
+	// Start background update check early so it can run concurrently with
+	// argument parsing and TUI startup.
+	go func() {
+		ch <- checkForUpdateFn(ctx, currentVersion)
+	}()
+	return ch
+}
+
+func updateCheckDisabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(noUpdateCheckEnv))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 func printUsage() {
@@ -157,6 +178,8 @@ Environment:
   DISPATCH_DB             Path to a custom session store database
   DISPATCH_SESSION_STATE  Path to a custom session state directory
   DISPATCH_LOG            Path to a log file (enables debug logging)
+  DISPATCH_NO_UPDATE_CHECK
+                          Skip the background release check when set to 1, true, yes, or on
 `, version.Version)
 }
 

--- a/cmd/dispatch/main.go
+++ b/cmd/dispatch/main.go
@@ -16,8 +16,10 @@ import (
 	"github.com/jongio/dispatch/internal/version"
 )
 
-const demoDBRel = "internal/data/testdata/fake_sessions.db"
-const noUpdateCheckEnv = "DISPATCH_NO_UPDATE_CHECK"
+const (
+	demoDBRel        = "internal/data/testdata/fake_sessions.db"
+	noUpdateCheckEnv = "DISPATCH_NO_UPDATE_CHECK"
+)
 
 var checkForUpdateFn = update.CheckForUpdate
 

--- a/cmd/dispatch/main_test.go
+++ b/cmd/dispatch/main_test.go
@@ -82,6 +82,72 @@ func TestShowUpdateNotification_NilWriter(t *testing.T) {
 	showUpdateNotification(nil, ch)
 }
 
+func TestUpdateCheckDisabledTruthyValues(t *testing.T) {
+	for _, value := range []string{"1", "true", "TRUE", "yes", "on", " On "} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv(noUpdateCheckEnv, value)
+			if !updateCheckDisabled() {
+				t.Errorf("updateCheckDisabled() = false, want true for %q", value)
+			}
+		})
+	}
+}
+
+func TestUpdateCheckDisabledFalsyValues(t *testing.T) {
+	for _, value := range []string{"", "0", "false", "no", "off", "maybe"} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv(noUpdateCheckEnv, value)
+			if updateCheckDisabled() {
+				t.Errorf("updateCheckDisabled() = true, want false for %q", value)
+			}
+		})
+	}
+}
+
+func TestStartUpdateCheckDisabledDoesNotCallChecker(t *testing.T) {
+	t.Setenv(noUpdateCheckEnv, "1")
+	called := make(chan struct{}, 1)
+	prev := checkForUpdateFn
+	checkForUpdateFn = func(context.Context, string) *update.UpdateInfo {
+		called <- struct{}{}
+		return nil
+	}
+	t.Cleanup(func() { checkForUpdateFn = prev })
+
+	ch := startUpdateCheck(context.Background(), "1.0.0")
+
+	select {
+	case <-called:
+		t.Fatal("update checker was called while disabled")
+	default:
+	}
+	select {
+	case info := <-ch:
+		t.Fatalf("update channel produced %v while disabled", info)
+	default:
+	}
+}
+
+func TestStartUpdateCheckEnabledCallsChecker(t *testing.T) {
+	t.Setenv(noUpdateCheckEnv, "0")
+	prev := checkForUpdateFn
+	checkForUpdateFn = func(context.Context, string) *update.UpdateInfo {
+		return &update.UpdateInfo{CurrentVersion: "1.0.0", LatestVersion: "1.1.0"}
+	}
+	t.Cleanup(func() { checkForUpdateFn = prev })
+
+	ch := startUpdateCheck(context.Background(), "1.0.0")
+
+	select {
+	case info := <-ch:
+		if info == nil || info.LatestVersion != "1.1.0" {
+			t.Fatalf("update info = %+v, want latest 1.1.0", info)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for update checker")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // findDemoDB
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `DISPATCH_NO_UPDATE_CHECK` to skip the background release check
- document the environment variable in help and README
- cover truthy values and enabled/disabled startup behavior with tests

Closes #263

## Validation
- `go test ./cmd/dispatch`
- `go build ./...`
- `go vet ./...`

## Notes
- `go test ./... -timeout 10m` did not complete because existing `internal/platform` git-state tests timed out while waiting on git subprocesses in this environment. The changed package tests passed.