### PR TITLE
fix(release): keep cosign classic signature format

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,11 +35,16 @@ sboms:
   - artifacts: archive
 
 signs:
+  # Keep cosign's classic output (separate .sig + .pem) instead of the new
+  # single-file bundle: install.sh and install.ps1 verify the checksums with
+  # `cosign verify-blob --signature ...sig --certificate ...pem`, which the
+  # bundle format would break.
   - cmd: cosign
     artifacts: checksum
     args:
       - "sign-blob"
       - "--yes"
+      - "--new-bundle-format=false"
       - "--output-signature=${signature}"
       - "--output-certificate=${certificate}"
       - "${artifact}"


### PR DESCRIPTION
## Problem

After #322 removed `--oidc-issuer`, the release got past the first cosign error but failed at signing with:

```
create bundle file: open : no such file or directory
```

The newer cosign defaults to `--new-bundle-format`, which ignores `--output-signature` / `--output-certificate` and instead wants a `--bundle` path. With none provided, it tried to write a bundle to an empty path and failed.

## Fix

Add `--new-bundle-format=false` so cosign keeps its classic output: separate `.sig` and `.pem` files.

This is deliberate rather than switching to the single-file bundle, because both `install.sh` and `install.ps1` verify the checksums with `cosign verify-blob --signature <checksums>.sig --certificate <checksums>.pem`. Adopting the bundle format would require changing both install scripts and would break verification for the existing release format. A code comment documents why.

## Follow-up

The `v0.14.0` tag (re-created by the second failed run, still no release attached) will be deleted and the Release workflow re-triggered after this merges.