### PR TITLE
fix(release): drop cosign --oidc-issuer flag that breaks signing

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,7 +40,6 @@ signs:
     args:
       - "sign-blob"
       - "--yes"
-      - "--oidc-issuer=https://token.actions.githubusercontent.com"
       - "--output-signature=${signature}"
       - "--output-certificate=${certificate}"
       - "${artifact}"


### PR DESCRIPTION
## Problem

The v0.14.0 release run built all binaries, archives, SBOMs, and checksums, then failed at the cosign signing step:

```
could not sign artifact: dispatch_checksums.txt
Error: cannot specify service URLs and use signing config
```

Newer cosign (the `cosign-installer` action installs the latest by default and it has never been pinned) auto-loads a signing config from its embedded trusted root and now rejects explicitly-set service URLs. The `--oidc-issuer` flag in the goreleaser `signs` block triggers this, so no GitHub Release was published.

## Fix

Remove the `--oidc-issuer=https://token.actions.githubusercontent.com` arg. In GitHub Actions the ambient OIDC identity plus the signing config already supply the issuer, so the flag is redundant. This matches the canonical goreleaser keyless-signing recipe.

The `--output-signature` / `--output-certificate` flags stay (they only emit deprecation warnings, not errors) so the `.sig` and `.pem` artifacts attached to the release are unchanged.

## Follow-up

The orphaned `v0.14.0` tag (pushed before goreleaser ran, no release attached) will be deleted and the Release workflow re-triggered after this merges.