### PR TITLE
deps: upgrade all dependencies to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	golang.org/x/exp v0.0.0-20260611194520-c48552f49976 // indirect
-	golang.org/x/net v0.56.0 // indirect
+	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	modernc.org/libc v1.74.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ golang.org/x/exp v0.0.0-20260611194520-c48552f49976 h1:X8Hz2ImujgbmetVuW+w2YkyZC
 golang.org/x/exp v0.0.0-20260611194520-c48552f49976/go.mod h1:vnf4pv9iKZXY58sQE1L86zmNWJ4159e1RkcWiLCkeEY=
 golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
 golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
-golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
-golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
+golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
+golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
 golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Recurring dependency upgrade.

## Go
- `golang.org/x/net`: v0.56.0 to v0.57.0 (via `go get -u ./...` + `go mod tidy`)

## npm (web/), held this cycle
- `typescript` 6.0.3 to 7.0.2: held. Major bump, and `@astrojs/check@0.9.9` (latest) peer-requires `typescript ^5 || ^6`, so TS 7 isn't supported by the Astro tooling yet. Also published under 7 days ago.
- `marked` 18.0.6: held. Published under 7 days ago (release-age cooldown).

## Verification (local, CI-equivalent)
- gofmt / gofumpt: clean
- `go mod tidy`: stable (only the x/net change)
- `mage deadcode`: OK
- `go build ./...` + cross-compile (darwin/amd64, darwin/arm64, windows/amd64, windows/arm64): pass
- golangci-lint v2.12.2: 0 issues
- `go vet ./...`: pass
- `go test ./...`: pass, 79.5% total coverage
- govulncheck: no vulnerabilities

Race detector tests run in CI (they need CGO/gcc, which isn't available on the local Windows box).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
