### PR TITLE
fix(web): allow legacy peer deps so Pages build resolves

### DIFF
--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,0 +1,5 @@
+# @astrojs/check 0.9.9 declares a peer of typescript ^5 || ^6, but this project
+# uses typescript ^7. TypeScript 7 works for `astro build` (the only step the
+# Pages deploy runs); the mismatch is only in peer resolution. Allow npm ci to
+# proceed until @astrojs/check widens its peer range to include typescript 7.
+legacy-peer-deps=true


### PR DESCRIPTION
## Problem

The website deploy in the Release workflow failed at `npm ci`:

```
npm error ERESOLVE could not resolve
npm error While resolving: @astrojs/check@0.9.9
npm error Found: typescript@7.0.2
npm error peer typescript@\\^5.0.0 || ^6.0.0\\ from @astrojs/check@0.9.9
```

`web/package.json` uses `typescript@^7.0.2` (bumped in #306), but the latest `@astrojs/check` (0.9.9) still peers `typescript ^5 || ^6`. npm@latest enforces this peer during `npm ci`. Pages only runs during a release or manual dispatch, so this stayed latent until the v0.14.0 release.

Note: the v0.14.0 GitHub Release itself published successfully (binaries, SBOMs, checksums, signature). Only the Pages/website deploy failed.

## Fix

Add `web/.npmrc` with `legacy-peer-deps=true`. TypeScript 7 works fine for `astro build` (the only step Pages runs; `@astrojs/check` is only used by `astro check` in the `test` script), so this lets resolution proceed until `@astrojs/check` widens its peer range.

## Verification

- Local `npm ci` (reading the new .npmrc): succeeds, exit 0
- `npm run build`: all 7 pages build
- `web/package-lock.json` unchanged by `npm ci`

## Follow-up

After merge, re-run the Pages workflow (workflow_dispatch) to deploy the site. No need to re-release; v0.14.0 is already published.