### PR TITLE
Search assistant replies and checkpoint bodies via the FTS5 index

### DIFF
--- a/internal/data/coverage_test.go
+++ b/internal/data/coverage_test.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -90,9 +91,47 @@ func TestFilterBuilder_QueryDeepSearch(t *testing.T) {
 	var fb filterBuilder
 	fb.apply(FilterOptions{Query: "test", DeepSearch: true})
 
-	// Deep search: 9 LIKE patterns
-	if len(fb.args) != 9 {
-		t.Errorf("expected 9 args for deep search, got %d", len(fb.args))
+	// Deep search without FTS5: 4 session fields + user_message + 2 checkpoint
+	// fields + files + refs + assistant_response = 10 LIKE patterns.
+	if len(fb.args) != 10 {
+		t.Errorf("expected 10 args for deep search, got %d", len(fb.args))
+	}
+	if !strings.Contains(fb.whereSQL(), "assistant_response") {
+		t.Error("deep search without FTS5 should scan turns.assistant_response")
+	}
+}
+
+func TestFilterBuilder_QueryDeepSearchFTS(t *testing.T) {
+	fb := filterBuilder{hasFTS: true}
+	fb.apply(FilterOptions{Query: "test", DeepSearch: true})
+
+	// Deep search with FTS5: 9 LIKE patterns + 1 MATCH = 10 args.
+	if len(fb.args) != 10 {
+		t.Errorf("expected 10 args for FTS deep search, got %d", len(fb.args))
+	}
+	where := fb.whereSQL()
+	if !strings.Contains(where, "search_index WHERE content MATCH ?") {
+		t.Errorf("FTS deep search should use the search_index table, got: %s", where)
+	}
+	if !strings.Contains(where, "t2.user_message LIKE") {
+		t.Error("FTS deep search should keep the LIKE clauses for substring matches")
+	}
+	if fb.args[len(fb.args)-1] != `"test"` {
+		t.Errorf("FTS arg should be the escaped phrase, got %v", fb.args[len(fb.args)-1])
+	}
+}
+
+func TestFilterBuilder_QueryDeepSearchFTSBlankQuery(t *testing.T) {
+	fb := filterBuilder{hasFTS: true}
+	fb.apply(FilterOptions{Query: "   ", DeepSearch: true})
+
+	// A whitespace-only query has no FTS terms, so it falls back to LIKE
+	// rather than issuing an empty MATCH.
+	if strings.Contains(fb.whereSQL(), "MATCH") {
+		t.Error("blank query should not produce an FTS MATCH clause")
+	}
+	if len(fb.args) != 10 {
+		t.Errorf("expected 10 args for LIKE fallback, got %d", len(fb.args))
 	}
 }
 
@@ -186,9 +225,9 @@ func TestFilterBuilder_AllFilters(t *testing.T) {
 	if where == "" {
 		t.Error("whereSQL should be non-empty for all filters")
 	}
-	// 9 (deep search) + 1 (folder) + 1 (repo) + 1 (branch) + 1 (since) + 1 (until) + 1 (excluded) = 15
-	if len(fb.args) != 15 {
-		t.Errorf("expected 15 args for all filters, got %d", len(fb.args))
+	// 10 (deep search) + 1 (folder) + 1 (repo) + 1 (branch) + 1 (since) + 1 (until) + 1 (excluded) = 16
+	if len(fb.args) != 16 {
+		t.Errorf("expected 16 args for all filters, got %d", len(fb.args))
 	}
 }
 

--- a/internal/data/store.go
+++ b/internal/data/store.go
@@ -309,6 +309,11 @@ type filterBuilder struct {
 	joins  []string
 	wheres []string
 	args   []any
+
+	// hasFTS reports whether the FTS5 search_index table is available. When
+	// true, deep search resolves turn and checkpoint text through the index
+	// instead of scanning those tables with LIKE.
+	hasFTS bool
 }
 
 func (fb *filterBuilder) apply(f FilterOptions) {
@@ -325,13 +330,32 @@ func (fb *filterBuilder) apply(f FilterOptions) {
 		pattern := "%" + escapeLIKE(f.Query) + "%"
 		if f.DeepSearch {
 			// Deep mode: search session fields + related tables.
-			fb.wheres = append(fb.wheres,
-				`(s.summary LIKE ? ESCAPE '\' OR s.branch LIKE ? ESCAPE '\' OR s.repository LIKE ? ESCAPE '\' OR s.cwd LIKE ? ESCAPE '\'`+
-					` OR EXISTS (SELECT 1 FROM turns t2 WHERE t2.session_id = s.id AND t2.user_message LIKE ? ESCAPE '\')`+
-					` OR EXISTS (SELECT 1 FROM checkpoints cp WHERE cp.session_id = s.id AND (cp.title LIKE ? ESCAPE '\' OR cp.overview LIKE ? ESCAPE '\'))`+
-					` OR EXISTS (SELECT 1 FROM session_files sf2 WHERE sf2.session_id = s.id AND sf2.file_path LIKE ? ESCAPE '\')`+
-					` OR EXISTS (SELECT 1 FROM session_refs sr2 WHERE sr2.session_id = s.id AND sr2.ref_value LIKE ? ESCAPE '\'))`)
+			clauses := []string{
+				`s.summary LIKE ? ESCAPE '\'`,
+				`s.branch LIKE ? ESCAPE '\'`,
+				`s.repository LIKE ? ESCAPE '\'`,
+				`s.cwd LIKE ? ESCAPE '\'`,
+				`EXISTS (SELECT 1 FROM turns t2 WHERE t2.session_id = s.id AND t2.user_message LIKE ? ESCAPE '\')`,
+				`EXISTS (SELECT 1 FROM checkpoints cp WHERE cp.session_id = s.id AND (cp.title LIKE ? ESCAPE '\' OR cp.overview LIKE ? ESCAPE '\'))`,
+				`EXISTS (SELECT 1 FROM session_files sf2 WHERE sf2.session_id = s.id AND sf2.file_path LIKE ? ESCAPE '\')`,
+				`EXISTS (SELECT 1 FROM session_refs sr2 WHERE sr2.session_id = s.id AND sr2.ref_value LIKE ? ESCAPE '\')`,
+			}
 			fb.args = append(fb.args, pattern, pattern, pattern, pattern, pattern, pattern, pattern, pattern, pattern)
+
+			// The FTS5 index covers assistant replies and every checkpoint text
+			// field, none of which the LIKE clauses above reach. It is additive
+			// rather than a replacement: LIKE still catches substrings inside a
+			// token (bug "1137" within "PR1137") that the tokenizer splits away.
+			if ftsTerms := escapeFTS5Terms(f.Query); fb.hasFTS && ftsTerms != "" {
+				clauses = append(clauses, `s.id IN (SELECT session_id FROM search_index WHERE content MATCH ?)`)
+				fb.args = append(fb.args, ftsTerms)
+			} else {
+				// Without the index, assistant replies are only reachable by scan.
+				clauses = append(clauses,
+					`EXISTS (SELECT 1 FROM turns t4 WHERE t4.session_id = s.id AND t4.assistant_response LIKE ? ESCAPE '\')`)
+				fb.args = append(fb.args, pattern)
+			}
+			fb.wheres = append(fb.wheres, "("+strings.Join(clauses, " OR ")+")")
 		} else {
 			// Quick mode: search only session-level fields (no JOINs).
 			fb.wheres = append(fb.wheres,
@@ -524,6 +548,7 @@ func (s *Store) withAutoExclusions(f FilterOptions) FilterOptions {
 // specified. TurnCount and FileCount are computed via subqueries.
 func (s *Store) ListSessions(ctx context.Context, filter FilterOptions, sort SortOptions, limit int) ([]Session, error) {
 	var fb filterBuilder
+	fb.hasFTS = s.hasFTS5
 	fb.apply(s.withAutoExclusions(filter))
 
 	q := "SELECT " + s.sessionColumns() + " FROM sessions s" + countJoins + fb.joinSQL() + fb.whereSQL()
@@ -928,9 +953,19 @@ func mergeSearchResults(primary, secondary []SearchResult, limit int) []SearchRe
 // FTS5 special characters (-, *, OR, AND, NOT, NEAR, etc.) are treated as
 // literals. Returns the escaped query suitable for MATCH.
 func escapeFTS5(query string) string {
+	if terms := escapeFTS5Terms(query); terms != "" {
+		return terms
+	}
+	return `""`
+}
+
+// escapeFTS5Terms is escapeFTS5 without the empty-query placeholder: it
+// returns "" when the query has no terms, letting callers skip the MATCH
+// clause entirely rather than issuing an empty phrase query.
+func escapeFTS5Terms(query string) string {
 	terms := strings.Fields(query)
 	if len(terms) == 0 {
-		return `""`
+		return ""
 	}
 	quoted := make([]string, len(terms))
 	for i, t := range terms {
@@ -1110,6 +1145,7 @@ func (s *Store) ResolveIDPrefix(ctx context.Context, prefix string) (string, err
 // given filter and sort order within each group.
 func (s *Store) GroupSessions(ctx context.Context, pivot PivotField, filter FilterOptions, sort SortOptions, limit int) ([]SessionGroup, error) {
 	var fb filterBuilder
+	fb.hasFTS = s.hasFTS5
 	fb.apply(s.withAutoExclusions(filter))
 
 	expr := pivotExpr(pivot)

--- a/internal/data/store_fts_test.go
+++ b/internal/data/store_fts_test.go
@@ -636,3 +636,123 @@ func BenchmarkSearchSessionsLIKEvsNTS(b *testing.B) {
 		}
 	})
 }
+
+// ---------------------------------------------------------------------------
+// Deep list filtering via FTS5
+// ---------------------------------------------------------------------------
+
+// TestListSessionsDeepSearchFTSMatchesAssistantResponse covers the case where a
+// term (a bug number, for example) appears only in the assistant half of a
+// turn. The LIKE fallback scans user_message only, so the FTS index is what
+// makes these sessions findable from the session list.
+func TestListSessionsDeepSearchFTSMatchesAssistantResponse(t *testing.T) {
+	s := newFTSTestStore(t)
+	db := s.db
+
+	seedSession(t, db, "asst-1", "/home/user/project", "owner/repo", "main",
+		"Investigate crash", "2024-01-10T10:00:00Z", "2024-01-10T12:00:00Z")
+	seedTurn(t, db, "asst-1", 0, "what is going on", "This is tracked in bug 1137.",
+		"2024-01-10T10:00:00Z")
+	seedSearchIndex(t, db, "what is going on\nThis is tracked in bug 1137.", "asst-1", "turn", "0")
+
+	sessions, err := s.ListSessions(context.Background(),
+		FilterOptions{Query: "1137", DeepSearch: true},
+		SortOptions{Field: SortByUpdated, Order: Descending}, 50)
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].ID != "asst-1" {
+		t.Fatalf("expected [asst-1], got %v", sessionIDs(sessions))
+	}
+}
+
+// TestListSessionsDeepSearchFTSMatchesCheckpointBody verifies that checkpoint
+// text beyond title and overview (history, technical details, files) is
+// reachable through the index.
+func TestListSessionsDeepSearchFTSMatchesCheckpointBody(t *testing.T) {
+	s := newFTSTestStore(t)
+	db := s.db
+
+	seedSession(t, db, "cp-1", "/home/user/project", "owner/repo", "main",
+		"Ship release", "2024-01-10T10:00:00Z", "2024-01-10T12:00:00Z")
+	seedTurn(t, db, "cp-1", 0, "ship it", "Shipped.", "2024-01-10T10:00:00Z")
+	seedSearchIndex(t, db, "Reverted the regression from PR 8842", "cp-1", "checkpoint_history", "1")
+
+	sessions, err := s.ListSessions(context.Background(),
+		FilterOptions{Query: "8842", DeepSearch: true},
+		SortOptions{Field: SortByUpdated, Order: Descending}, 50)
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].ID != "cp-1" {
+		t.Fatalf("expected [cp-1], got %v", sessionIDs(sessions))
+	}
+}
+
+// TestListSessionsDeepSearchFTSNoMatch guards against the index clause
+// matching everything when the term is absent.
+func TestListSessionsDeepSearchFTSNoMatch(t *testing.T) {
+	s := newFTSTestStore(t)
+	populateFTSData(t, s)
+
+	sessions, err := s.ListSessions(context.Background(),
+		FilterOptions{Query: "zzz_nothing_matches_zzz", DeepSearch: true},
+		SortOptions{Field: SortByUpdated, Order: Descending}, 50)
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Fatalf("expected no matches, got %v", sessionIDs(sessions))
+	}
+}
+
+// TestListSessionsDeepSearchFTSPunctuationQuery ensures a query made only of
+// FTS5 operator characters is treated as a literal and never produces a
+// syntax error that would break the whole session list.
+func TestListSessionsDeepSearchFTSPunctuationQuery(t *testing.T) {
+	s := newFTSTestStore(t)
+	populateFTSData(t, s)
+
+	for _, q := range []string{"-", "*", "^", "NEAR(", `"`, "AND OR NOT"} {
+		if _, err := s.ListSessions(context.Background(),
+			FilterOptions{Query: q, DeepSearch: true},
+			SortOptions{Field: SortByUpdated, Order: Descending}, 50); err != nil {
+			t.Errorf("ListSessions(%q): %v", q, err)
+		}
+	}
+}
+
+// TestGroupSessionsDeepSearchFTS verifies the grouped list path uses the same
+// index-backed predicate as the flat list.
+func TestGroupSessionsDeepSearchFTS(t *testing.T) {
+	s := newFTSTestStore(t)
+	db := s.db
+
+	seedSession(t, db, "grp-1", "/home/user/project", "owner/repo", "main",
+		"Investigate crash", "2024-01-10T10:00:00Z", "2024-01-10T12:00:00Z")
+	seedTurn(t, db, "grp-1", 0, "what is going on", "Tracked in bug 1137.", "2024-01-10T10:00:00Z")
+	seedSearchIndex(t, db, "what is going on\nTracked in bug 1137.", "grp-1", "turn", "0")
+
+	groups, err := s.GroupSessions(context.Background(), PivotByRepo,
+		FilterOptions{Query: "1137", DeepSearch: true},
+		SortOptions{Field: SortByUpdated, Order: Descending}, 50)
+	if err != nil {
+		t.Fatalf("GroupSessions: %v", err)
+	}
+	var total int
+	for _, g := range groups {
+		total += len(g.Sessions)
+	}
+	if total != 1 {
+		t.Fatalf("expected 1 grouped session, got %d", total)
+	}
+}
+
+// sessionIDs extracts IDs for readable test failure output.
+func sessionIDs(sessions []Session) []string {
+	ids := make([]string, len(sessions))
+	for i, s := range sessions {
+		ids[i] = s.ID
+	}
+	return ids
+}


### PR DESCRIPTION
Searching the session list for a bug or PR number returned nothing when that number only appeared in Copilot's reply rather than in what the user typed.

## What was wrong

The session store ships an FTS5 `search_index` table covering full turn text and every checkpoint field, but the list filter never touched it. Deep search built a LIKE predicate over `turns.user_message`, checkpoint title and overview, file paths, and refs. Assistant replies, checkpoint history, work done, technical details, and next steps were all unreachable.

`SearchSessionsFTS` did use the index, but only the Copilot SDK search tool ever called it.

## The change

Deep search now also matches `s.id IN (SELECT session_id FROM search_index WHERE content MATCH ?)` when the index is present.

The index clause is additive rather than a replacement. FTS5 tokenizes, so it misses substrings inside a token: searching `1137` finds `bug 1137` but not `PR1137`, which LIKE catches. Keeping both makes the result set a strict superset of the old behavior.

Stores without the index get an `assistant_response` LIKE clause instead, so assistant text is searchable there too.

Query terms are wrapped in double quotes before being passed to MATCH, so FTS5 operators (`-`, `*`, `NEAR`, `^`) are treated as literals and can't turn a search into a syntax error that breaks the whole list. A whitespace-only query skips the MATCH clause rather than issuing an empty phrase.

## Verification

Against a real 20k-session store, searching `1137`:

| | sessions found |
|---|---|
| before | 6 |
| after | 13 |

The recent session that prompted the report (the number appeared only in an assistant reply) is now in the results.

## Tests

- assistant-only match through the index
- checkpoint body match (history, technical details, files)
- no-match, so the index clause can't match everything
- FTS5 operator characters as the whole query
- grouped list path uses the same predicate
- filter-builder shape for both the indexed and fallback branches
