### PR TITLE
fix(release): pin cosign to v2.x to keep classic signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,12 @@ jobs:
           go-version-file: go.mod
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Pin to the maintained v2.x line. cosign v3 auto-loads a signing
+          # config and forces the new single-file bundle format, which breaks
+          # the classic detached .sig/.pem signing that install.sh and
+          # install.ps1 verify. See the signs block in .goreleaser.yml.
+          cosign-release: v2.6.4
 
       - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,16 +35,16 @@ sboms:
   - artifacts: archive
 
 signs:
-  # Keep cosign's classic output (separate .sig + .pem) instead of the new
-  # single-file bundle: install.sh and install.ps1 verify the checksums with
-  # `cosign verify-blob --signature ...sig --certificate ...pem`, which the
-  # bundle format would break.
+  # Classic detached signature: produces ${artifact}.sig and ${artifact}.pem,
+  # which install.sh and install.ps1 verify with
+  # `cosign verify-blob --signature ...sig --certificate ...pem`. cosign is
+  # pinned to the v2.x line in release.yml so this keeps working; cosign v3
+  # forces the single-file bundle format instead.
   - cmd: cosign
     artifacts: checksum
     args:
       - "sign-blob"
       - "--yes"
-      - "--new-bundle-format=false"
       - "--output-signature=${signature}"
       - "--output-certificate=${certificate}"
       - "${artifact}"


### PR DESCRIPTION
## Problem

The v0.14.0 release kept failing at the cosign signing step. `cosign-installer` installs the latest cosign by default, which is now v3.x. cosign v3 auto-loads a signing config and forces the new single-file bundle format, producing a chain of failures:

1. `cannot specify service URLs and use signing config` (from `--oidc-issuer`)
2. `create bundle file: open : no such file or directory`
3. `must provide --new-bundle-format or --bundle ... with --signing-config`

No GitHub Release was ever published.

## Why not just adopt the bundle format

`install.sh` and `install.ps1` verify releases with:

```
cosign verify-blob --signature <checksums>.sig --certificate <checksums>.pem ...
```

Switching to the single-file bundle would break signature verification for every end user who has cosign installed.

## Fix

cosign maintains two lines in parallel: v3.x (new behavior) and v2.6.x (classic). Pin `cosign-installer` to `v2.6.4` (current, released 2026-07-17) which keeps the classic detached `.sig` + `.pem` output, and restore the classic goreleaser `signs` args. Both files carry a comment explaining the pin. No install-script or user-facing verification change.

## Follow-up

The `v0.14.0` tag (re-created by the failed runs, no release attached) will be deleted and the Release workflow re-triggered after this merges.