### PR TITLE
docs(changelog): cut v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [v0.14.0] — 2026-07-18
+
 This release turns Dispatch from a TUI-only tool into a scriptable CLI: most session operations are now available as non-interactive commands with JSON output, and the TUI gains a git status overlay plus several navigation and organization features.
 
 ### Added


### PR DESCRIPTION
Promotes the CHANGELOG `[Unreleased]` section to `[v0.14.0]` (2026-07-18) so the Release workflow's changelog verification step passes. Keeps an empty `[Unreleased]` section on top for future work. No content changes to the entries themselves. Required before triggering the v0.14.0 release.