### PR TITLE
fix(mage): report PATH changes clearly during install

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -450,15 +450,22 @@ func ensurePath() error {
 		return nil
 	}
 
-	fmt.Printf("\n=== Adding %s to system PATH ===\n", binDir)
-	newPath := binDir + ";" + machinePath
-	err := exec.Command("powershell", "-NoProfile", "-Command",
-		fmt.Sprintf(`[Environment]::SetEnvironmentVariable('Path','%s','Machine')`, newPath)).Run()
-	if err != nil {
-		fmt.Println("   Machine PATH failed (need admin), trying User PATH...")
-		if !containsPath(userPath, binDir) {
-			exec.Command("powershell", "-NoProfile", "-Command",
-				fmt.Sprintf(`[Environment]::SetEnvironmentVariable('Path','%s;%s','User')`, binDir, userPath)).Run()
+	fmt.Printf("\n=== Adding %s to PATH ===\n", binDir)
+	// Prefer Machine PATH (visible to every user) but fall back to User PATH,
+	// which does not need administrator rights. Report the outcome either way
+	// so a failed persist is never silent.
+	machineErr := exec.Command("powershell", "-NoProfile", "-Command",
+		fmt.Sprintf(`[Environment]::SetEnvironmentVariable('Path','%s;%s','Machine')`, binDir, machinePath)).Run()
+	if machineErr == nil {
+		fmt.Println("   Added to Machine PATH.")
+	} else {
+		fmt.Println("   Machine PATH needs admin; adding to User PATH instead...")
+		if userErr := exec.Command("powershell", "-NoProfile", "-Command",
+			fmt.Sprintf(`[Environment]::SetEnvironmentVariable('Path','%s;%s','User')`, binDir, userPath)).Run(); userErr != nil {
+			fmt.Printf("   WARNING: could not add %s to User PATH: %v\n", binDir, userErr)
+			fmt.Println("   Add it manually, or re-run `mage install` from an elevated terminal.")
+		} else {
+			fmt.Println("   Added to User PATH.")
 		}
 	}
 	ensureSessionPath(binDir)
@@ -555,6 +562,7 @@ func verify() error {
 	fmt.Printf("\n✅ %s installed\n", binaryName())
 	fmt.Printf("   Path:  %s\n", outPath)
 	fmt.Printf("   Built: %s\n", info.ModTime().Format(time.DateTime))
+	fmt.Printf("   Run:   open a new terminal, then `%s` (already-open shells keep the old PATH)\n", binName)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

`mage install` was adding the dev bin dir to the User PATH, but the output never confirmed it. The last PATH-related line users saw was `Machine PATH failed (need admin), trying User PATH...`, which reads like an error. There was no success message and no hint that a new terminal is needed, so it looked like install did not touch PATH at all.

Two concrete problems in the `Install` target:

1. The User PATH fallback ran `SetEnvironmentVariable(..., 'User')` but ignored its error, so a real failure was indistinguishable from success.
2. There was no confirmation line and no "open a new terminal" guidance.

## Changes

- Print `Added to Machine PATH.` or `Added to User PATH.` on success.
- Surface a warning with the actual error when the User PATH write fails, and point the user at re-running from an elevated terminal.
- End the install with: open a new terminal, then `dispatch-dev`, because already-open shells keep the old PATH.

## Verification

- `mage -l` and `go build ./...`: pass
- Full `mage install` re-ran green (all tests with the race detector, build, deploy) and printed the new hint
- Confirmed a fresh shell resolves `dispatch-dev` to `bin/dispatch-dev.exe`

No behavior change to what gets written to PATH; this only fixes the reporting and error handling.
