### PR TITLE
fix(ci): deploy Pages on web changes pushed to main

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,6 +1,11 @@
 name: Deploy website to GitHub Pages
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - '.github/workflows/pages.yml'
   workflow_dispatch:
   workflow_call:
 


### PR DESCRIPTION
## Problem

The website at https://jongio.github.io/dispatch was serving 45 broken images (9 screenshots x 5 themes) on the homepage and the features page.

## Root cause

`pages.yml` had no automatic trigger. It ran only on `workflow_dispatch` or `workflow_call`, and its only caller is the `pages` job in `release.yml`, which is gated on `needs: release`. The site therefore redeployed only when a release was cut or someone dispatched it by hand.

Timeline:

| When | What |
|---|---|
| 2026-07-18 17:24 EDT | `2560b1d` is the sha of the last successful deploy (run `29661562296`, manual dispatch) |
| 2026-07-18 20:58 EDT | `4101500` adds 9 feature screenshots across 5 themes |
| after | no release, no dispatch, so no redeploy |

Result: `main` had 240 screenshots while the published artifact still had the 195 that existed at `2560b1d`. The 45 newer files returned 404.

Ruled out as causes: the `base` path is correct (`/dispatch/`), all 240 PNGs are tracked in git, the 5 theme directories have identical 48-file parity, all 51 `<Screenshot>` references resolve, and nothing relevant is gitignored. A local `npm run build` off current `main` emits all 240 files, which confirms the site code was never the problem.

## Fix

Add a `push` trigger on `main` scoped to `web/**` and this workflow file, so web changes publish without waiting for a release.

## Verification

The live site was redeployed via run `30639581688`. All 240 image URLs now return 200, down from 45 failing.
