### PR TITLE
Add path output to dispatch search

### DIFF
--- a/cmd/dispatch/main.go
+++ b/cmd/dispatch/main.go
@@ -126,7 +126,7 @@ Commands:
   completion <shell>      Print shell completion (bash, zsh, fish, powershell)
   doctor [--json]         Print environment diagnostics (--json for machine-readable output)
   stats [flags]           Print session totals and breakdowns
-  search [query] [flags]  Print matching sessions as JSON, CSV, IDs, or a table
+  search [query] [flags]  Print matching sessions as JSON, CSV, IDs, paths, or a table
   tags [--json]           List tags in use with per-tag session counts
   aliases [--json]        List session aliases with orphan detection
   alias <id> <name>       Set, reassign, clear (--clear), or remove (--remove) a session alias
@@ -180,8 +180,9 @@ Stats flags:
 Search flags:
   --json                  Print results as JSON (default)
   --ids                   Print one session ID per line
+  --paths                 Print one working directory per line
   --table                 Print a readable table
-  --format json|csv|ids|table
+  --format json|csv|ids|paths|table
                           Choose the output format
   --query <text>          Text to match (also accepted as a positional argument)
   --deep                  Search turns, checkpoints, files, and refs too

--- a/cmd/dispatch/search.go
+++ b/cmd/dispatch/search.go
@@ -33,6 +33,7 @@ const (
 	searchFormatIDs   searchOutputFormat = "ids"
 	searchFormatTable searchOutputFormat = "table"
 	searchFormatCSV   searchOutputFormat = "csv"
+	searchFormatPaths searchOutputFormat = "paths"
 )
 
 // searchOptions holds the parsed flags for the search command.
@@ -93,6 +94,9 @@ func runSearch(w io.Writer, args []string) error {
 	}
 	if opts.format == searchFormatCSV {
 		return writeSearchCSV(w, sessions)
+	}
+	if opts.format == searchFormatPaths {
+		return writeSearchPaths(w, sessions)
 	}
 
 	results := make([]searchSession, 0, len(sessions))
@@ -170,6 +174,24 @@ func writeSearchCSV(w io.Writer, sessions []data.Session) error {
 	return cw.Error()
 }
 
+func writeSearchPaths(w io.Writer, sessions []data.Session) error {
+	seen := map[string]struct{}{}
+	for _, s := range sessions {
+		path := strings.TrimSpace(s.Cwd)
+		if path == "" {
+			continue
+		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		if _, err := fmt.Fprintln(w, path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func shortSearchID(id string) string {
 	if len(id) <= 12 {
 		return id
@@ -235,6 +257,8 @@ func parseSearchArgs(args []string) (searchOptions, error) {
 			opts.format = searchFormatTable
 		case name == "--csv":
 			opts.format = searchFormatCSV
+		case name == "--paths":
+			opts.format = searchFormatPaths
 		case name == "--format":
 			v, ni, err := takeValue(i, "--format", inlineOrEmpty(inline, hasInline))
 			if err != nil {
@@ -405,8 +429,10 @@ func parseSearchFormat(v string) (searchOutputFormat, error) {
 		return searchFormatTable, nil
 	case string(searchFormatCSV):
 		return searchFormatCSV, nil
+	case string(searchFormatPaths):
+		return searchFormatPaths, nil
 	default:
-		return "", fmt.Errorf("invalid --format value %q (want json, ids, table, or csv)", v)
+		return "", fmt.Errorf("invalid --format value %q (want json, ids, table, csv, or paths)", v)
 	}
 }
 

--- a/cmd/dispatch/search_test.go
+++ b/cmd/dispatch/search_test.go
@@ -113,6 +113,9 @@ func TestParseSearchArgsIDFormats(t *testing.T) {
 		{name: "csv shortcut", args: []string{"search", "--csv"}},
 		{name: "format csv separate", args: []string{"search", "--format", "csv"}},
 		{name: "format csv inline", args: []string{"search", "--format=csv"}},
+		{name: "paths shortcut", args: []string{"search", "--paths"}},
+		{name: "format paths separate", args: []string{"search", "--format", "paths"}},
+		{name: "format paths inline", args: []string{"search", "--format=paths"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -126,6 +129,9 @@ func TestParseSearchArgsIDFormats(t *testing.T) {
 			}
 			if strings.Contains(strings.Join(tc.args, " "), "csv") {
 				want = searchFormatCSV
+			}
+			if strings.Contains(strings.Join(tc.args, " "), "paths") {
+				want = searchFormatPaths
 			}
 			if opts.format != want {
 				t.Errorf("format = %q, want %s", opts.format, want)
@@ -356,6 +362,27 @@ func TestRunSearchCSVEmptyPrintsHeader(t *testing.T) {
 		t.Fatalf("runSearch returned error: %v", err)
 	}
 	if got, want := buf.String(), "id,summary,cwd,repository,branch,created_at,updated_at,turn_count,file_count\n"; got != want {
+		t.Errorf("output = %q, want %q", got, want)
+	}
+}
+
+func TestRunSearchPathsOutput(t *testing.T) {
+	sessions := []data.Session{
+		{ID: "session-a", Cwd: "/code/app"},
+		{ID: "session-b", Cwd: "  "},
+		{ID: "session-c", Cwd: "/code/app"},
+		{ID: "session-d", Cwd: "/code/other"},
+	}
+	withSearchList(t, func(data.FilterOptions, data.SortOptions, int) ([]data.Session, error) {
+		return sessions, nil
+	})
+
+	var buf bytes.Buffer
+	if err := runSearch(&buf, []string{"search", "--paths"}); err != nil {
+		t.Fatalf("runSearch returned error: %v", err)
+	}
+
+	if got, want := buf.String(), "/code/app\n/code/other\n"; got != want {
 		t.Errorf("output = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
Adds path-only output for search results so shell pickers and terminal project jumpers can read matching working directories directly.

Validation:
- `go build ./...`
- `mage install`
- `go test ./...`

Closes https://github.com/jongio/dispatch/issues/364