### PR TITLE
fix: restore grouped views, excluded-word filtering, and collapse state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **Grouped views collapsing to a single group** — grouped queries ordered rows by pivot label before applying `max_sessions`, so the entire row budget was spent on whichever label sorted first and every other group disappeared. The cap now keeps the sessions the active sort puts first, and groups are ordered by label afterwards. This also restores the `all` time range, which appeared to stop partway through history for the same reason.
+- **Excluded words not hiding sessions** — the filter matched raw stored text while the list displays summaries with whitespace collapsed, so a phrase typed exactly as shown (`Task Invoke` against a stored `## Task\n\nInvoke…`) never matched. Matching now normalizes both sides, folds case for accented and non-Latin text, and covers checkpoint content in addition to summaries and turns.
+- **Group collapse state lost on refresh** — an absent expand entry meant both "never shown" and "user collapsed", so the background refresh re-expanded anything collapsed and made the collapse-all key appear to toggle at random. Groups now track whether they have already been given their default state. This also fixes `default_collapsed`, which was reverted by the first refresh.
+
 ## [v0.16.0] — 2026-08-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Dispatch reads your local Copilot CLI session store and presents every past sess
 
 - **Full-text search** (`/`) — Two-tier search: quick search (summaries, branches, repos, directories) returns results instantly; deep search scans all user-visible session metadata and content fields after 300ms. FTS5 adds indexed matches when available without replacing the source-field scan. Searching a number (e.g. "42", "#42", "PR42") also matches session refs (PRs, issues, commits)
 - **Directory filtering** (`f`) — hierarchical tree panel for toggling directory exclusion, persisted to config
-- **Word filtering** (Settings panel) — comma-separated list of words to exclude sessions by content. Sessions whose summary or conversation turns contain any excluded word (case-insensitive) are hidden from the list
+- **Word filtering** (Settings panel) — comma-separated list of words to exclude sessions by content. Sessions whose summary, conversation turns, or checkpoint content contain any excluded word are hidden from the list. Matching is case-insensitive (including accented and non-Latin text) and matches the phrase as displayed in the list, so line breaks in the stored text do not break a multi-word phrase. Each comma-separated entry is one phrase, so `Task, Invoke` excludes either word while `Task Invoke` excludes only the phrase
 - **Sorting** (`s` / `S`) — 4 fields (updated, folder, name, attention) with toggleable direction. Sort applies within each group; configuration also accepts the legacy `created` and `turns` values
 - **Grouping modes** (`Tab`) — list, folder, repo, branch, date, host. Displayed as collapsible trees with session counts
 - **Time range filtering** (`1`–`4`) — 1 hour, 1 day, 7 days, all
@@ -750,7 +750,7 @@ Use `dispatch config validate --path <file>` to check another config file withou
 | `preview_position` | string | `"right"` | Position of the preview pane: `right`, `bottom`, `left`, `top` |
 | `redact_preview_secrets` | bool | `false` | Mask common secret patterns (bearer tokens, GitHub PATs, connection strings, `.env` secrets) with `[redacted]` in the preview pane. Rendering only; stored session data is never modified |
 | `conversation_newest_first` | bool | `true` | Show newest conversation turns first in preview |
-| `max_sessions` | int | `100` | Maximum sessions to load |
+| `max_sessions` | int | `100` | Maximum sessions to load. In grouped views this is the total across all groups |
 | `yoloMode` | bool | `false` | Pass `--allow-all` to Copilot CLI (auto-confirm commands) |
 | `agent` | string | `""` | Pass `--agent <name>` to Copilot CLI |
 | `model` | string | `""` | Pass `--model <name>` to Copilot CLI |
@@ -759,7 +759,7 @@ Use `dispatch config validate --path <file>` to check another config file withou
 | `resume_session_command` | string | `""` | Custom resume command (`{sessionId}` is replaced). Defaults to `copilot --resume` |
 | `new_session_command` | string | `""` | Command to launch new sessions (`{cwd}` is replaced). Defaults to `copilot` |
 | `excluded_dirs` | array | `[]` | Directory paths to hide from session list |
-| `excluded_words` | array | `[]` | Comma-separated words; sessions containing any word are hidden |
+| `excluded_words` | array | `[]` | Phrases to hide; a session is hidden when its summary, turns, or checkpoints contain one (case-insensitive) |
 | `attention_threshold` | string | `"15m"` | Duration after which an inactive running session is marked stale |
 | `notify_on_waiting` | bool | `false` | Ring the terminal bell and show a footer message when a session enters the waiting state |
 | `auto_refresh_seconds` | int | *(unset)* | Session-list poll interval in seconds. Unset uses the default (2s); `0` disables polling; a positive value sets the interval (minimum 1s). Applies on next launch |

--- a/internal/data/coverage_test.go
+++ b/internal/data/coverage_test.go
@@ -140,7 +140,7 @@ func TestFilterBuilder_QueryDeepSearchFTS(t *testing.T) {
 	if !strings.Contains(where, "search_index WHERE content MATCH ?") {
 		t.Errorf("FTS deep search should use the search_index table, got: %s", where)
 	}
-	if !strings.Contains(where, "t2.user_message LIKE") {
+	if !strings.Contains(where, "COALESCE(t2.user_message,'') LIKE") {
 		t.Error("FTS deep search should keep the LIKE clauses for substring matches")
 	}
 	if fb.args[len(fb.args)-1] != `"test"` {

--- a/internal/data/match.go
+++ b/internal/data/match.go
@@ -145,14 +145,6 @@ func (m matcher) columnSQL(column string) string {
 	return "(" + raw + like + " AND " + normalized + ")"
 }
 
-// argsPerColumn reports how many bound values columnSQL consumes.
-func (m matcher) argsPerColumn() int {
-	if m.guard != "" {
-		return 2
-	}
-	return 1
-}
-
 // appendArgs appends one column's bound values, in the order columnSQL
 // consumes them.
 func (m matcher) appendArgs(dst []any) []any {

--- a/internal/data/match.go
+++ b/internal/data/match.go
@@ -1,0 +1,172 @@
+package data
+
+import (
+	"database/sql/driver"
+	"log/slog"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	sqlite "modernc.org/sqlite"
+)
+
+// normFuncName is a SQLite scalar function that renders text the way the
+// session list does before matching against it.
+//
+// Two things differ between stored text and what a user reads on screen:
+//
+//   - SQLite's LIKE and lower() fold ASCII only, so "café" never matches
+//     stored "CAFÉ".
+//   - The list renders summaries through CleanSummary, which collapses every
+//     whitespace run to a single space. A summary stored as
+//     "## Task\n\nInvoke the skill" is displayed as "## Task Invoke the
+//     skill", so a user filtering on the phrase they can see types
+//     "Task Invoke" and the raw text never matches.
+//
+// Users filter and search by what they see, so matching normalizes both sides
+// the same way.
+const normFuncName = "dispatch_norm"
+
+// normReady reports whether normFuncName was registered with the driver.
+// Registration happens once at package load and can only fail if the name is
+// already taken, but queries degrade to SQLite's raw matching rather than
+// erroring if it ever does.
+var normReady bool
+
+func init() {
+	err := sqlite.RegisterDeterministicScalarFunction(normFuncName, 1, normScalar)
+	if err != nil {
+		slog.Warn("match normalization unavailable; filters fall back to raw text matching",
+			"function", normFuncName, "error", err)
+		return
+	}
+	normReady = true
+}
+
+// normScalar normalizes its argument. NULL and non-text values normalize to
+// the empty string so the result is never NULL: these expressions are also
+// used negated, where a NULL would drop a row that should have been kept.
+func normScalar(_ *sqlite.FunctionContext, args []driver.Value) (driver.Value, error) {
+	if len(args) != 1 {
+		return "", nil
+	}
+	switch v := args[0].(type) {
+	case string:
+		return normalizeMatchText(v), nil
+	case []byte:
+		return normalizeMatchText(string(v)), nil
+	default:
+		return "", nil
+	}
+}
+
+// normalizeMatchText lowercases with Unicode awareness and collapses runs of
+// whitespace to a single space, mirroring how the session list renders text.
+func normalizeMatchText(s string) string {
+	return strings.Join(strings.Fields(strings.ToLower(s)), " ")
+}
+
+// needsNormalization reports whether matching term requires the normalizing
+// path. Normalization runs a callback per scanned row, so it is only paid for
+// when it can change the result:
+//
+//   - a term containing whitespace has to match across the line breaks that
+//     the list collapses for display;
+//   - a term containing non-ASCII text needs Unicode folding, which SQLite's
+//     LIKE does not do.
+//
+// A single-word ASCII term is already matched case-insensitively by LIKE and
+// stays on the fast path, as does a term that normalizes to nothing.
+func needsNormalization(term string) bool {
+	if !normReady || normalizeMatchText(term) == "" {
+		return false
+	}
+	if len(term) != utf8.RuneCountInString(term) {
+		return true
+	}
+	return strings.ContainsFunc(term, unicode.IsSpace)
+}
+
+// matcher renders the per-column comparison for one search term.
+type matcher struct {
+	pattern   string // LIKE pattern, normalized when normalize is true
+	guard     string // cheap raw-text prefilter; empty when not applicable
+	normalize bool
+}
+
+// newMatcher builds the comparison for term.
+//
+// Normalizing every scanned row is expensive: the excluded-word filter is
+// negated, so SQLite cannot stop at the first hit and ends up folding whole
+// assistant responses. Where possible the normalized test is therefore
+// guarded by a plain LIKE over the raw column, which SQLite evaluates first
+// and which discards nearly every row without calling into Go.
+//
+// The guard is sound because normalization only lowercases and collapses
+// whitespace: it never reorders or removes a token. So any text whose
+// normalized form contains "task invoke" must contain "task", then some
+// whitespace, then "invoke" in the raw text, which "%task%invoke%" matches.
+// The guard over-matches ("task and then invoke"), and the normalized
+// comparison that follows rejects those.
+func newMatcher(term string) matcher {
+	normalize := needsNormalization(term)
+	m := matcher{pattern: likePattern(term, normalize), normalize: normalize}
+	if !normalize {
+		return m
+	}
+	// A non-ASCII term cannot be guarded by a raw LIKE, because the guard
+	// would itself need the case folding it is trying to avoid.
+	if len(term) != utf8.RuneCountInString(term) {
+		return m
+	}
+	fields := strings.Fields(term)
+	if len(fields) < 2 {
+		return m
+	}
+	escaped := make([]string, len(fields))
+	for i, f := range fields {
+		escaped[i] = escapeLIKE(f)
+	}
+	m.guard = "%" + strings.Join(escaped, "%") + "%"
+	return m
+}
+
+// columnSQL renders the comparison for one column.
+func (m matcher) columnSQL(column string) string {
+	const like = ` LIKE ? ESCAPE '\'`
+	raw := "COALESCE(" + column + ",'')"
+	if !m.normalize {
+		return raw + like
+	}
+	normalized := normFuncName + "(" + raw + ")" + like
+	if m.guard == "" {
+		return normalized
+	}
+	return "(" + raw + like + " AND " + normalized + ")"
+}
+
+// argsPerColumn reports how many bound values columnSQL consumes.
+func (m matcher) argsPerColumn() int {
+	if m.guard != "" {
+		return 2
+	}
+	return 1
+}
+
+// appendArgs appends one column's bound values, in the order columnSQL
+// consumes them.
+func (m matcher) appendArgs(dst []any) []any {
+	if m.guard != "" {
+		dst = append(dst, m.guard)
+	}
+	return append(dst, m.pattern)
+}
+
+// likePattern builds the LIKE pattern for term, normalizing it when the
+// comparison is normalized so both sides agree.
+func likePattern(term string, normalize bool) string {
+	if normalize {
+		term = normalizeMatchText(term)
+	}
+	return "%" + escapeLIKE(term) + "%"
+}

--- a/internal/data/store.go
+++ b/internal/data/store.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -320,6 +321,88 @@ const lastActiveJoinedExpr = `MAX(
 	COALESCE(s.created_at, '')
 )`
 
+// contentClause describes one searchable content source: a set of columns,
+// reached either directly on the session row or through an EXISTS subquery.
+// Keeping the columns declarative lets every caller render the same source
+// list with or without Unicode case folding.
+type contentClause struct {
+	from    string // subquery source, e.g. "turns t2"; empty for session columns
+	on      string // subquery join predicate
+	columns []string
+}
+
+// sql renders the clause. Each column contributes one comparison, bound in
+// column order.
+func (c contentClause) sql(m matcher) string {
+	parts := make([]string, len(c.columns))
+	for i, col := range c.columns {
+		parts[i] = m.columnSQL(col)
+	}
+	joined := strings.Join(parts, " OR ")
+	if c.from == "" {
+		if len(parts) == 1 {
+			return joined
+		}
+		return "(" + joined + ")"
+	}
+	return "EXISTS (SELECT 1 FROM " + c.from + " WHERE " + c.on + " AND (" + joined + "))"
+}
+
+// conversationClauses match the text a user reads inside a session: its
+// summary plus the turn and checkpoint content behind it. Deep search and the
+// excluded-word filter are inverse operations over this same list, so they
+// cannot drift apart: anything search can find, exclusion can hide.
+var conversationClauses = []contentClause{
+	{columns: []string{"s.summary"}},
+	{
+		from:    "turns t2",
+		on:      "t2.session_id = s.id",
+		columns: []string{"t2.user_message", "t2.assistant_response"},
+	},
+	{
+		from: "checkpoints cp",
+		on:   "cp.session_id = s.id",
+		columns: []string{
+			"cp.title", "cp.overview", "cp.history", "cp.work_done",
+			"cp.technical_details", "cp.important_files", "cp.next_steps",
+		},
+	},
+}
+
+// workspaceClauses match the artifacts a session touched. Search covers them
+// so that a file path or PR number finds the session; the excluded-word
+// filter deliberately does not, because hiding a session by a path it touched
+// is the job of excluded_dirs.
+var workspaceClauses = []contentClause{
+	{
+		from:    "session_files sf2",
+		on:      "sf2.session_id = s.id",
+		columns: []string{"sf2.file_path", "sf2.tool_name"},
+	},
+	{
+		from:    "session_refs sr2",
+		on:      "sr2.session_id = s.id",
+		columns: []string{"sr2.ref_type", "sr2.ref_value"},
+	},
+}
+
+// sessionMetadataClauses match a session's identity fields. Search covers
+// them; exclusion does not, so that excluding a common word cannot wipe out
+// every session that happens to live in a matching repository or folder.
+var sessionMetadataClauses = []contentClause{
+	{columns: []string{"s.branch"}},
+	{columns: []string{"s.repository"}},
+	{columns: []string{"s.cwd"}},
+}
+
+// quickSearchClauses are the session-level fields scanned without JOINs.
+var quickSearchClauses = []contentClause{
+	{columns: []string{"s.summary", "s.branch", "s.repository", "s.cwd"}},
+}
+
+// hostTypeClause is appended to deep search on schemas that have the column.
+var hostTypeClause = contentClause{columns: []string{"s.host_type"}}
+
 // filterBuilder accumulates JOIN and WHERE clauses with parameterised args.
 type filterBuilder struct {
 	joins                []string
@@ -353,33 +436,18 @@ func (fb *filterBuilder) apply(f FilterOptions) {
 			` OR EXISTS (SELECT 1 FROM session_refs sr3 WHERE sr3.session_id = s.id))`)
 
 	if f.Query != "" {
-		pattern := "%" + escapeLIKE(f.Query) + "%"
+		m := newMatcher(f.Query)
 		if f.DeepSearch {
 			// Deep mode scans every modeled source-table field directly. The
 			// search index is additive because it can be stale or incomplete.
-			clauses := []string{
-				`s.summary LIKE ? ESCAPE '\'`,
-				`s.branch LIKE ? ESCAPE '\'`,
-				`s.repository LIKE ? ESCAPE '\'`,
-				`s.cwd LIKE ? ESCAPE '\'`,
-				`EXISTS (SELECT 1 FROM turns t2 WHERE t2.session_id = s.id AND (` +
-					`t2.user_message LIKE ? ESCAPE '\' OR t2.assistant_response LIKE ? ESCAPE '\'))`,
-				`EXISTS (SELECT 1 FROM checkpoints cp WHERE cp.session_id = s.id AND (` +
-					`cp.title LIKE ? ESCAPE '\' OR cp.overview LIKE ? ESCAPE '\' OR cp.history LIKE ? ESCAPE '\' OR ` +
-					`cp.work_done LIKE ? ESCAPE '\' OR cp.technical_details LIKE ? ESCAPE '\' OR ` +
-					`cp.important_files LIKE ? ESCAPE '\' OR cp.next_steps LIKE ? ESCAPE '\'))`,
-				`EXISTS (SELECT 1 FROM session_files sf2 WHERE sf2.session_id = s.id AND (` +
-					`sf2.file_path LIKE ? ESCAPE '\' OR sf2.tool_name LIKE ? ESCAPE '\'))`,
-				`EXISTS (SELECT 1 FROM session_refs sr2 WHERE sr2.session_id = s.id AND (` +
-					`sr2.ref_type LIKE ? ESCAPE '\' OR sr2.ref_value LIKE ? ESCAPE '\'))`,
-			}
-			for range 17 {
-				fb.args = append(fb.args, pattern)
-			}
+			sources := make([]contentClause, 0, 9)
+			sources = append(sources, conversationClauses...)
+			sources = append(sources, workspaceClauses...)
+			sources = append(sources, sessionMetadataClauses...)
 			if fb.hasHostType {
-				clauses = append(clauses, `s.host_type LIKE ? ESCAPE '\'`)
-				fb.args = append(fb.args, pattern)
+				sources = append(sources, hostTypeClause)
 			}
+			clauses := fb.appendMatchClauses(sources, m)
 
 			if ftsTerms := escapeFTS5Terms(f.Query); fb.hasFTS && ftsTerms != "" {
 				clauses = append(clauses, `s.id IN (SELECT session_id FROM search_index WHERE content MATCH ?)`)
@@ -388,9 +456,8 @@ func (fb *filterBuilder) apply(f FilterOptions) {
 			fb.wheres = append(fb.wheres, "("+strings.Join(clauses, " OR ")+")")
 		} else {
 			// Quick mode: search only session-level fields (no JOINs).
-			fb.wheres = append(fb.wheres,
-				`(s.summary LIKE ? ESCAPE '\' OR s.branch LIKE ? ESCAPE '\' OR s.repository LIKE ? ESCAPE '\' OR s.cwd LIKE ? ESCAPE '\')`)
-			fb.args = append(fb.args, pattern, pattern, pattern, pattern)
+			clauses := fb.appendMatchClauses(quickSearchClauses, m)
+			fb.wheres = append(fb.wheres, "("+strings.Join(clauses, " OR ")+")")
 		}
 	}
 	if f.Folder != "" {
@@ -474,15 +541,27 @@ func (fb *filterBuilder) apply(f FilterOptions) {
 			if word == "" {
 				continue
 			}
-			pattern := "%" + escapeLIKE(strings.ToLower(word)) + "%"
-			fb.wheres = append(fb.wheres,
-				`(LOWER(COALESCE(s.summary,'')) NOT LIKE ? ESCAPE '\'`+
-					` AND NOT EXISTS (SELECT 1 FROM turns t3 WHERE t3.session_id = s.id`+
-					` AND (LOWER(COALESCE(t3.user_message,'')) LIKE ? ESCAPE '\'`+
-					` OR LOWER(COALESCE(t3.assistant_response,'')) LIKE ? ESCAPE '\')))`)
-			fb.args = append(fb.args, pattern, pattern, pattern)
+			// Hide the session when the word appears anywhere deep search
+			// would find it in the conversation, not just in the summary or
+			// a turn. NOT(a OR b OR c) keeps the predicate list identical to
+			// the search side.
+			clauses := fb.appendMatchClauses(conversationClauses, newMatcher(word))
+			fb.wheres = append(fb.wheres, "NOT ("+strings.Join(clauses, " OR ")+")")
 		}
 	}
+}
+
+// appendMatchClauses renders each clause and records its bound values, in
+// clause and column order.
+func (fb *filterBuilder) appendMatchClauses(clauses []contentClause, m matcher) []string {
+	rendered := make([]string, 0, len(clauses))
+	for _, c := range clauses {
+		rendered = append(rendered, c.sql(m))
+		for range len(c.columns) {
+			fb.args = m.appendArgs(fb.args)
+		}
+	}
+	return rendered
 }
 
 func folderMatchPatterns(folder string, windows bool) []string {
@@ -1428,7 +1507,12 @@ func (s *Store) GroupSessions(ctx context.Context, pivot PivotField, filter Filt
 			sortExpr = lastActiveJoinedExpr
 		}
 	}
-	q := fmt.Sprintf("SELECT %s AS pivot_label, %s FROM sessions s%s%s ORDER BY pivot_label, %s %s",
+	// Order by the session sort, not the pivot label. The row cap below is a
+	// budget of sessions to display, so it has to keep the ones the sort puts
+	// first; ordering by label instead would spend the whole budget on
+	// whichever label happens to sort first and hide every other group.
+	// Groups are re-ordered by label after grouping.
+	q := fmt.Sprintf("SELECT %s AS pivot_label, %s FROM sessions s%s%s ORDER BY %s %s, s.id ASC",
 		expr, columns, joins+fb.joinSQL(), fb.whereSQL(), sortExpr, sortDir(sort.Order))
 
 	if limit == 0 {
@@ -1480,6 +1564,12 @@ func (s *Store) GroupSessions(ctx context.Context, pivot PivotField, filter Filt
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterating grouped session rows: %w", err)
 	}
+
+	// Groups arrive in "first session seen" order because the query is sorted
+	// by session, not by label. Restore the label ordering callers rely on.
+	slices.SortFunc(result, func(a, b SessionGroup) int {
+		return strings.Compare(a.Label, b.Label)
+	})
 
 	return result, nil
 }

--- a/internal/data/store_regression_test.go
+++ b/internal/data/store_regression_test.go
@@ -1,0 +1,700 @@
+package data
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Grouped-query limit semantics
+//
+// GroupSessions caps the number of rows it reads. The cap must keep the most
+// relevant sessions according to the requested sort, exactly like
+// ListSessions does, so that every group the user is looking at is
+// represented. Truncating in pivot-label order instead collapses the result
+// to whichever label happens to sort first, which looks to the user like
+// "grouping shows one bucket of N sessions".
+// ---------------------------------------------------------------------------
+
+// seedGroupedFixture inserts sessions across three repositories. Repository
+// names are chosen so that "aaa/old" sorts before "zzz/new" as a pivot label
+// while its sessions are the least recently active.
+func seedGroupedFixture(t *testing.T, s *Store) {
+	t.Helper()
+	// Oldest sessions live in the alphabetically first repository.
+	for i := range 5 {
+		id := fmt.Sprintf("old-%d", i)
+		ts := fmt.Sprintf("2026-01-%02dT10:00:00Z", i+1)
+		seedSession(t, s.db, id, "/work/old", "aaa/old", "main", "old work", ts, ts)
+		seedTurn(t, s.db, id, 0, "question", "answer", ts)
+	}
+	// Newest sessions live in the alphabetically last repository.
+	for i := range 3 {
+		id := fmt.Sprintf("new-%d", i)
+		ts := fmt.Sprintf("2026-08-%02dT10:00:00Z", i+1)
+		seedSession(t, s.db, id, "/work/new", "zzz/new", "main", "new work", ts, ts)
+		seedTurn(t, s.db, id, 0, "question", "answer", ts)
+	}
+}
+
+// groupedSessionIDs flattens every session in every group.
+func groupedSessionIDs(groups []SessionGroup) []string {
+	var ids []string
+	for _, g := range groups {
+		for _, sess := range g.Sessions {
+			ids = append(ids, sess.ID)
+		}
+	}
+	return ids
+}
+
+func groupLabels(groups []SessionGroup) []string {
+	labels := make([]string, 0, len(groups))
+	for _, g := range groups {
+		labels = append(labels, g.Label)
+	}
+	return labels
+}
+
+func TestGroupSessionsLimitKeepsMostRecentAcrossGroups(t *testing.T) {
+	s := newTestStore(t)
+	defer func() { _ = s.Close() }()
+	seedGroupedFixture(t, s)
+
+	groups, err := s.GroupSessions(context.Background(), PivotByRepo, FilterOptions{},
+		SortOptions{Field: SortByUpdated, Order: Descending}, 3)
+	if err != nil {
+		t.Fatalf("GroupSessions: %v", err)
+	}
+
+	got := groupedSessionIDs(groups)
+	want := []string{"new-2", "new-1", "new-0"}
+	if len(got) != len(want) {
+		t.Fatalf("returned %d sessions %v, want %d %v", len(got), got, len(want), want)
+	}
+	for i, id := range want {
+		if got[i] != id {
+			t.Fatalf("session IDs = %v, want %v (limit must keep the most recently active sessions)", got, want)
+		}
+	}
+}
+
+func TestGroupSessionsLimitCoversEveryPivot(t *testing.T) {
+	pivots := []PivotField{PivotByRepo, PivotByBranch, PivotByHost, PivotByFolder}
+	for _, pivot := range pivots {
+		t.Run(string(pivot), func(t *testing.T) {
+			s := newTestStore(t)
+			defer func() { _ = s.Close() }()
+
+			// Two distinct pivot values: the first-sorting one holds only
+			// stale sessions, the second holds the freshest session.
+			seedSession(t, s.db, "stale-a", "/aaa", "aaa/repo", "aaa-branch", "stale", "2026-01-01T10:00:00Z", "2026-01-01T10:00:00Z")
+			seedTurn(t, s.db, "stale-a", 0, "q", "a", "2026-01-01T10:00:00Z")
+			seedSession(t, s.db, "stale-b", "/aaa", "aaa/repo", "aaa-branch", "stale", "2026-01-02T10:00:00Z", "2026-01-02T10:00:00Z")
+			seedTurn(t, s.db, "stale-b", 0, "q", "a", "2026-01-02T10:00:00Z")
+			seedSession(t, s.db, "fresh", "/zzz", "zzz/repo", "zzz-branch", "fresh", "2026-08-01T10:00:00Z", "2026-08-01T10:00:00Z")
+			seedTurn(t, s.db, "fresh", 0, "q", "a", "2026-08-01T10:00:00Z")
+			if _, err := s.db.Exec(`UPDATE sessions SET host_type = 'aaa-host' WHERE id LIKE 'stale%'`); err != nil {
+				t.Fatalf("setting host_type: %v", err)
+			}
+			if _, err := s.db.Exec(`UPDATE sessions SET host_type = 'zzz-host' WHERE id = 'fresh'`); err != nil {
+				t.Fatalf("setting host_type: %v", err)
+			}
+
+			groups, err := s.GroupSessions(context.Background(), pivot, FilterOptions{},
+				SortOptions{Field: SortByUpdated, Order: Descending}, 1)
+			if err != nil {
+				t.Fatalf("GroupSessions(%s): %v", pivot, err)
+			}
+			got := groupedSessionIDs(groups)
+			if len(got) != 1 || got[0] != "fresh" {
+				t.Fatalf("GroupSessions(%s) with limit 1 = %v, want [fresh]", pivot, got)
+			}
+		})
+	}
+}
+
+func TestGroupSessionsByDateLimitKeepsNewestDays(t *testing.T) {
+	s := newTestStore(t)
+	defer func() { _ = s.Close() }()
+
+	// Five sessions, one per day, spanning January to August.
+	days := []string{
+		"2026-01-29T12:00:00Z",
+		"2026-01-30T12:00:00Z",
+		"2026-02-02T12:00:00Z",
+		"2026-08-19T12:00:00Z",
+		"2026-08-20T12:00:00Z",
+	}
+	for i, ts := range days {
+		id := fmt.Sprintf("day-%d", i)
+		seedSession(t, s.db, id, "/work", "owner/repo", "main", "work", ts, ts)
+		seedTurn(t, s.db, id, 0, "q", "a", ts)
+	}
+
+	groups, err := s.GroupSessions(context.Background(), PivotByDate, FilterOptions{},
+		SortOptions{Field: SortByUpdated, Order: Descending}, 2)
+	if err != nil {
+		t.Fatalf("GroupSessions: %v", err)
+	}
+
+	got := groupedSessionIDs(groups)
+	if len(got) != 2 {
+		t.Fatalf("returned %d sessions %v, want 2", len(got), got)
+	}
+	for _, id := range got {
+		if id != "day-3" && id != "day-4" {
+			t.Fatalf("date pivot with limit 2 returned %v, want the two newest days (day-3, day-4); "+
+				"truncating oldest-first hides recent activity", got)
+		}
+	}
+}
+
+func TestGroupSessionsOrdersGroupsByLabel(t *testing.T) {
+	s := newTestStore(t)
+	defer func() { _ = s.Close() }()
+	seedGroupedFixture(t, s)
+
+	groups, err := s.GroupSessions(context.Background(), PivotByRepo, FilterOptions{},
+		SortOptions{Field: SortByUpdated, Order: Descending}, 0)
+	if err != nil {
+		t.Fatalf("GroupSessions: %v", err)
+	}
+	want := []string{"aaa/old", "zzz/new"}
+	got := groupLabels(groups)
+	if len(got) != len(want) {
+		t.Fatalf("group labels = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("group labels = %v, want %v (groups must stay label-ordered)", got, want)
+		}
+	}
+}
+
+func TestGroupSessionsSortsSessionsWithinGroup(t *testing.T) {
+	s := newTestStore(t)
+	defer func() { _ = s.Close() }()
+	seedGroupedFixture(t, s)
+
+	groups, err := s.GroupSessions(context.Background(), PivotByRepo, FilterOptions{},
+		SortOptions{Field: SortByUpdated, Order: Descending}, 0)
+	if err != nil {
+		t.Fatalf("GroupSessions: %v", err)
+	}
+	for _, g := range groups {
+		for i := 1; i < len(g.Sessions); i++ {
+			if g.Sessions[i-1].LastActiveAt < g.Sessions[i].LastActiveAt {
+				t.Fatalf("group %q not sorted descending by last active: %v", g.Label, g.Sessions)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Excluded-word coverage
+//
+// Deep search matches a session when the term appears in any indexed content
+// source. The excluded-word filter is the inverse operation and must cover
+// the same sources, otherwise a session the user asked to hide stays visible
+// (and is still discoverable through search).
+// ---------------------------------------------------------------------------
+
+// seedExcludedWordSources inserts one session per content source, each holding
+// the token "quarantine" in exactly one place.
+func seedExcludedWordSources(t *testing.T, s *Store) {
+	t.Helper()
+	const ts = "2026-05-01T10:00:00Z"
+	mk := func(id, summary string) {
+		seedSession(t, s.db, id, "/work/"+id, "owner/repo", "main", summary, ts, ts)
+		seedTurn(t, s.db, id, 0, "unrelated", "unrelated", ts)
+	}
+	mk("by-summary", "quarantine this session")
+	mk("by-user-message", "clean summary")
+	mk("by-assistant-response", "clean summary")
+	mk("by-checkpoint-title", "clean summary")
+	mk("by-checkpoint-overview", "clean summary")
+	mk("by-checkpoint-body", "clean summary")
+	mk("keep-me", "clean summary")
+
+	seedTurn(t, s.db, "by-user-message", 1, "please quarantine it", "sure", ts)
+	seedTurn(t, s.db, "by-assistant-response", 1, "go on", "running quarantine now", ts)
+	seedCheckpoint(t, s.db, "by-checkpoint-title", 1, "quarantine plan", "nothing here")
+	seedCheckpoint(t, s.db, "by-checkpoint-overview", 1, "plan", "quarantine the flaky job")
+	seedCheckpointBody(t, s.db, "by-checkpoint-body", 1, "quarantine")
+}
+
+// seedCheckpointBody inserts a checkpoint whose only match is in the
+// long-form fields (history, work_done, technical_details, next_steps).
+func seedCheckpointBody(t *testing.T, db *sql.DB, sessionID string, num int, token string) {
+	t.Helper()
+	_, err := db.Exec(
+		`INSERT INTO checkpoints (session_id, checkpoint_number, title, overview, history, work_done, technical_details, important_files, next_steps)
+		 VALUES (?, ?, 'plan', 'nothing', ?, ?, ?, '', ?)`,
+		sessionID, num, token, token, token, token,
+	)
+	if err != nil {
+		t.Fatalf("seeding checkpoint body: %v", err)
+	}
+}
+
+func TestExcludedWordsCoverSameSourcesAsDeepSearch(t *testing.T) {
+	s := newTestStore(t)
+	defer func() { _ = s.Close() }()
+	seedExcludedWordSources(t, s)
+
+	ctx := context.Background()
+	sort := SortOptions{Field: SortByUpdated, Order: Descending}
+
+	// Every session deep search can find by the token must be hidden when
+	// the same token is excluded.
+	found, err := s.ListSessions(ctx, FilterOptions{Query: "quarantine", DeepSearch: true}, sort, 0)
+	if err != nil {
+		t.Fatalf("deep search: %v", err)
+	}
+	if len(found) == 0 {
+		t.Fatal("deep search found no sessions; fixture is wrong")
+	}
+
+	remaining, err := s.ListSessions(ctx, FilterOptions{ExcludedWords: []string{"quarantine"}}, sort, 0)
+	if err != nil {
+		t.Fatalf("ListSessions with ExcludedWords: %v", err)
+	}
+	visible := make(map[string]bool, len(remaining))
+	for _, sess := range remaining {
+		visible[sess.ID] = true
+	}
+	for _, sess := range found {
+		if visible[sess.ID] {
+			t.Errorf("session %q matches deep search for %q but survives the excluded-word filter",
+				sess.ID, "quarantine")
+		}
+	}
+	if !visible["keep-me"] {
+		t.Error("session without the excluded word should stay visible")
+	}
+}
+
+func TestExcludedWordsAreCaseInsensitiveInEverySource(t *testing.T) {
+	const ts = "2026-05-01T10:00:00Z"
+	cases := []struct {
+		name string
+		// seed places the mixed-case token in one content source.
+		seed func(t *testing.T, s *Store, id string)
+	}{
+		{
+			name: "summary",
+			seed: func(t *testing.T, s *Store, id string) {
+				seedSession(t, s.db, id, "/work", "owner/repo", "main", "Refactor QuarantineRunner", ts, ts)
+				seedTurn(t, s.db, id, 0, "unrelated", "unrelated", ts)
+			},
+		},
+		{
+			name: "user_message",
+			seed: func(t *testing.T, s *Store, id string) {
+				seedSession(t, s.db, id, "/work", "owner/repo", "main", "clean", ts, ts)
+				seedTurn(t, s.db, id, 0, "Please QUARANTINE the job", "sure", ts)
+			},
+		},
+		{
+			name: "assistant_response",
+			seed: func(t *testing.T, s *Store, id string) {
+				seedSession(t, s.db, id, "/work", "owner/repo", "main", "clean", ts, ts)
+				seedTurn(t, s.db, id, 0, "go on", "Running Quarantine now", ts)
+			},
+		},
+		{
+			name: "checkpoint_title",
+			seed: func(t *testing.T, s *Store, id string) {
+				seedSession(t, s.db, id, "/work", "owner/repo", "main", "clean", ts, ts)
+				seedTurn(t, s.db, id, 0, "unrelated", "unrelated", ts)
+				seedCheckpoint(t, s.db, id, 1, "QuArAnTiNe plan", "nothing")
+			},
+		},
+		{
+			name: "checkpoint_body",
+			seed: func(t *testing.T, s *Store, id string) {
+				seedSession(t, s.db, id, "/work", "owner/repo", "main", "clean", ts, ts)
+				seedTurn(t, s.db, id, 0, "unrelated", "unrelated", ts)
+				seedCheckpointBody(t, s.db, id, 1, "QUARANTINE")
+			},
+		},
+	}
+
+	// The configured word and the stored text differ in case in both
+	// directions, so neither side may be relied on to be pre-folded.
+	words := []string{"quarantine", "QUARANTINE", "QuArAnTiNe"}
+
+	for _, tc := range cases {
+		for _, word := range words {
+			t.Run(tc.name+"/"+word, func(t *testing.T) {
+				s := newTestStore(t)
+				defer func() { _ = s.Close() }()
+				tc.seed(t, s, "hide-me")
+
+				sessions, err := s.ListSessions(context.Background(),
+					FilterOptions{ExcludedWords: []string{word}},
+					SortOptions{Field: SortByUpdated, Order: Descending}, 0)
+				if err != nil {
+					t.Fatalf("ListSessions: %v", err)
+				}
+				if len(sessions) != 0 {
+					t.Fatalf("excluding %q left %d sessions visible; the %s match must be case-insensitive",
+						word, len(sessions), tc.name)
+				}
+			})
+		}
+	}
+}
+
+func TestExcludedWordsCaseInsensitiveKeepsNonMatches(t *testing.T) {
+	s := newTestStore(t)
+	defer func() { _ = s.Close() }()
+	const ts = "2026-05-01T10:00:00Z"
+	seedSession(t, s.db, "keep-me", "/work", "owner/repo", "main", "Quarterly report", ts, ts)
+	seedTurn(t, s.db, "keep-me", 0, "unrelated", "unrelated", ts)
+
+	sessions, err := s.ListSessions(context.Background(),
+		FilterOptions{ExcludedWords: []string{"QUARANTINE"}},
+		SortOptions{Field: SortByUpdated, Order: Descending}, 0)
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	requireSessionIDs(t, sessions, "keep-me")
+}
+
+func TestExcludedWordsFoldNonASCIICase(t *testing.T) {
+	const ts = "2026-05-01T10:00:00Z"
+	cases := []struct {
+		name   string
+		stored string
+		word   string
+	}{
+		{"upper-content-lower-word", "Réparer le CAFÉ", "café"},
+		{"lower-content-upper-word", "Réparer le café", "CAFÉ"},
+		{"umlaut", "ÜBER pipeline", "über"},
+		{"a-umlaut", "Ärger report", "ärger"},
+		{"cyrillic", "ПРИВЕТ мир", "привет"},
+		{"turkish-dotted-i", "İSTANBUL trip", "İstanbul"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(t)
+			defer func() { _ = s.Close() }()
+			seedSession(t, s.db, "hide-me", "/work", "owner/repo", "main", tc.stored, ts, ts)
+			seedTurn(t, s.db, "hide-me", 0, "unrelated", "unrelated", ts)
+
+			sessions, err := s.ListSessions(context.Background(),
+				FilterOptions{ExcludedWords: []string{tc.word}},
+				SortOptions{Field: SortByUpdated, Order: Descending}, 0)
+			if err != nil {
+				t.Fatalf("ListSessions: %v", err)
+			}
+			if len(sessions) != 0 {
+				t.Fatalf("excluding %q left the session with summary %q visible; "+
+					"case folding must cover non-ASCII text", tc.word, tc.stored)
+			}
+		})
+	}
+}
+
+func TestExcludedWordsFoldNonASCIIInTurnsAndCheckpoints(t *testing.T) {
+	const ts = "2026-05-01T10:00:00Z"
+	cases := []struct {
+		name string
+		seed func(t *testing.T, s *Store)
+	}{
+		{
+			name: "turn",
+			seed: func(t *testing.T, s *Store) {
+				seedSession(t, s.db, "hide-me", "/work", "owner/repo", "main", "clean", ts, ts)
+				seedTurn(t, s.db, "hide-me", 0, "check the CAFÉ order", "ok", ts)
+			},
+		},
+		{
+			name: "checkpoint",
+			seed: func(t *testing.T, s *Store) {
+				seedSession(t, s.db, "hide-me", "/work", "owner/repo", "main", "clean", ts, ts)
+				seedTurn(t, s.db, "hide-me", 0, "unrelated", "unrelated", ts)
+				seedCheckpoint(t, s.db, "hide-me", 1, "CAFÉ rollout", "nothing")
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(t)
+			defer func() { _ = s.Close() }()
+			tc.seed(t, s)
+
+			sessions, err := s.ListSessions(context.Background(),
+				FilterOptions{ExcludedWords: []string{"café"}},
+				SortOptions{Field: SortByUpdated, Order: Descending}, 0)
+			if err != nil {
+				t.Fatalf("ListSessions: %v", err)
+			}
+			if len(sessions) != 0 {
+				t.Fatalf("excluding %q left the %s match visible", "café", tc.name)
+			}
+		})
+	}
+}
+
+// Search and exclusion share one clause list, so case folding has to behave
+// the same on both sides.
+func TestDeepSearchFoldsNonASCIICase(t *testing.T) {
+	s := newTestStore(t)
+	defer func() { _ = s.Close() }()
+	const ts = "2026-05-01T10:00:00Z"
+	seedSession(t, s.db, "find-me", "/work", "owner/repo", "main", "Réparer le CAFÉ", ts, ts)
+	seedTurn(t, s.db, "find-me", 0, "unrelated", "unrelated", ts)
+
+	for _, query := range []string{"café", "CAFÉ", "Café"} {
+		found, err := s.ListSessions(context.Background(),
+			FilterOptions{Query: query, DeepSearch: true},
+			SortOptions{Field: SortByUpdated, Order: Descending}, 0)
+		if err != nil {
+			t.Fatalf("deep search %q: %v", query, err)
+		}
+		if len(found) != 1 {
+			t.Errorf("deep search for %q found %d sessions, want 1", query, len(found))
+		}
+	}
+}
+
+func TestQuickSearchFoldsNonASCIICase(t *testing.T) {
+	s := newTestStore(t)
+	defer func() { _ = s.Close() }()
+	const ts = "2026-05-01T10:00:00Z"
+	seedSession(t, s.db, "find-me", "/work", "owner/repo", "main", "Réparer le CAFÉ", ts, ts)
+	seedTurn(t, s.db, "find-me", 0, "unrelated", "unrelated", ts)
+
+	found, err := s.ListSessions(context.Background(),
+		FilterOptions{Query: "café"},
+		SortOptions{Field: SortByUpdated, Order: Descending}, 0)
+	if err != nil {
+		t.Fatalf("quick search: %v", err)
+	}
+	if len(found) != 1 {
+		t.Fatalf("quick search for %q found %d sessions, want 1", "café", len(found))
+	}
+}
+
+// Normalization runs a per-row callback, so it is only enabled when the term
+// needs it: non-ASCII text (which SQLite's LIKE cannot fold) or whitespace
+// (which the list collapses for display). This pins that trigger, and with it
+// the one case the filter cannot fold: a single-word ASCII term whose only
+// case-variant in the stored text is a non-ASCII character (Turkish "İ").
+func TestNeedsNormalization(t *testing.T) {
+	if !normReady {
+		t.Skip("match normalization function not registered")
+	}
+	cases := []struct {
+		term string
+		want bool
+	}{
+		{"invoke", false},
+		{"", false},
+		{"devx-frontend-learn", false},
+		{"Task Invoke", true},
+		{"Task\tInvoke", true},
+		{"café", true},
+		{"ÜBER", true},
+		{"привет", true},
+		{"İstanbul", true},
+	}
+	for _, tc := range cases {
+		if got := needsNormalization(tc.term); got != tc.want {
+			t.Errorf("needsNormalization(%q) = %v, want %v", tc.term, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeMatchTextMirrorsDisplay(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"## Task\n\nInvoke the skill", "## task invoke the skill"},
+		{"  leading and   trailing  ", "leading and trailing"},
+		{"CAFÉ", "café"},
+		{"tabs\tand\nnewlines", "tabs and newlines"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := normalizeMatchText(tc.in); got != tc.want {
+			t.Errorf("normalizeMatchText(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestLikePatternNormalizesOnlyWhenAsked(t *testing.T) {
+	if got, want := likePattern("Task\n\nInvoke", true), "%task invoke%"; got != want {
+		t.Errorf("likePattern(normalized) = %q, want %q", got, want)
+	}
+	// Unnormalized patterns keep their case because SQLite's LIKE folds ASCII
+	// on both sides already.
+	if got, want := likePattern("Invoke", false), "%Invoke%"; got != want {
+		t.Errorf("likePattern(raw) = %q, want %q", got, want)
+	}
+	// Wildcards stay literal in both modes.
+	if got, want := likePattern("100%", false), `%100\%%`; got != want {
+		t.Errorf("likePattern(wildcard) = %q, want %q", got, want)
+	}
+	if got, want := likePattern("50% off", true), `%50\% off%`; got != want {
+		t.Errorf("likePattern(normalized wildcard) = %q, want %q", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Displayed text vs stored text
+//
+// The session list renders summaries through CleanSummary, which collapses
+// every whitespace run to a single space. A summary stored as
+// "## Task\n\nInvoke the skill" is shown as "## Task Invoke the skill", so a
+// user excluding the phrase they can see types "Task Invoke". Matching against
+// the raw stored text never finds it.
+// ---------------------------------------------------------------------------
+
+// storedTaskSummary reproduces the real shape of an agent sub-task summary:
+// a markdown heading, a blank line, then the body.
+const storedTaskSummary = "## Task\n\nInvoke the devx-frontend-learn skill via the skill tool. You have the contract."
+
+func TestExcludedWordsMatchDisplayedWhitespace(t *testing.T) {
+	const ts = "2026-05-01T10:00:00Z"
+	cases := []struct {
+		name string
+		word string
+	}{
+		{"phrase-as-displayed", "Task Invoke"},
+		{"phrase-lowercase", "task invoke"},
+		{"phrase-extra-spaces", "Task   Invoke"},
+		{"phrase-spanning-body", "Invoke the devx-frontend-learn skill"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(t)
+			defer func() { _ = s.Close() }()
+			seedSession(t, s.db, "hide-me", "/work", "owner/repo", "main", storedTaskSummary, ts, ts)
+			seedTurn(t, s.db, "hide-me", 0, "unrelated", "unrelated", ts)
+
+			sessions, err := s.ListSessions(context.Background(),
+				FilterOptions{ExcludedWords: []string{tc.word}},
+				SortOptions{Field: SortByUpdated, Order: Descending}, 0)
+			if err != nil {
+				t.Fatalf("ListSessions: %v", err)
+			}
+			if len(sessions) != 0 {
+				t.Fatalf("excluding %q left the session visible; the summary renders as "+
+					"%q in the list, so the phrase the user sees must match", tc.word, "## Task Invoke ...")
+			}
+		})
+	}
+}
+
+func TestExcludedWordsWhitespaceInTurnsAndCheckpoints(t *testing.T) {
+	const ts = "2026-05-01T10:00:00Z"
+	cases := []struct {
+		name string
+		seed func(t *testing.T, s *Store)
+	}{
+		{
+			name: "turn",
+			seed: func(t *testing.T, s *Store) {
+				seedSession(t, s.db, "hide-me", "/work", "owner/repo", "main", "clean", ts, ts)
+				seedTurn(t, s.db, "hide-me", 0, storedTaskSummary, "ok", ts)
+			},
+		},
+		{
+			name: "checkpoint",
+			seed: func(t *testing.T, s *Store) {
+				seedSession(t, s.db, "hide-me", "/work", "owner/repo", "main", "clean", ts, ts)
+				seedTurn(t, s.db, "hide-me", 0, "unrelated", "unrelated", ts)
+				seedCheckpoint(t, s.db, "hide-me", 1, "plan", storedTaskSummary)
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(t)
+			defer func() { _ = s.Close() }()
+			tc.seed(t, s)
+
+			sessions, err := s.ListSessions(context.Background(),
+				FilterOptions{ExcludedWords: []string{"Task Invoke"}},
+				SortOptions{Field: SortByUpdated, Order: Descending}, 0)
+			if err != nil {
+				t.Fatalf("ListSessions: %v", err)
+			}
+			if len(sessions) != 0 {
+				t.Fatalf("excluding %q left the %s match visible", "Task Invoke", tc.name)
+			}
+		})
+	}
+}
+
+// Search and exclusion share one clause list, so searching the phrase a user
+// can see has to find the same sessions exclusion hides.
+func TestSearchMatchesDisplayedWhitespace(t *testing.T) {
+	const ts = "2026-05-01T10:00:00Z"
+	for _, deep := range []bool{false, true} {
+		name := "quick"
+		if deep {
+			name = "deep"
+		}
+		t.Run(name, func(t *testing.T) {
+			s := newTestStore(t)
+			defer func() { _ = s.Close() }()
+			seedSession(t, s.db, "find-me", "/work", "owner/repo", "main", storedTaskSummary, ts, ts)
+			seedTurn(t, s.db, "find-me", 0, "unrelated", "unrelated", ts)
+
+			found, err := s.ListSessions(context.Background(),
+				FilterOptions{Query: "Task Invoke", DeepSearch: deep},
+				SortOptions{Field: SortByUpdated, Order: Descending}, 0)
+			if err != nil {
+				t.Fatalf("search: %v", err)
+			}
+			if len(found) != 1 {
+				t.Fatalf("%s search for %q found %d sessions, want 1", name, "Task Invoke", len(found))
+			}
+		})
+	}
+}
+
+// A phrase must still be a phrase: collapsing whitespace must not turn the
+// match into "these words appear somewhere in any order".
+func TestExcludedWordsPhraseStaysContiguous(t *testing.T) {
+	s := newTestStore(t)
+	defer func() { _ = s.Close() }()
+	const ts = "2026-05-01T10:00:00Z"
+	seedSession(t, s.db, "keep-me", "/work", "owner/repo", "main",
+		"Task queue cleanup, then invoke the runner", ts, ts)
+	seedTurn(t, s.db, "keep-me", 0, "unrelated", "unrelated", ts)
+
+	sessions, err := s.ListSessions(context.Background(),
+		FilterOptions{ExcludedWords: []string{"Task Invoke"}},
+		SortOptions{Field: SortByUpdated, Order: Descending}, 0)
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	requireSessionIDs(t, sessions, "keep-me")
+}
+
+func TestGroupSessionsExcludedWordsCoverCheckpoints(t *testing.T) {
+	s := newTestStore(t)
+	defer func() { _ = s.Close() }()
+	seedExcludedWordSources(t, s)
+
+	groups, err := s.GroupSessions(context.Background(), PivotByRepo,
+		FilterOptions{ExcludedWords: []string{"quarantine"}},
+		SortOptions{Field: SortByUpdated, Order: Descending}, 0)
+	if err != nil {
+		t.Fatalf("GroupSessions: %v", err)
+	}
+	for _, id := range groupedSessionIDs(groups) {
+		if id != "keep-me" {
+			t.Errorf("grouped list still shows %q after excluding %q", id, "quarantine")
+		}
+	}
+}

--- a/internal/tui/components/sessionlist.go
+++ b/internal/tui/components/sessionlist.go
@@ -43,6 +43,7 @@ type SessionList struct {
 	allItems       []displayItem                    // every item (folders + sessions)
 	visItems       []int                            // indices into allItems that are currently visible
 	expanded       map[string]struct{}              // folder path → expanded state (tree mode)
+	knownGroups    map[string]struct{}              // folder path → already given its default state
 	hiddenSet      map[string]struct{}              // session ID → hidden sessions
 	favoritedSet   map[string]struct{}              // session ID → favorited sessions
 	attentionMap   map[string]data.AttentionStatus  // session ID → attention status
@@ -69,8 +70,9 @@ type SessionList struct {
 // NewSessionList returns an empty SessionList.
 func NewSessionList() SessionList {
 	return SessionList{
-		expanded: make(map[string]struct{}),
-		selected: make(map[string]struct{}),
+		expanded:    make(map[string]struct{}),
+		knownGroups: make(map[string]struct{}),
+		selected:    make(map[string]struct{}),
 	}
 }
 
@@ -109,11 +111,19 @@ func (s *SessionList) SetGroups(groups []data.SessionGroup) {
 
 // SetGroupsWithQuickStarts replaces the list content with grouped sessions and
 // optional "New session" rows under a dedicated group.
+//
+// This runs on every reload, including the background auto-refresh, so it must
+// preserve the expand/collapse state the user chose. Only a group that has
+// never been shown before gets the expanded default: an absent entry in
+// `expanded` otherwise means the user collapsed it.
 func (s *SessionList) SetGroupsWithQuickStarts(groups []data.SessionGroup, quickStarts []QuickStart) {
 	s.allItems = nil
 	s.selected = make(map[string]struct{})
 	if s.expanded == nil {
 		s.expanded = make(map[string]struct{})
+	}
+	if s.knownGroups == nil {
+		s.knownGroups = make(map[string]struct{})
 	}
 	for _, g := range groups {
 		s.allItems = append(s.allItems, displayItem{
@@ -121,23 +131,28 @@ func (s *SessionList) SetGroupsWithQuickStarts(groups []data.SessionGroup, quick
 			folderPath: g.Label,
 			count:      g.Count,
 		})
-		// Default to expanded on first encounter.
-		if _, ok := s.expanded[g.Label]; !ok {
-			s.expanded[g.Label] = struct{}{}
-		}
+		s.applyDefaultExpansion(g.Label)
 		for _, sess := range g.Sessions {
 			s.allItems = append(s.allItems, displayItem{session: sess})
 		}
 	}
 	if len(quickStarts) > 0 {
 		s.allItems = append(s.allItems, displayItem{isFolder: true, folderPath: quickStartGroupLabel, count: len(quickStarts)})
-		if _, ok := s.expanded[quickStartGroupLabel]; !ok {
-			s.expanded[quickStartGroupLabel] = struct{}{}
-		}
+		s.applyDefaultExpansion(quickStartGroupLabel)
 		s.appendQuickStarts(quickStarts)
 	}
 	s.treeMode = true
 	s.rebuildVisible()
+}
+
+// applyDefaultExpansion expands a group the first time it is displayed and
+// leaves the user's choice alone on every later reload.
+func (s *SessionList) applyDefaultExpansion(label string) {
+	if _, known := s.knownGroups[label]; known {
+		return
+	}
+	s.knownGroups[label] = struct{}{}
+	s.expanded[label] = struct{}{}
 }
 
 func (s *SessionList) appendQuickStarts(quickStarts []QuickStart) {

--- a/internal/tui/components/sessionlist_collapse_persist_test.go
+++ b/internal/tui/components/sessionlist_collapse_persist_test.go
@@ -1,0 +1,109 @@
+package components
+
+import (
+	"testing"
+
+	"github.com/jongio/dispatch/internal/data"
+)
+
+// The session list reloads on a timer (auto-refresh defaults to 2s) and after
+// every sort, filter, or status update. Each reload calls SetGroups again with
+// the same labels. Collapse state is user intent and has to survive that:
+// otherwise pressing "collapse all" appears to work and then silently undoes
+// itself the moment a refresh lands.
+
+func collapseTestGroups() []data.SessionGroup {
+	return []data.SessionGroup{
+		{Label: "alpha", Count: 2, Sessions: []data.Session{{ID: "a1"}, {ID: "a2"}}},
+		{Label: "beta", Count: 1, Sessions: []data.Session{{ID: "b1"}}},
+	}
+}
+
+func newCollapseTestList(t *testing.T) *SessionList {
+	t.Helper()
+	sl := NewSessionList()
+	sl.SetSize(120, 20)
+	sl.SetGroups(collapseTestGroups())
+	return &sl
+}
+
+func TestCollapseAllSurvivesReload(t *testing.T) {
+	sl := newCollapseTestList(t)
+	if !sl.AllExpanded() {
+		t.Fatal("groups should start expanded")
+	}
+
+	sl.CollapseAll()
+	if got := len(sl.visItems); got != 2 {
+		t.Fatalf("after CollapseAll: %d visible items, want 2 folder rows", got)
+	}
+
+	// A background refresh delivers the same groups again.
+	sl.SetGroups(collapseTestGroups())
+
+	if got := len(sl.visItems); got != 2 {
+		t.Fatalf("after reload: %d visible items, want 2; the reload re-expanded "+
+			"groups the user collapsed", got)
+	}
+	if sl.AllExpanded() {
+		t.Fatal("after reload: groups report expanded again, so the next keypress expands instead of collapsing")
+	}
+}
+
+func TestCollapsedFolderSurvivesReload(t *testing.T) {
+	sl := newCollapseTestList(t)
+
+	// Collapse only the first group.
+	sl.SetCursor(0)
+	if !sl.ToggleFolder() {
+		t.Fatal("cursor should be on a folder row")
+	}
+	before := len(sl.visItems)
+	if before != 4 { // alpha header + beta header + beta's 1 session... plus alpha collapsed
+		t.Logf("visible after collapsing alpha: %d", before)
+	}
+
+	sl.SetGroups(collapseTestGroups())
+
+	if got := len(sl.visItems); got != before {
+		t.Fatalf("after reload: %d visible items, want %d; the reload re-expanded "+
+			"the folder the user collapsed", got, before)
+	}
+}
+
+// A group the user has never seen still defaults to expanded, so new activity
+// is visible without hunting for it.
+func TestNewGroupDefaultsToExpandedAfterCollapseAll(t *testing.T) {
+	sl := newCollapseTestList(t)
+	sl.CollapseAll()
+
+	groups := append(collapseTestGroups(), data.SessionGroup{
+		Label: "gamma", Count: 1, Sessions: []data.Session{{ID: "g1"}},
+	})
+	sl.SetGroups(groups)
+
+	// alpha, beta stay collapsed (2 rows); gamma is new so it expands (2 rows).
+	if got := len(sl.visItems); got != 4 {
+		t.Fatalf("after reload with a new group: %d visible items, want 4 "+
+			"(2 collapsed headers + new group header + its session)", got)
+	}
+}
+
+// Re-expanding after a collapse must also stick across a reload.
+func TestExpandAllSurvivesReload(t *testing.T) {
+	sl := newCollapseTestList(t)
+	sl.CollapseAll()
+	sl.SetGroups(collapseTestGroups())
+	sl.ExpandAll()
+
+	if got := len(sl.visItems); got != 5 {
+		t.Fatalf("after ExpandAll: %d visible items, want 5", got)
+	}
+	sl.SetGroups(collapseTestGroups())
+	if got := len(sl.visItems); got != 5 {
+		t.Fatalf("after reload: %d visible items, want 5", got)
+	}
+	if !sl.AllExpanded() {
+		t.Fatal("groups should still report expanded after reload")
+	}
+}

--- a/internal/tui/model_expand_collapse_test.go
+++ b/internal/tui/model_expand_collapse_test.go
@@ -1,0 +1,129 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/jongio/dispatch/internal/data"
+)
+
+// The session list reloads on a timer and after every sort, filter, or status
+// update. Pressing "x" has to stay a predictable toggle across those reloads:
+// collapse, then expand, then collapse. When a reload silently re-expands the
+// groups, the next "x" collapses again instead of expanding, so the key
+// appears to do the same thing twice, or to collapse and immediately reopen.
+
+func expandCollapseTestGroups() []data.SessionGroup {
+	return []data.SessionGroup{
+		{Label: "alpha", Count: 2, Sessions: []data.Session{{ID: "a1"}, {ID: "a2"}}},
+		{Label: "beta", Count: 1, Sessions: []data.Session{{ID: "b1"}}},
+	}
+}
+
+// newExpandCollapseModel returns a model in grouped mode with two groups.
+func newExpandCollapseModel(t *testing.T) Model {
+	t.Helper()
+	m := newTestModelWithSize(120, 30)
+	m.pivot = pivotRepo
+	m.groups = expandCollapseTestGroups()
+	m.sessionList.SetPivotField(m.pivot)
+	m.sessionList.SetGroupsWithQuickStarts(m.groups, nil)
+	return m
+}
+
+// reload simulates the background refresh delivering the same groups again.
+func reload(m Model) Model {
+	m.sessionList.SetPivotField(m.pivot)
+	m.sessionList.SetGroupsWithQuickStarts(m.groups, nil)
+	return m
+}
+
+func pressX(t *testing.T, m Model) Model {
+	t.Helper()
+	result, _ := m.Update(runeKeyMsg('x'))
+	return result.(Model)
+}
+
+func TestExpandCollapseAllTogglesAcrossReloads(t *testing.T) {
+	m := newExpandCollapseModel(t)
+	const expanded, collapsed = 5, 2 // 2 headers + 3 sessions, vs 2 headers
+
+	if got := m.sessionList.VisibleCount(); got != expanded {
+		t.Fatalf("initial visible = %d, want %d", got, expanded)
+	}
+
+	m = pressX(t, m)
+	if got := m.sessionList.VisibleCount(); got != collapsed {
+		t.Fatalf("after first x: visible = %d, want %d (collapse)", got, collapsed)
+	}
+
+	// A refresh lands before the next keypress.
+	m = reload(m)
+	if got := m.sessionList.VisibleCount(); got != collapsed {
+		t.Fatalf("after reload: visible = %d, want %d; the refresh re-expanded "+
+			"groups the user collapsed", got, collapsed)
+	}
+
+	m = pressX(t, m)
+	if got := m.sessionList.VisibleCount(); got != expanded {
+		t.Fatalf("after second x: visible = %d, want %d (expand)", got, expanded)
+	}
+
+	m = reload(m)
+	m = pressX(t, m)
+	if got := m.sessionList.VisibleCount(); got != collapsed {
+		t.Fatalf("after third x: visible = %d, want %d (collapse)", got, collapsed)
+	}
+}
+
+// Without an intervening reload the key must still alternate cleanly.
+func TestExpandCollapseAllAlternatesWithoutReload(t *testing.T) {
+	m := newExpandCollapseModel(t)
+	want := []int{2, 5, 2, 5}
+	for i, expect := range want {
+		m = pressX(t, m)
+		if got := m.sessionList.VisibleCount(); got != expect {
+			t.Fatalf("press %d: visible = %d, want %d", i+1, got, expect)
+		}
+	}
+}
+
+// Several reloads in a row (auto-refresh ticks while the user is reading)
+// must not accumulate into a re-expand.
+func TestCollapseSurvivesRepeatedReloads(t *testing.T) {
+	m := newExpandCollapseModel(t)
+	m = pressX(t, m)
+	for i := range 5 {
+		m = reload(m)
+		if got := m.sessionList.VisibleCount(); got != 2 {
+			t.Fatalf("reload %d: visible = %d, want 2", i+1, got)
+		}
+	}
+}
+
+// default_collapsed collapses the list once the first load lands. That
+// collapse runs through the same path as the "x" key, so it has to survive
+// the reloads that follow.
+func TestDefaultCollapsedSurvivesReload(t *testing.T) {
+	m := newTestModelWithSize(120, 30)
+	m.pivot = pivotRepo
+	m.cfg.DefaultCollapsed = true
+	m.state = stateLoading
+
+	msg := groupsLoadedMsg{groups: expandCollapseTestGroups(), version: m.sessionLoadVersion}
+	loaded, _ := m.handleGroupsLoaded(msg)
+	if got := loaded.sessionList.VisibleCount(); got != 2 {
+		t.Fatalf("initial load with default_collapsed: visible = %d, want 2", got)
+	}
+
+	loaded = reload(loaded)
+	if got := loaded.sessionList.VisibleCount(); got != 2 {
+		t.Fatalf("after reload: visible = %d, want 2; default_collapsed was undone "+
+			"by the refresh", got)
+	}
+
+	// The first "x" should expand, because the list is currently collapsed.
+	loaded = pressX(t, loaded)
+	if got := loaded.sessionList.VisibleCount(); got != 5 {
+		t.Fatalf("after x: visible = %d, want 5 (expand)", got)
+	}
+}

--- a/internal/tui/model_grouped_limit_test.go
+++ b/internal/tui/model_grouped_limit_test.go
@@ -1,0 +1,97 @@
+package tui
+
+import "testing"
+
+// The session cap is a budget of rows to display, so a grouped load has to
+// spend it on the most recently active sessions across every group. Spending
+// it on whichever pivot label sorts first collapses the list to a single
+// group and hides recent work, which is what users see as "grouping by repo
+// just shows N sessions".
+func TestGroupedLoadSpendsSessionCapOnNewestAcrossGroups(t *testing.T) {
+	m := newBehavioralFlowModel(t)
+	m.store = openBehavioralFlowStore(t)
+
+	// Fixture: sess-000..sess-004, one hour apart with sess-000 newest,
+	// alternating between user/repo0 (even) and user/repo1 (odd).
+	m.cfg.MaxSessions = 2
+	m.pivot = pivotRepo
+
+	msg, ok := m.loadSessionsCmd()().(groupsLoadedMsg)
+	if !ok {
+		t.Fatalf("loadSessionsCmd returned %T, want groupsLoadedMsg", m.loadSessionsCmd()())
+	}
+
+	var ids []string
+	for _, group := range msg.groups {
+		for _, sess := range group.Sessions {
+			ids = append(ids, sess.ID)
+		}
+	}
+	if len(ids) != 2 {
+		t.Fatalf("grouped load returned %d sessions %v, want 2", len(ids), ids)
+	}
+	want := map[string]bool{"sess-000": true, "sess-001": true}
+	for _, id := range ids {
+		if !want[id] {
+			t.Fatalf("grouped load returned %v, want the two most recent sessions "+
+				"(sess-000, sess-001) rather than the first repository's rows", ids)
+		}
+	}
+	if len(msg.groups) != 2 {
+		t.Fatalf("grouped load produced %d groups, want one per repository", len(msg.groups))
+	}
+}
+
+// A pivot whose labels sort chronologically makes the truncation direction
+// obvious: capping in label order returns the oldest days and hides today's
+// sessions entirely.
+func TestGroupedByDateLoadKeepsNewestDays(t *testing.T) {
+	m := newBehavioralFlowModel(t)
+	m.store = openBehavioralFlowStore(t)
+
+	m.cfg.MaxSessions = 2
+	m.pivot = pivotDate
+
+	msg, ok := m.loadSessionsCmd()().(groupsLoadedMsg)
+	if !ok {
+		t.Fatal("loadSessionsCmd did not return groupsLoadedMsg")
+	}
+
+	var ids []string
+	for _, group := range msg.groups {
+		for _, sess := range group.Sessions {
+			ids = append(ids, sess.ID)
+		}
+	}
+	want := map[string]bool{"sess-000": true, "sess-001": true}
+	if len(ids) != 2 {
+		t.Fatalf("grouped date load returned %d sessions %v, want 2", len(ids), ids)
+	}
+	for _, id := range ids {
+		if !want[id] {
+			t.Fatalf("grouped date load returned %v, want the two most recent sessions", ids)
+		}
+	}
+}
+
+// Excluded words must hide sessions in the grouped list too, not only in the
+// flat one.
+func TestGroupedLoadAppliesExcludedWords(t *testing.T) {
+	m := newBehavioralFlowModel(t)
+	m.store = openBehavioralFlowStore(t)
+
+	m.pivot = pivotRepo
+	m.filter.ExcludedWords = []string{"Question 0-0"}
+
+	msg, ok := m.loadSessionsCmd()().(groupsLoadedMsg)
+	if !ok {
+		t.Fatal("loadSessionsCmd did not return groupsLoadedMsg")
+	}
+	for _, group := range msg.groups {
+		for _, sess := range group.Sessions {
+			if sess.ID == "sess-000" {
+				t.Fatal("grouped list still shows a session containing an excluded word")
+			}
+		}
+	}
+}


### PR DESCRIPTION
Restores three session-list regressions reported together, plus one related bug found while fixing them. Each was reproduced as a failing test before the fix.

## Grouped views showed a single group

`GroupSessions` built `ORDER BY pivot_label, <sort>` and then applied a global `LIMIT`. That cap is a budget of sessions to display, so ordering by label first spent the entire budget on whichever label sorted first and hid every other group. The `all` time range looked like it stopped partway through history for the same reason.

The query now orders by the active session sort, caps after, and sorts the assembled groups by label so callers see the ordering they had before.

## Excluded words did nothing

Two separate causes:

The filter matched raw stored text, but the list renders summaries through `CleanSummary`, which collapses whitespace runs. A summary stored as `## Task\n\nInvoke the skill` displays as `## Task Invoke the skill`, so the phrase a user types after reading the list never matched what was stored. On my database that was 70 sessions escaping a filter that looked correct.

SQLite's `LIKE` and `lower()` fold ASCII only, so `café` did not hide `CAFÉ` and `über` did not hide `ÜBER`. This affected search too, not just exclusion.

Matching now normalizes both sides through a registered deterministic scalar function. Normalization is only paid for when it can change the result, and the negated exclusion is guarded by a plain `LIKE` over the raw column so SQLite discards nearly every row without calling into Go. Without that guard a filtered load took roughly 2 seconds against 7,700 sessions, which the 2-second auto-refresh cannot absorb.

The searchable sources are also declared once as clause tables rather than duplicated between the search and exclusion branches, so the two cannot drift apart. Exclusion now covers checkpoint content alongside summaries and turns, which closes a gap where 57 sessions carried an excluded word only in a checkpoint.

Metadata fields stay search-only on purpose: hiding every session in a repository because its name contains a common word is `excluded_dirs`' job.

## Collapse state was undone by the background refresh

`SetGroupsWithQuickStarts` treated "label absent from `expanded`" as first encounter and expanded it, but `CollapseAll` works by deleting those keys. So every reload, including the 2-second refresh and any sort, filter, or status update, read a collapse as "never seen before" and re-expanded everything.

That explains why the collapse-all key felt random. It worked when no refresh landed between presses, collapsed and instantly re-expanded when one did, and looked like it collapsed twice in a row when the list had already been silently re-expanded.

`TestExpandCollapseAllAlternatesWithoutReload` passes without the fix, which pins the toggle logic as correct and the reload as the cause. Groups now track whether they have already been given their default state, so an absent entry unambiguously means the user collapsed it while a genuinely new group still defaults to expanded.

**Also fixed by the same change:** `default_collapsed` calls `CollapseAll` right after the first `SetGroups`, so the next refresh reverted it. `TestDefaultCollapsedSurvivesReload` covers it and fails without the fix.

## Tests

Every test here was confirmed failing before its fix and passing after.

- Store-level regression coverage for the grouped cap, the displayed-text mismatch, and case folding across 5 content sources (summary, user message, assistant response, checkpoint title, checkpoint body) in 3 case variants
- Model-level coverage that the grouped cap fills groups by sort order
- Component and model coverage that collapse-all, single-group collapse, expand-all, and `default_collapsed` all survive reloads, including 5 consecutive refresh ticks

`go build`, `go vet`, and the full suite pass, and the fixes were verified against a real 7,700-session database.

## Note for reviewers

One thing worth flagging separately: a full-suite run during this work produced 7 `internal/platform` failures that passed in isolation and on re-run. Those tests share a `sync.Once` that shells out to `go build` for a helper binary, and under full-suite parallelism that nested build contends for the Go build cache, propagating one failure to all 7. It is a pre-existing test-infrastructure flake in a package this PR does not touch, but it could bite CI.