### PR TITLE
fix: stop silently discarding style state, errors, and status messages

### DIFF
--- a/cmd/contributors/main_test.go
+++ b/cmd/contributors/main_test.go
@@ -254,10 +254,10 @@ func TestRunMode(t *testing.T) {
 // Main subprocess tests — test argument parsing via exit codes
 // ---------------------------------------------------------------------------
 
-func TestMain_NoArgs(t *testing.T) {
-	if len(os.Args) < 1 {
-		t.Skip("os.Args not available")
-	}
+// TestUsageStringContainsHeader verifies the usage constant carries the
+// "Usage:" header that main() prints when invoked with no arguments. The
+// no-args path itself is exercised by TestMainSubprocess_NoArgs below.
+func TestUsageStringContainsHeader(t *testing.T) {
 	if !strings.Contains(usage, "Usage:") {
 		t.Error("usage should contain 'Usage:'")
 	}

--- a/cmd/dispatch/main_test.go
+++ b/cmd/dispatch/main_test.go
@@ -72,14 +72,33 @@ func TestShowUpdateNotification_ChannelEmpty(t *testing.T) {
 }
 
 func TestShowUpdateNotification_NilWriter(t *testing.T) {
-	t.Parallel()
+	// A nil writer must not panic; the function falls back to os.Stderr.
+	// Capture os.Stderr to prove the notification is actually written there.
+	// (Global os.Stderr capture rules out t.Parallel.)
 	ch := make(chan *update.UpdateInfo, 1)
 	ch <- &update.UpdateInfo{
 		CurrentVersion: "1.0.0",
 		LatestVersion:  "2.0.0",
 	}
-	// Should not panic when w is nil (falls back to os.Stderr).
-	showUpdateNotification(nil, ch)
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	showUpdateNotification(nil, ch) // must not panic
+	_ = w.Close()
+	os.Stderr = origStderr
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading captured stderr: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "v1.0.0") || !strings.Contains(got, "v2.0.0") {
+		t.Errorf("nil writer should fall back to os.Stderr and write the update notice, got: %q", got)
+	}
 }
 
 func TestCleanupAfterHandleArgs(t *testing.T) {

--- a/cmd/dispatch/watch_exec_test.go
+++ b/cmd/dispatch/watch_exec_test.go
@@ -3,9 +3,12 @@ package main
 import (
 	"context"
 	"errors"
+	"io"
+	"os"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jongio/dispatch/internal/data"
 )
@@ -97,12 +100,49 @@ func TestFireWatchHook_InvokesExec(t *testing.T) {
 }
 
 func TestFireWatchHook_ErrorDoesNotBlock(t *testing.T) {
+	// The name promises that a hook returning an error does not block the
+	// watch loop and does not panic; the error must instead be surfaced to
+	// stderr. Assert all three: the hook is invoked, fireWatchHook returns
+	// promptly (checked via a timeout), and the error reaches stderr.
+	called := false
 	prev := watchExecFn
-	watchExecFn = func(context.Context, string, []string) error { return errors.New("boom") }
+	watchExecFn = func(context.Context, string, []string) error {
+		called = true
+		return errors.New("boom")
+	}
 	t.Cleanup(func() { watchExecFn = prev })
 
-	// A failing hook must not panic; the error is written to stderr.
-	fireWatchHook(context.Background(), "bad", "id", "waiting", "none", data.Session{})
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+
+	done := make(chan struct{})
+	go func() {
+		fireWatchHook(context.Background(), "bad", "session-xyz", "waiting", "none", data.Session{})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		os.Stderr = origStderr
+		t.Fatal("fireWatchHook blocked when the hook returned an error")
+	}
+
+	_ = w.Close()
+	os.Stderr = origStderr
+
+	out, _ := io.ReadAll(r)
+
+	if !called {
+		t.Error("fireWatchHook did not invoke the hook command")
+	}
+	if !strings.Contains(string(out), "boom") {
+		t.Errorf("fireWatchHook should report the hook error to stderr, got: %q", string(out))
+	}
 }
 
 func TestHookShell(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/jongio/dispatch
 go 1.26.6
 
 require (
-	charm.land/bubbles/v2 v2.1.1
+	charm.land/bubbles/v2 v2.2.0
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/glamour/v2 v2.0.1
 	charm.land/lipgloss/v2 v2.0.6

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-charm.land/bubbles/v2 v2.1.1 h1:7r55WzBxpo/R3z98hGmY7KKPd3ET6vsf0Fb9sDHOV60=
-charm.land/bubbles/v2 v2.1.1/go.mod h1:GE6M31gaWZVXzGw73OeuTTgy4lX+OtkH0E5ymnNsHxo=
+charm.land/bubbles/v2 v2.2.0 h1:9GEMewcejrNtVIxZ9Y2wSsWJamsWNsXa8MpMLnH4yI4=
+charm.land/bubbles/v2 v2.2.0/go.mod h1:wdMgn+sje1KNXdwFizIWjbf328fIUBxqEmJ/vYPo8yc=
 charm.land/bubbletea/v2 v2.0.8 h1:SxTJMhCAI3lbPmy4SgX5LWZ24AdINr4I6UEqzZvYJuY=
 charm.land/bubbletea/v2 v2.0.8/go.mod h1:2SkdgoTXluXJHOUwAoRlRXF/28vklb1rFl6GcgV1/ss=
 charm.land/glamour/v2 v2.0.1 h1:xl+r00A4aJWU0z8fgwKd9fQQ4rsphqGUzuEiXZP5n+c=

--- a/internal/data/chronicle_coverage_test.go
+++ b/internal/data/chronicle_coverage_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	_ "modernc.org/sqlite"
 )
@@ -51,22 +52,32 @@ func TestAnsiRegex_StripsSGR(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestChronicleReindex_CancelledContext(t *testing.T) {
-	// Use an already-cancelled context. If the binary is not found,
-	// ErrCopilotNotFound is returned before ctx is checked — that's fine.
-	// If the binary IS found, the cancelled ctx should cause
-	// ErrReindexCancelled after startPTY returns.
+	// An already-cancelled context must never yield a successful reindex.
+	// Two deterministic outcomes are possible depending on the environment:
+	//   - the Copilot binary is missing, so ErrCopilotNotFound is returned
+	//     before the context is even consulted; or
+	//   - the binary is found, and the cancelled context short-circuits the
+	//     first collect() via its ctx.Done() branch (ErrReindexCancelled),
+	//     or PTY startup fails.
+	// In every case the result is a NON-NIL error, and the call returns
+	// promptly instead of running the full multi-minute reindex timeline
+	// (startupWait + reindexTimeout + exitWait ~= 145s). Both properties are
+	// what "cancellation honored" means here.
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
 
-	var lines []string
-	err := ChronicleReindex(ctx, func(line string) {
-		lines = append(lines, line)
-	})
+	done := make(chan error, 1)
+	go func() {
+		done <- ChronicleReindex(ctx, func(string) {})
+	}()
 
-	// Either ErrCopilotNotFound (no binary) or ErrReindexCancelled (binary found + ctx cancel)
-	if err != nil && err != ErrCopilotNotFound && err != ErrReindexCancelled {
-		// Also accept PTY startup errors when context is cancelled
-		t.Logf("ChronicleReindex with cancelled ctx: %v (acceptable)", err)
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("ChronicleReindex with a cancelled context returned nil; a cancelled reindex must not report success")
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("ChronicleReindex did not honor context cancellation within 30s (work was not stopped early)")
 	}
 }
 
@@ -75,21 +86,27 @@ func TestChronicleReindex_CancelledContext(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestChronicleReindex_NilCallback(t *testing.T) {
-	// Verify nil onLine callback doesn't panic, regardless of whether
-	// the copilot binary is installed. Use an already-cancelled context
-	// so the function returns quickly even if the binary is found.
+	// Passing a nil onLine callback must never panic: the internal status()
+	// and emit() helpers guard every callback invocation with a nil check.
+	// With an already-cancelled context the call also returns promptly with
+	// a non-nil error (either ErrCopilotNotFound or ErrReindexCancelled), so
+	// we assert both the no-panic contract (implicit) and the non-nil,
+	// bounded-time return.
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
 
-	err := ChronicleReindex(ctx, nil)
-	// Any of these outcomes is acceptable:
-	// - ErrCopilotNotFound (binary not installed)
-	// - ErrReindexCancelled (binary found, context cancelled)
-	// - other error (PTY start failed)
-	// The only unacceptable outcome is a panic (which would crash the test).
-	if err == nil {
-		// nil is also acceptable — means it completed before noticing cancellation.
-		t.Log("ChronicleReindex returned nil (completed before cancellation)")
+	done := make(chan error, 1)
+	go func() {
+		done <- ChronicleReindex(ctx, nil) // nil callback must not panic
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("ChronicleReindex(ctx, nil) with a cancelled context returned nil; expected a non-nil error")
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("ChronicleReindex(ctx, nil) did not return within 30s")
 	}
 }
 

--- a/internal/data/plans_test.go
+++ b/internal/data/plans_test.go
@@ -139,24 +139,43 @@ func TestSessionStatePath_WithOverride(t *testing.T) {
 }
 
 func TestSessionStatePath_EmptyOverride(t *testing.T) {
+	// With no override, sessionStatePath falls back to the user's home
+	// directory joined with sessionStateRel. Pin the home env so the
+	// fallback is deterministic and hermetic.
+	home := t.TempDir()
 	t.Setenv("DISPATCH_SESSION_STATE", "")
+	t.Setenv("HOME", home)        // Unix / macOS
+	t.Setenv("USERPROFILE", home) // Windows
 
 	got := sessionStatePath()
-	if got == "" {
-		// When no override is set, sessionStatePath uses os.UserHomeDir + sessionStateRel.
-		// It should only be empty if UserHomeDir fails.
-		t.Log("sessionStatePath returned empty — UserHomeDir may have failed")
+	want := filepath.Join(home, sessionStateRel)
+	if got != want {
+		t.Errorf("sessionStatePath() = %q, want %q", got, want)
 	}
 }
 
 func TestSessionStatePath_UNCPath(t *testing.T) {
-	// UNC paths (\\server\share) should be rejected on Windows
+	// UNC paths (\\server\share) are a security boundary: on Windows they
+	// must be rejected so session state cannot be read from an attacker
+	// controlled network share. On other platforms backslashes are ordinary
+	// filename characters, so filepath.Clean is a no-op and the override is
+	// returned unchanged (not rejected). Both branches assert.
 	t.Setenv("DISPATCH_SESSION_STATE", `\\server\share\path`)
 
 	got := sessionStatePath()
-	// On Windows: should return "" (UNC paths rejected)
-	// On non-Windows: UNC path is just a regular path
-	_ = got
+	if runtime.GOOS == "windows" {
+		if got != "" {
+			t.Errorf("sessionStatePath() = %q, want %q (UNC paths must be rejected on Windows)", got, "")
+		}
+		return
+	}
+	want := filepath.Clean(`\\server\share\path`)
+	if got == "" {
+		t.Errorf("sessionStatePath() rejected a non-UNC path on %s; want %q", runtime.GOOS, want)
+	}
+	if got != want {
+		t.Errorf("sessionStatePath() = %q, want %q", got, want)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -164,15 +183,18 @@ func TestSessionStatePath_UNCPath(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestPlanFilePath_NoStateDir(t *testing.T) {
-	// Set DISPATCH_SESSION_STATE to empty to force sessionStatePath to use home dir
-	// but set HOME to non-existent to make it fail
+	// Force sessionStatePath to fail resolution: an empty override combined
+	// with empty home env makes os.UserHomeDir error, so sessionStatePath
+	// returns "". PlanFilePath must then return an error rather than a bogus
+	// path built on an unresolved state directory.
 	t.Setenv("DISPATCH_SESSION_STATE", "")
-	t.Setenv("HOME", "/nonexistent-path-12345")
-	t.Setenv("USERPROFILE", "/nonexistent-path-12345")
+	t.Setenv("HOME", "")        // Unix / macOS
+	t.Setenv("USERPROFILE", "") // Windows
 
 	_, err := PlanFilePath("valid-session-id")
-	// May or may not error depending on platform
-	_ = err
+	if err == nil {
+		t.Error("PlanFilePath should return an error when the session-state dir cannot be resolved")
+	}
 }
 
 func TestReadPlanContent_NoStateDir(t *testing.T) {

--- a/internal/data/store_regression_test.go
+++ b/internal/data/store_regression_test.go
@@ -488,7 +488,7 @@ func TestQuickSearchFoldsNonASCIICase(t *testing.T) {
 // case-variant in the stored text is a non-ASCII character (Turkish "İ").
 func TestNeedsNormalization(t *testing.T) {
 	if !normReady {
-		t.Skip("match normalization function not registered")
+		t.Fatal("match normalization function not registered: needsNormalization would then return false for every term, making the whole normalization matching path dead code and this table wrong")
 	}
 	cases := []struct {
 		term string

--- a/internal/platform/fonts_test.go
+++ b/internal/platform/fonts_test.go
@@ -3,6 +3,7 @@ package platform
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -116,12 +117,35 @@ func TestHasNerdFontFiles_TableDriven(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// IsNerdFontInstalled (smoke test)
+// IsNerdFontInstalled
 // ---------------------------------------------------------------------------
 
-func TestIsNerdFontInstalled_ReturnsBool(t *testing.T) {
-	t.Parallel()
-	// Result depends on system; verify no crash and log result for visibility.
-	installed := IsNerdFontInstalled()
-	t.Logf("IsNerdFontInstalled() = %v", installed)
+func TestIsNerdFontInstalled_DetectsFontInUserDir(t *testing.T) {
+	// Point the per-user font directory at a temp dir that contains a Nerd
+	// Font so IsNerdFontInstalled has a deterministic answer regardless of
+	// what is actually installed on the host. The dispatcher must route to
+	// the OS-appropriate helper and report true.
+	home := t.TempDir()
+	var fontDir string
+	switch runtime.GOOS {
+	case "windows":
+		t.Setenv("LOCALAPPDATA", home)
+		fontDir = filepath.Join(home, "Microsoft", "Windows", "Fonts")
+	case "darwin":
+		t.Setenv("HOME", home)
+		fontDir = filepath.Join(home, "Library", "Fonts")
+	default:
+		t.Setenv("HOME", home)
+		fontDir = filepath.Join(home, ".local", "share", "fonts")
+	}
+	if err := os.MkdirAll(fontDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fontDir, "JetBrainsMonoNerdFont-Regular.ttf"), []byte("fake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !IsNerdFontInstalled() {
+		t.Error("IsNerdFontInstalled() = false, want true when a Nerd Font .ttf is present in the user font directory")
+	}
 }

--- a/internal/platform/open.go
+++ b/internal/platform/open.go
@@ -26,7 +26,21 @@ func openCommand(ctx context.Context, path string) *exec.Cmd {
 // OpenFile opens the given file path using the platform default application.
 // On Windows it uses explorer.exe (avoids cmd.exe metacharacter injection),
 // on macOS "open", and on Linux "xdg-open".
+//
+// Like OpenDir, it returns an error if the path is empty or does not exist, so
+// callers get a clear message instead of a silent success. The OS openers do
+// not report a missing path through the exit status: explorer detaches
+// immediately and surfaces its own error window, so without this check a bad
+// path looks identical to a successful open. A directory is still accepted,
+// since every opener handles one and rejecting it would break callers that
+// pass a path they have not classified.
 func OpenFile(path string) error {
+	if path == "" {
+		return fmt.Errorf("no file to open")
+	}
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("file not found: %s", path)
+	}
 	return openCommand(context.Background(), path).Start()
 }
 

--- a/internal/platform/open_test.go
+++ b/internal/platform/open_test.go
@@ -8,14 +8,37 @@ import (
 	"testing"
 )
 
+func TestOpenFile_EmptyPath(t *testing.T) {
+	t.Parallel()
+	if err := OpenFile(""); err == nil {
+		t.Error("OpenFile(\"\") = nil, want an error for an empty path")
+	}
+}
+
+func TestOpenFile_MissingPath(t *testing.T) {
+	t.Parallel()
+	// The OS openers detach and report a missing path through their own UI,
+	// not through the exit status, so OpenFile must reject it up front or a
+	// bad path is indistinguishable from a successful open.
+	missing := filepath.Join(t.TempDir(), "does-not-exist.txt")
+	if err := OpenFile(missing); err == nil {
+		t.Error("OpenFile() = nil, want an error for a path that does not exist")
+	}
+}
+
 func TestOpenFile_ErrorWhenOpenerUnavailable(t *testing.T) {
-	// OpenFile does not pre-validate the path; it launches the platform
-	// opener (explorer/open/xdg-open) and returns that process's start
-	// error. Point PATH at an empty dir so the opener cannot be resolved,
-	// then confirm OpenFile surfaces the launch failure rather than
-	// swallowing it. (Cannot use t.Parallel with t.Setenv.)
+	// Past validation, OpenFile launches the platform opener
+	// (explorer/open/xdg-open) and returns that process's start error. Use a
+	// file that really exists so validation passes, then point PATH at an
+	// empty dir so the opener cannot be resolved, and confirm the launch
+	// failure is surfaced rather than swallowed.
+	// (Cannot use t.Parallel with t.Setenv.)
+	existing := filepath.Join(t.TempDir(), "real.txt")
+	if err := os.WriteFile(existing, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
 	t.Setenv("PATH", t.TempDir())
-	if err := OpenFile(filepath.Join("nonexistent", "path", "does", "not", "exist.txt")); err == nil {
+	if err := OpenFile(existing); err == nil {
 		t.Error("OpenFile() = nil, want an error when the platform opener cannot be started")
 	}
 }

--- a/internal/platform/open_test.go
+++ b/internal/platform/open_test.go
@@ -8,16 +8,16 @@ import (
 	"testing"
 )
 
-func TestOpenFile_NonExistentPath(t *testing.T) {
-	t.Parallel()
-	// OpenFile should not panic even for a non-existent path.
-	// It will start the OS opener which may fail silently or report
-	// an error through its own UI. We only verify no Go-level panic.
-	err := OpenFile("/nonexistent/path/that/does/not/exist.txt")
-	// On Windows cmd /c start returns immediately without error even for
-	// missing paths; on Linux/macOS xdg-open/open may or may not error.
-	// We just verify no panic occurred.
-	_ = err
+func TestOpenFile_ErrorWhenOpenerUnavailable(t *testing.T) {
+	// OpenFile does not pre-validate the path; it launches the platform
+	// opener (explorer/open/xdg-open) and returns that process's start
+	// error. Point PATH at an empty dir so the opener cannot be resolved,
+	// then confirm OpenFile surfaces the launch failure rather than
+	// swallowing it. (Cannot use t.Parallel with t.Setenv.)
+	t.Setenv("PATH", t.TempDir())
+	if err := OpenFile(filepath.Join("nonexistent", "path", "does", "not", "exist.txt")); err == nil {
+		t.Error("OpenFile() = nil, want an error when the platform opener cannot be started")
+	}
 }
 
 func TestOpenCommand_PerOS(t *testing.T) {

--- a/internal/platform/platform_additional_test.go
+++ b/internal/platform/platform_additional_test.go
@@ -547,16 +547,61 @@ func TestBuildResumeArgs_EmptySession(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestIsNerdFontInstalledWindows_WINDIRFallback(t *testing.T) {
-	// Clear WINDIR to exercise the fallback to C:\Windows.
+	// LOCALAPPDATA holds no fonts, so the WINDIR-derived directory is the
+	// only signal path.
+	empty := t.TempDir()
+	t.Setenv("LOCALAPPDATA", empty)
+
+	// Place a Nerd Font under a fake WINDIR/Fonts and confirm detection sees
+	// it when WINDIR points there.
+	fakeWin := t.TempDir()
+	winFonts := filepath.Join(fakeWin, "Fonts")
+	if err := os.MkdirAll(winFonts, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(winFonts, "MyNerdFont.ttf"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WINDIR", fakeWin)
+	if !isNerdFontInstalledWindows() {
+		t.Fatal("expected Nerd Font to be detected via WINDIR/Fonts when WINDIR is set")
+	}
+
+	// Clearing WINDIR must fall back to C:\Windows (NOT the fake dir), so the
+	// font placed under fakeWin must no longer be found. The result must match
+	// an independent check of the real fallback directory.
 	t.Setenv("WINDIR", "")
-	// Just verify it doesn't panic — result depends on installed fonts.
-	_ = isNerdFontInstalledWindows()
+	got := isNerdFontInstalledWindows()
+	want := hasNerdFontFiles(`C:\Windows\Fonts`)
+	if got != want {
+		t.Errorf("with WINDIR unset, isNerdFontInstalledWindows() = %v, want %v (C:\\Windows\\Fonts fallback)", got, want)
+	}
 }
 
 func TestIsNerdFontInstalledWindows_NoLocalAppData(t *testing.T) {
 	t.Setenv("LOCALAPPDATA", "")
-	// Should still work using WINDIR/system fonts.
-	_ = isNerdFontInstalledWindows()
+
+	// With a Nerd Font under WINDIR/Fonts, detection must still succeed even
+	// though LOCALAPPDATA is unset (the empty user path is skipped).
+	fakeWin := t.TempDir()
+	winFonts := filepath.Join(fakeWin, "Fonts")
+	if err := os.MkdirAll(winFonts, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(winFonts, "MyNerdFont.ttf"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WINDIR", fakeWin)
+	if !isNerdFontInstalledWindows() {
+		t.Error("expected detection via WINDIR/Fonts when LOCALAPPDATA is unset")
+	}
+
+	// With no fonts reachable anywhere, detection must be false: an empty
+	// LOCALAPPDATA must be skipped, not treated as a valid font root.
+	t.Setenv("WINDIR", t.TempDir())
+	if isNerdFontInstalledWindows() {
+		t.Error("expected no detection when neither LOCALAPPDATA nor WINDIR has a Nerd Font")
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/platform/platform_coverage_test.go
+++ b/internal/platform/platform_coverage_test.go
@@ -156,15 +156,23 @@ func TestCovBuildResumeCommandString_ResumeSessionCommandEmptyAfterExpand(t *tes
 }
 
 func TestCovBuildResumeCommandString_NoCLIBinary(t *testing.T) {
-	// Without resume session command, depends on CLI binary presence
+	// With no copilot/ghcs reachable via PATH, FindCLIBinary returns "" and
+	// buildResumeCommandString must report ErrCLINotFound.
+	t.Setenv("PATH", t.TempDir())
 	_, err := buildResumeCommandString("test-session", ResumeConfig{})
-	// May succeed or fail depending on PATH
-	t.Logf("buildResumeCommandString (no custom cmd): err=%v", err)
+	if !errors.Is(err, ErrCLINotFound) {
+		t.Errorf("buildResumeCommandString with no CLI binary = %v, want ErrCLINotFound", err)
+	}
 }
 
 func TestCovBuildResumeCommandString_NoCLIBinaryNoSession(t *testing.T) {
+	// Same contract as above but with an empty session ID: the missing-binary
+	// branch is still reached and ErrCLINotFound is returned.
+	t.Setenv("PATH", t.TempDir())
 	_, err := buildResumeCommandString("", ResumeConfig{})
-	t.Logf("buildResumeCommandString (no session, no custom cmd): err=%v", err)
+	if !errors.Is(err, ErrCLINotFound) {
+		t.Errorf("buildResumeCommandString with no CLI binary (no session) = %v, want ErrCLINotFound", err)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -431,7 +439,28 @@ func TestCovDefaultTerminal(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestCovIsNerdFontInstalled(t *testing.T) {
-	_ = IsNerdFontInstalled()
+	// Positive: a Nerd Font under LOCALAPPDATA makes detection deterministic.
+	// WINDIR is isolated to an empty temp dir so system fonts cannot
+	// interfere with the negative case below.
+	dir := t.TempDir()
+	t.Setenv("LOCALAPPDATA", dir)
+	t.Setenv("WINDIR", t.TempDir())
+	fontDir := filepath.Join(dir, "Microsoft", "Windows", "Fonts")
+	if err := os.MkdirAll(fontDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fontDir, "JetBrainsMonoNerdFont.ttf"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !IsNerdFontInstalled() {
+		t.Error("IsNerdFontInstalled() = false, want true with a Nerd Font under LOCALAPPDATA")
+	}
+
+	// Negative: with both font roots empty, detection must be false.
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+	if IsNerdFontInstalled() {
+		t.Error("IsNerdFontInstalled() = true, want false when no font directory contains a Nerd Font")
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -527,16 +556,53 @@ func TestCovIsNerdFontInstalledWindows_UserFontPresent(t *testing.T) {
 
 func TestCovIsNerdFontInstalledWindows_EmptyLocalAppData(t *testing.T) {
 	t.Setenv("LOCALAPPDATA", "")
-	// Should skip user fonts and check system fonts
-	_ = isNerdFontInstalledWindows()
+
+	// Detection still works via WINDIR/Fonts when LOCALAPPDATA is empty.
+	fakeWin := t.TempDir()
+	winFonts := filepath.Join(fakeWin, "Fonts")
+	if err := os.MkdirAll(winFonts, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(winFonts, "MyNerdFont.ttf"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WINDIR", fakeWin)
+	if !isNerdFontInstalledWindows() {
+		t.Error("expected detection via WINDIR when LOCALAPPDATA is empty")
+	}
+
+	// And false when WINDIR has no fonts either.
+	t.Setenv("WINDIR", t.TempDir())
+	if isNerdFontInstalledWindows() {
+		t.Error("expected no detection when LOCALAPPDATA is empty and WINDIR has no fonts")
+	}
 }
 
 func TestCovIsNerdFontInstalledWindows_EmptyWinDir(t *testing.T) {
+	// A Nerd Font under LOCALAPPDATA makes detection deterministically true
+	// even though WINDIR is empty (which triggers the C:\Windows fallback).
 	dir := t.TempDir()
-	t.Setenv("LOCALAPPDATA", dir) // no fonts here
+	t.Setenv("LOCALAPPDATA", dir)
+	fontDir := filepath.Join(dir, "Microsoft", "Windows", "Fonts")
+	if err := os.MkdirAll(fontDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fontDir, "MyNerdFont.ttf"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	t.Setenv("WINDIR", "")
-	// Falls back to C:\Windows
-	_ = isNerdFontInstalledWindows()
+	if !isNerdFontInstalledWindows() {
+		t.Error("expected detection via LOCALAPPDATA even with WINDIR empty")
+	}
+
+	// With LOCALAPPDATA emptied too, the only remaining source is the
+	// C:\Windows fallback, so the result must equal a direct check of it.
+	t.Setenv("LOCALAPPDATA", t.TempDir())
+	got := isNerdFontInstalledWindows()
+	want := hasNerdFontFiles(`C:\Windows\Fonts`)
+	if got != want {
+		t.Errorf("with WINDIR empty and no user fonts, got %v, want %v (C:\\Windows\\Fonts fallback)", got, want)
+	}
 }
 
 // ===========================================================================
@@ -610,13 +676,23 @@ func TestCovDetectWTColorScheme_InvalidJSON(t *testing.T) {
 	t.Setenv("LOCALAPPDATA", dir)
 
 	settingsDir := filepath.Join(dir, "Packages", "Microsoft.WindowsTerminal_8wekyb3d8bbwe", "LocalState")
-	_ = os.MkdirAll(settingsDir, 0o755)
-	_ = os.WriteFile(filepath.Join(settingsDir, "settings.json"), []byte("{invalid}"), 0o644)
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(settingsDir, "settings.json"), []byte("{invalid}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
-	// Should continue past invalid JSON (try next path)
-	scheme, _ := DetectWTColorScheme()
-	// May be nil since no valid settings found
-	_ = scheme
+	// Invalid JSON in the only settings file must not yield a color scheme.
+	// DetectWTColorScheme skips unparseable files and, finding nothing valid,
+	// returns (nil, nil) rather than surfacing the parse error.
+	scheme, err := DetectWTColorScheme()
+	if err != nil {
+		t.Errorf("DetectWTColorScheme() error = %v, want nil (per-file parse errors are swallowed)", err)
+	}
+	if scheme != nil {
+		t.Errorf("DetectWTColorScheme() scheme = %+v, want nil for invalid JSON", scheme)
+	}
 }
 
 func TestCovDetectWTColorScheme_NoSettings(t *testing.T) {

--- a/internal/platform/shell_test.go
+++ b/internal/platform/shell_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -559,15 +560,42 @@ func TestNewResumeCmd_IgnoresInvalidCwd(t *testing.T) {
 // FindCLIBinary
 // ---------------------------------------------------------------------------
 
-func TestFindCLIBinary_ReturnsStringOrEmpty(t *testing.T) {
-	// FindCLIBinary should either find a binary or return empty.
-	// We can't guarantee ghcs/copilot is installed, but we verify
-	// it doesn't panic and returns a valid result.
-	result := FindCLIBinary()
-	// Result is either empty or a path.
-	if result != "" {
-		// If found, it should be an absolute path or at least non-empty.
-		t.Logf("FindCLIBinary found: %s", result)
+func TestFindCLIBinary_FindsOnPathAndEmptyWhenAbsent(t *testing.T) {
+	// Negative: with PATH pointing at an empty dir, neither copilot nor ghcs
+	// can be resolved, so FindCLIBinary must return "".
+	t.Setenv("PATH", t.TempDir())
+	if got := FindCLIBinary(); got != "" {
+		t.Errorf("FindCLIBinary() = %q, want \"\" when copilot/ghcs are not on PATH", got)
+	}
+
+	// Positive: create a fake "copilot" executable on a controlled PATH and
+	// confirm FindCLIBinary resolves to it. A non-empty result must be an
+	// absolute path to a file that actually exists on disk.
+	dir := t.TempDir()
+	name := "copilot"
+	if runtime.GOOS == "windows" {
+		name = "copilot.exe"
+		// Ensure .EXE is a recognized executable extension for LookPath.
+		t.Setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD")
+	}
+	fake := filepath.Join(dir, name)
+	if err := os.WriteFile(fake, []byte(""), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	got := FindCLIBinary()
+	if got == "" {
+		t.Fatal("FindCLIBinary() = \"\", want the fake copilot resolved from PATH")
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("FindCLIBinary() = %q, want an absolute path", got)
+	}
+	if filepath.Dir(got) != dir {
+		t.Errorf("FindCLIBinary() = %q, want a path inside %q", got, dir)
+	}
+	if _, err := os.Stat(got); err != nil {
+		t.Errorf("FindCLIBinary() = %q, but that path does not exist: %v", got, err)
 	}
 }
 

--- a/internal/tui/components/attentionpicker_test.go
+++ b/internal/tui/components/attentionpicker_test.go
@@ -315,9 +315,11 @@ func TestAttentionPicker_View_ShowsCounts(t *testing.T) {
 func TestAttentionPicker_View_DoesNotPanic(t *testing.T) {
 	t.Parallel()
 	p := NewAttentionPicker()
-	_ = p.View() // zero size
+	_ = p.View() // zero size must not panic
 	p.SetSize(80, 40)
-	_ = p.View() // with size
+	if got := p.View(); got == "" {
+		t.Error("View() with a size should render a non-empty overlay")
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/tui/components/configpanel_test.go
+++ b/internal/tui/components/configpanel_test.go
@@ -418,9 +418,11 @@ func TestConfigPanel_View_ResumeSessionCommandHelp(t *testing.T) {
 func TestConfigPanel_View_DoesNotPanic(t *testing.T) {
 	t.Parallel()
 	cp := NewConfigPanel()
-	_ = cp.View() // zero size
+	_ = cp.View() // zero size must not panic
 	cp.SetSize(80, 40)
-	_ = cp.View()
+	if got := cp.View(); got == "" {
+		t.Error("View() with a size should render a non-empty overlay")
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/tui/components/coverage_test.go
+++ b/internal/tui/components/coverage_test.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -425,16 +426,51 @@ func TestSessionList_SetHiddenSessions(t *testing.T) {
 
 func TestFilterPanel_SetOptions(t *testing.T) {
 	t.Parallel()
-	fp := NewFilterPanel()
 	folders := []string{"/a/b", "/a/c"}
-	fp.SetOptions(folders, nil, nil)
-	// SetOptions is a shim for SetFolders — should not panic
+
+	viaOptions := NewFilterPanel()
+	viaOptions.SetOptions(folders, nil, nil)
+
+	// SetOptions is a shim for SetFolders, so it must build the same tree.
+	viaFolders := NewFilterPanel()
+	viaFolders.SetFolders(folders, nil)
+
+	if len(viaOptions.groups) != len(viaFolders.groups) {
+		t.Fatalf("SetOptions built %d groups, want %d (same as SetFolders)", len(viaOptions.groups), len(viaFolders.groups))
+	}
+	if len(viaOptions.groups) != 1 {
+		t.Fatalf("expected 1 group for folders under a common parent, got %d", len(viaOptions.groups))
+	}
+	if got, want := len(viaOptions.navItems), len(viaFolders.navItems); got != want {
+		t.Errorf("SetOptions navItems = %d, want %d", got, want)
+	}
+	// 1 group header + 2 children.
+	if got := len(viaOptions.navItems); got != 3 {
+		t.Errorf("SetOptions navItems = %d, want 3 (1 header + 2 children)", got)
+	}
 }
 
 func TestFilterPanel_SetActive(t *testing.T) {
 	t.Parallel()
 	fp := NewFilterPanel()
-	fp.SetActive(FilterFolder, "test") // no-op, should not panic
+	fp.SetFolders([]string{"/work/a", "/work/b"}, []string{"/work/a"})
+
+	// SetActive is a documented no-op; calling it must not change any state.
+	wantActive := fp.HasActive()
+	wantApplied := strings.Join(fp.applied, ",")
+	wantNav := len(fp.navItems)
+
+	fp.SetActive(FilterFolder, "test")
+
+	if fp.HasActive() != wantActive {
+		t.Errorf("SetActive changed HasActive: got %v, want %v", fp.HasActive(), wantActive)
+	}
+	if got := strings.Join(fp.applied, ","); got != wantApplied {
+		t.Errorf("SetActive changed applied: got %q, want %q", got, wantApplied)
+	}
+	if got := len(fp.navItems); got != wantNav {
+		t.Errorf("SetActive changed navItems: got %d, want %d", got, wantNav)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -699,7 +735,8 @@ func TestSearchBar_Update(t *testing.T) {
 	sb.Focus()
 	msg := tea.KeyPressMsg{Code: 'h', Text: "h"}
 	sb2, _ := sb.Update(msg)
-	// Value may or may not contain 'h' depending on textinput state,
-	// but should not panic.
-	_ = sb2.Value()
+	// Update delegates to the focused textinput, so typing 'h' must insert it.
+	if got := sb2.Value(); got != "h" {
+		t.Errorf("after typing 'h', Value() = %q, want %q", got, "h")
+	}
 }

--- a/internal/tui/components/filepicker_test.go
+++ b/internal/tui/components/filepicker_test.go
@@ -212,9 +212,11 @@ func TestFilePicker_View_ShowsWarning(t *testing.T) {
 func TestFilePicker_View_DoesNotPanic(t *testing.T) {
 	t.Parallel()
 	fp := NewFilePicker()
-	_ = fp.View() // zero files, zero size
+	_ = fp.View() // zero files, zero size must not panic
 	fp.SetSize(80, 40)
 	_ = fp.View() // with size but no files
 	fp.SetFiles([]data.SessionFile{{FilePath: "test.go"}})
-	_ = fp.View() // full setup
+	if got := fp.View(); got == "" {
+		t.Error("View() with a size and files should render a non-empty overlay")
+	}
 }

--- a/internal/tui/components/filterpanel_test.go
+++ b/internal/tui/components/filterpanel_test.go
@@ -259,14 +259,16 @@ func TestFilterPanel_View_WithFolders(t *testing.T) {
 func TestFilterPanel_View_DoesNotPanic(t *testing.T) {
 	t.Parallel()
 	fp := NewFilterPanel()
-	// Zero size.
+	// Zero size must not panic.
 	_ = fp.View()
 	// With size.
 	fp.SetSize(80, 40)
 	_ = fp.View()
 	// With folders.
 	fp.SetFolders([]string{"/a/b", "/a/c", "/d/e"}, nil)
-	_ = fp.View()
+	if got := fp.View(); got == "" {
+		t.Error("View() with a size and folders should render a non-empty overlay")
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -291,8 +293,21 @@ func TestFilterPanel_ActiveBadges_WithExclusions(t *testing.T) {
 func TestFilterPanel_SetActive_NoOp(t *testing.T) {
 	t.Parallel()
 	fp := NewFilterPanel()
-	// Should not panic.
+	fp.SetFolders([]string{"/home/x", "/home/y"}, []string{"/home/x"})
+
+	// SetActive is a documented no-op: the applied exclusions and active
+	// state must be identical before and after the call.
+	beforeActive := fp.HasActive()
+	beforeApplied := strings.Join(fp.applied, ",")
+
 	fp.SetActive(FilterFolder, "test")
+
+	if fp.HasActive() != beforeActive {
+		t.Errorf("SetActive mutated HasActive: got %v, want %v", fp.HasActive(), beforeActive)
+	}
+	if after := strings.Join(fp.applied, ","); after != beforeApplied {
+		t.Errorf("SetActive mutated applied: got %q, want %q", after, beforeApplied)
+	}
 }
 
 func TestFilterPanel_Toggle_BackwardCompat(t *testing.T) {

--- a/internal/tui/components/help_test.go
+++ b/internal/tui/components/help_test.go
@@ -146,9 +146,11 @@ func TestHelpOverlay_View_ContainsCloseHint(t *testing.T) {
 func TestHelpOverlay_View_DoesNotPanic(t *testing.T) {
 	t.Parallel()
 	h := testHelpOverlay()
-	_ = h.View() // zero size
+	_ = h.View() // zero size must not panic
 	h.SetSize(80, 40)
-	_ = h.View()
+	if got := h.View(); got == "" {
+		t.Error("View() with a size should render a non-empty overlay")
+	}
 }
 
 func TestShortcutRowsUseWidthAwareColumns(t *testing.T) {

--- a/internal/tui/components/noteinput_test.go
+++ b/internal/tui/components/noteinput_test.go
@@ -39,10 +39,13 @@ func TestNoteInput_FocusAndBlur(t *testing.T) {
 func TestNoteInput_SetWidth(t *testing.T) {
 	t.Parallel()
 	ni := NewNoteInput()
-	// Should not panic.
-	ni.SetWidth(80)
-	ni.SetWidth(10)
-	ni.SetWidth(0)
+
+	for _, w := range []int{80, 10, 0} {
+		ni.SetWidth(w)
+		if ni.width != w {
+			t.Errorf("SetWidth(%d): width = %d, want %d", w, ni.width, w)
+		}
+	}
 }
 
 func TestNoteInput_View(t *testing.T) {

--- a/internal/tui/components/preview_test.go
+++ b/internal/tui/components/preview_test.go
@@ -319,7 +319,7 @@ func TestPreviewPanelScrollUpAfterDown(t *testing.T) {
 	p.ScrollDown(5)
 	prev := p.scroll
 	if prev <= 0 {
-		t.Skipf("Content not long enough to scroll, totalLines=%d, viewport=%d", p.totalLines, p.height-2)
+		t.Fatalf("ScrollDown(5) should advance scroll on a 10-turn fixture, got scroll=%d (totalLines=%d, viewport=%d)", prev, p.totalLines, p.height-2)
 	}
 	p.ScrollUp(2)
 	if p.scroll >= prev {

--- a/internal/tui/components/reindex_test.go
+++ b/internal/tui/components/reindex_test.go
@@ -391,14 +391,12 @@ func TestSessionList_SetPivotField(t *testing.T) {
 	t.Parallel()
 	s := NewSessionList()
 
-	s.SetPivotField("folder")
-	// Verify indirectly: SetPivotField stores the pivot, which affects View() rendering.
-	// We just ensure it doesn't panic and can be called with various values.
-	s.SetPivotField("repo")
-	s.SetPivotField("branch")
-	s.SetPivotField("date")
-	s.SetPivotField("")
-	s.SetPivotField("unknown")
+	for _, pivot := range []string{"folder", "repo", "branch", "date", "", "unknown"} {
+		s.SetPivotField(pivot)
+		if s.pivotField != pivot {
+			t.Errorf("SetPivotField(%q): pivotField = %q, want %q", pivot, s.pivotField, pivot)
+		}
+	}
 }
 
 func TestSessionList_SetFavoritedSessions(t *testing.T) {
@@ -427,8 +425,18 @@ func TestSessionList_SetFavoritedSessions(t *testing.T) {
 func TestSessionList_SetFavoritedSessions_Empty(t *testing.T) {
 	t.Parallel()
 	s := NewSessionList()
+
+	// Populate first, then clear with nil to prove the setter overwrites
+	// the stored set rather than ignoring its argument.
+	s.SetFavoritedSessions(map[string]struct{}{"s1": {}})
+	if len(s.favoritedSet) != 1 {
+		t.Fatalf("precondition: favoritedSet size = %d, want 1", len(s.favoritedSet))
+	}
+
 	s.SetFavoritedSessions(nil)
-	// Should not panic
+	if s.favoritedSet != nil {
+		t.Errorf("SetFavoritedSessions(nil) should clear the set, got %v", s.favoritedSet)
+	}
 }
 
 func TestSessionList_SetFavoritedSessions_WithGroupView(t *testing.T) {
@@ -736,5 +744,19 @@ func TestPlanDot_HasPlan(t *testing.T) {
 func TestFilterPanel_SetActive_Cov(t *testing.T) {
 	t.Parallel()
 	fp := NewFilterPanel()
-	fp.SetActive(FilterCategory(0), "something") // should not panic
+	fp.SetFolders([]string{"/work/a", "/work/b"}, []string{"/work/a", "/work/b"})
+
+	// SetActive is a no-op kept for backward compatibility; it must not
+	// touch the applied exclusion set.
+	beforeActive := fp.HasActive()
+	beforeApplied := strings.Join(fp.applied, ",")
+
+	fp.SetActive(FilterCategory(0), "something")
+
+	if fp.HasActive() != beforeActive {
+		t.Errorf("SetActive mutated HasActive: got %v, want %v", fp.HasActive(), beforeActive)
+	}
+	if after := strings.Join(fp.applied, ","); after != beforeApplied {
+		t.Errorf("SetActive mutated applied: got %q, want %q", after, beforeApplied)
+	}
 }

--- a/internal/tui/components/searchbar_test.go
+++ b/internal/tui/components/searchbar_test.go
@@ -114,7 +114,9 @@ func TestSearchBar_SetWidth(t *testing.T) {
 func TestSearchBar_View_DoesNotPanic(t *testing.T) {
 	t.Parallel()
 	sb := NewSearchBar()
-	_ = sb.View()
+	if got := sb.View(); got == "" {
+		t.Error("View() should render a non-empty bar (prompt is always shown)")
+	}
 }
 
 func TestSearchBar_View_ShowsResultCount(t *testing.T) {

--- a/internal/tui/components/sessionpickerview_test.go
+++ b/internal/tui/components/sessionpickerview_test.go
@@ -1,0 +1,462 @@
+package components
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// makePickerRows returns n rows whose IDs are "id0".."id{n-1}" and whose other
+// columns are empty, so tests can search for a row by its unique ID substring.
+func makePickerRows(n int) []SessionPickerRow {
+	rows := make([]SessionPickerRow, n)
+	for i := range rows {
+		rows[i] = SessionPickerRow{ID: "id" + strconv.Itoa(i)}
+	}
+	return rows
+}
+
+func firstLine(s string) string {
+	return strings.SplitN(s, "\n", 2)[0]
+}
+
+// lineContaining returns the first output line that contains sub, or "" if none.
+func lineContaining(s, sub string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if strings.Contains(line, sub) {
+			return line
+		}
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Render: header line (three distinct title forms)
+// ---------------------------------------------------------------------------
+
+func TestSessionPickerView_RenderHeader(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		view SessionPickerView
+		want string
+	}{
+		{
+			// Not hasMore: HasMore false and everything loaded is shown.
+			name: "plain count",
+			view: SessionPickerView{Rows: makePickerRows(3), Visible: 3, Height: 40},
+			want: "Select a session (3)",
+		},
+		{
+			// Visible < len(Rows) forces the "of" form.
+			name: "visible of total",
+			view: SessionPickerView{Rows: makePickerRows(5), Visible: 2, Height: 40},
+			want: "Select a session (2 of 5)",
+		},
+		{
+			// HasMore with everything loaded shown uses the "loaded" form.
+			name: "loaded with more available",
+			view: SessionPickerView{Rows: makePickerRows(3), Visible: 3, HasMore: true, Height: 40},
+			want: "Select a session (3 loaded)",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := firstLine(tc.view.Render())
+			if got != tc.want {
+				t.Errorf("header = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Render: cursor prefix
+// ---------------------------------------------------------------------------
+
+func TestSessionPickerView_RenderCursor(t *testing.T) {
+	t.Parallel()
+	v := SessionPickerView{Rows: makePickerRows(4), Visible: 4, Cursor: 2, Height: 40}
+	out := v.Render()
+
+	cursorLine := lineContaining(out, "id2")
+	if cursorLine == "" {
+		t.Fatal("expected a rendered row containing id2")
+	}
+	if !strings.HasPrefix(cursorLine, "> ") {
+		t.Errorf("cursor row = %q, want prefix %q", cursorLine, "> ")
+	}
+
+	otherLine := lineContaining(out, "id0")
+	if otherLine == "" {
+		t.Fatal("expected a rendered row containing id0")
+	}
+	if !strings.HasPrefix(otherLine, "  ") {
+		t.Errorf("non-cursor row = %q, want prefix %q", otherLine, "  ")
+	}
+	if strings.HasPrefix(otherLine, "> ") {
+		t.Errorf("non-cursor row must not carry the cursor marker: %q", otherLine)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Render: "show more" affordance
+// ---------------------------------------------------------------------------
+
+func TestSessionPickerView_RenderShowMore(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		view        SessionPickerView
+		wantContain string
+		wantAbsent  string
+	}{
+		{
+			name:        "loading",
+			view:        SessionPickerView{Rows: makePickerRows(5), Visible: 2, Loading: true, Height: 40},
+			wantContain: "Loading more sessions…",
+		},
+		{
+			name:        "remaining smaller than batch",
+			view:        SessionPickerView{Rows: makePickerRows(10), Visible: 3, Height: 40},
+			wantContain: "Show 7 more sessions (7 remaining)",
+		},
+		{
+			name:        "remaining larger than batch is capped",
+			view:        SessionPickerView{Rows: makePickerRows(100), Visible: 10, Height: 40},
+			wantContain: "Show 50 more sessions (90 remaining)",
+		},
+		{
+			name:        "morecount fallback honored",
+			view:        SessionPickerView{Rows: makePickerRows(3), Visible: 3, HasMore: true, MoreCount: 25, Height: 40},
+			wantContain: "Show 25 more sessions",
+			wantAbsent:  "remaining",
+		},
+		{
+			name:        "morecount zero uses default batch",
+			view:        SessionPickerView{Rows: makePickerRows(3), Visible: 3, HasMore: true, MoreCount: 0, Height: 40},
+			wantContain: "Show 50 more sessions",
+			wantAbsent:  "remaining",
+		},
+		{
+			name:        "morecount negative uses default batch",
+			view:        SessionPickerView{Rows: makePickerRows(3), Visible: 3, HasMore: true, MoreCount: -4, Height: 40},
+			wantContain: "Show 50 more sessions",
+			wantAbsent:  "remaining",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out := tc.view.Render()
+			if !strings.Contains(out, tc.wantContain) {
+				t.Errorf("Render() missing %q\n---\n%s", tc.wantContain, out)
+			}
+			if tc.wantAbsent != "" && strings.Contains(out, tc.wantAbsent) {
+				t.Errorf("Render() should not contain %q\n---\n%s", tc.wantAbsent, out)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Render: footer hints
+// ---------------------------------------------------------------------------
+
+func TestSessionPickerView_RenderFooter(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		view        SessionPickerView
+		wantMoreHnt bool
+	}{
+		{
+			name:        "no more data",
+			view:        SessionPickerView{Rows: makePickerRows(2), Visible: 2, Height: 40},
+			wantMoreHnt: false,
+		},
+		{
+			name:        "more data available",
+			view:        SessionPickerView{Rows: makePickerRows(5), Visible: 2, Height: 40},
+			wantMoreHnt: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out := tc.view.Render()
+			for _, hint := range []string{"↑/↓ move", "Enter resume", "q cancel"} {
+				if !strings.Contains(out, hint) {
+					t.Errorf("footer missing required hint %q\n---\n%s", hint, out)
+				}
+			}
+			hasMoreHint := strings.Contains(out, "· m more")
+			if hasMoreHint != tc.wantMoreHnt {
+				t.Errorf("footer 'm more' hint present = %v, want %v", hasMoreHint, tc.wantMoreHnt)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SessionPickerVisibleRows: boundary values and the floor of 1
+// ---------------------------------------------------------------------------
+
+func TestSessionPickerVisibleRows(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		height int
+		want   int
+	}{
+		{height: 100, want: 94},
+		{height: 10, want: 4},
+		{height: 7, want: 1},  // 7-6 = 1
+		{height: 6, want: 1},  // 6-6 = 0, floored to 1
+		{height: 1, want: 1},  // floored
+		{height: 0, want: 1},  // floored
+		{height: -5, want: 1}, // floored despite negative height
+	}
+
+	for _, tc := range cases {
+		if got := SessionPickerVisibleRows(tc.height); got != tc.want {
+			t.Errorf("SessionPickerVisibleRows(%d) = %d, want %d", tc.height, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// columnWidths: min widths, growth toward targets, leftover, ID sizing
+// ---------------------------------------------------------------------------
+
+func TestSessionPickerColumnWidths(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name                                   string
+		view                                   SessionPickerView
+		wantID, wantSummary, wantRepo, wantBrn int
+	}{
+		{
+			// Tiny width: every column collapses to its minimum, and the ID
+			// column collapses to the "SESSION ID" header width.
+			name:        "minimum widths at tiny width",
+			view:        SessionPickerView{Width: 1, IDWidth: 10},
+			wantID:      10,
+			wantSummary: 8,
+			wantRepo:    10,
+			wantBrn:     6,
+		},
+		{
+			// Partway: summary reaches its target first, repo grows partially.
+			name:        "partial growth",
+			view:        SessionPickerView{Width: 60, IDWidth: 10},
+			wantID:      10,
+			wantSummary: 24,
+			wantRepo:    12,
+			wantBrn:     6,
+		},
+		{
+			// Further: summary and repo at target, branch grows partially.
+			name:        "more growth",
+			view:        SessionPickerView{Width: 80, IDWidth: 10},
+			wantID:      10,
+			wantSummary: 24,
+			wantRepo:    28,
+			wantBrn:     10,
+		},
+		{
+			// All targets met and leftover space is handed to the summary.
+			name:        "leftover goes to summary",
+			view:        SessionPickerView{Width: 102, IDWidth: 10},
+			wantID:      10,
+			wantSummary: 34, // 24 target + 10 leftover
+			wantRepo:    28,
+			wantBrn:     22,
+		},
+		{
+			// An explicit IDWidth is honored and the rows are not scanned,
+			// even though the row ID is far wider than IDWidth.
+			name:        "explicit id width honored",
+			view:        SessionPickerView{Width: 1, IDWidth: 20, Rows: []SessionPickerRow{{ID: strings.Repeat("x", 40)}}},
+			wantID:      20,
+			wantSummary: 8,
+			wantRepo:    10,
+			wantBrn:     6,
+		},
+		{
+			// IDWidth <= 0 derives the ID column from the widest row ID.
+			name:        "derive id width from widest row",
+			view:        SessionPickerView{Width: 1, IDWidth: 0, Rows: []SessionPickerRow{{ID: "short"}, {ID: "a-much-longer-id"}}},
+			wantID:      len("a-much-longer-id"), // 16
+			wantSummary: 8,
+			wantRepo:    10,
+			wantBrn:     6,
+		},
+		{
+			// IDWidth <= 0 never drops below the "SESSION ID" header width.
+			name:        "derived id width floors at header width",
+			view:        SessionPickerView{Width: 1, IDWidth: 0, Rows: []SessionPickerRow{{ID: "ab"}, {ID: "cd"}}},
+			wantID:      10,
+			wantSummary: 8,
+			wantRepo:    10,
+			wantBrn:     6,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			id, summary, repo, branch := tc.view.columnWidths()
+			if id != tc.wantID {
+				t.Errorf("id width = %d, want %d", id, tc.wantID)
+			}
+			if summary != tc.wantSummary {
+				t.Errorf("summary width = %d, want %d", summary, tc.wantSummary)
+			}
+			if repo != tc.wantRepo {
+				t.Errorf("repo width = %d, want %d", repo, tc.wantRepo)
+			}
+			if branch != tc.wantBrn {
+				t.Errorf("branch width = %d, want %d", branch, tc.wantBrn)
+			}
+		})
+	}
+}
+
+func TestSessionPickerColumnWidths_GrowWithWidth(t *testing.T) {
+	t.Parallel()
+
+	widths := []int{40, 60, 80, 100, 140}
+	var prevID, prevSummary, prevRepo, prevBranch, prevTotal int
+	for i, w := range widths {
+		v := SessionPickerView{Width: w, IDWidth: 10}
+		id, summary, repo, branch := v.columnWidths()
+		total := id + summary + repo + branch
+		if i > 0 {
+			if id < prevID || summary < prevSummary || repo < prevRepo || branch < prevBranch {
+				t.Errorf("width %d: columns shrank (id %d->%d, summary %d->%d, repo %d->%d, branch %d->%d)",
+					w, prevID, id, prevSummary, summary, prevRepo, repo, prevBranch, branch)
+			}
+			if total <= prevTotal {
+				t.Errorf("width %d: total column width %d did not grow past %d", w, total, prevTotal)
+			}
+		}
+		prevID, prevSummary, prevRepo, prevBranch, prevTotal = id, summary, repo, branch, total
+	}
+}
+
+// ---------------------------------------------------------------------------
+// padSessionPickerCell: truncate + pad to an exact display width
+// ---------------------------------------------------------------------------
+
+func TestPadSessionPickerCell(t *testing.T) {
+	t.Parallel()
+
+	t.Run("short value is padded on the right", func(t *testing.T) {
+		t.Parallel()
+		got := padSessionPickerCell("abc", 6)
+		want := "abc   "
+		if got != want {
+			t.Errorf("padSessionPickerCell(\"abc\", 6) = %q, want %q", got, want)
+		}
+		if w := ansi.StringWidth(got); w != 6 {
+			t.Errorf("display width = %d, want 6", w)
+		}
+	})
+
+	t.Run("exact width value is unchanged", func(t *testing.T) {
+		t.Parallel()
+		got := padSessionPickerCell("hello", 5)
+		if got != "hello" {
+			t.Errorf("padSessionPickerCell(\"hello\", 5) = %q, want %q", got, "hello")
+		}
+	})
+
+	t.Run("over-long value is truncated with ellipsis", func(t *testing.T) {
+		t.Parallel()
+		got := padSessionPickerCell("abcdefghij", 5)
+		want := "abcd…" // 4 columns of content plus the 1-column ellipsis tail
+		if got != want {
+			t.Errorf("padSessionPickerCell(\"abcdefghij\", 5) = %q, want %q", got, want)
+		}
+		if w := ansi.StringWidth(got); w != 5 {
+			t.Errorf("display width = %d, want 5", w)
+		}
+	})
+
+	t.Run("wide characters padded to display width", func(t *testing.T) {
+		t.Parallel()
+		// "日" has a display width of 2, so padding to 5 yields width 5, not
+		// a byte-length-based result.
+		got := padSessionPickerCell("日", 5)
+		if w := ansi.StringWidth(got); w != 5 {
+			t.Errorf("display width = %d, want 5 (got %q)", w, got)
+		}
+		if !strings.HasPrefix(got, "日") {
+			t.Errorf("padded cell should start with the original wide char, got %q", got)
+		}
+	})
+
+	t.Run("wide characters truncated to display width", func(t *testing.T) {
+		t.Parallel()
+		// "日本語" is 6 display columns; truncating to 4 must yield a cell of
+		// display width 4 (not 4 bytes) and include the ellipsis.
+		got := padSessionPickerCell("日本語", 4)
+		if w := ansi.StringWidth(got); w != 4 {
+			t.Errorf("display width = %d, want 4 (got %q)", w, got)
+		}
+		if !strings.Contains(got, "…") {
+			t.Errorf("truncated wide cell should contain the ellipsis, got %q", got)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Render: offset windowing
+// ---------------------------------------------------------------------------
+
+func TestSessionPickerView_RenderOffsetWindow(t *testing.T) {
+	t.Parallel()
+
+	// 10 loaded rows, a viewport that shows 4 (Height 10 -> visibleRows 4),
+	// scrolled so the window starts at Offset 3.
+	v := SessionPickerView{Rows: makePickerRows(10), Visible: 10, Offset: 3, Cursor: 3, Height: 10}
+	if got := v.visibleRows(); got != 4 {
+		t.Fatalf("precondition: visibleRows = %d, want 4", got)
+	}
+	out := v.Render()
+
+	// Rows inside the window [3,7) must render.
+	for _, id := range []string{"id3", "id4", "id5", "id6"} {
+		if lineContaining(out, id) == "" {
+			t.Errorf("row %s should be rendered within the window", id)
+		}
+	}
+	// Rows before the offset and past the window must not render.
+	for _, id := range []string{"id0", "id1", "id2", "id7", "id8", "id9"} {
+		if lineContaining(out, id) != "" {
+			t.Errorf("row %s should be outside the rendered window", id)
+		}
+	}
+
+	// No more than visibleRows() data rows are rendered.
+	rendered := 0
+	for _, line := range strings.Split(out, "\n") {
+		if (strings.HasPrefix(line, "  ") || strings.HasPrefix(line, "> ")) && strings.Contains(line, "id") {
+			rendered++
+		}
+	}
+	if rendered != 4 {
+		t.Errorf("rendered %d data rows, want 4 (== visibleRows)", rendered)
+	}
+}

--- a/internal/tui/components/shellpicker_test.go
+++ b/internal/tui/components/shellpicker_test.go
@@ -212,9 +212,11 @@ func TestShellPicker_View_UsesPathWhenNameEmpty(t *testing.T) {
 func TestShellPicker_View_DoesNotPanic(t *testing.T) {
 	t.Parallel()
 	sp := NewShellPicker()
-	_ = sp.View() // zero shells, zero size
+	_ = sp.View() // zero shells, zero size must not panic
 	sp.SetSize(80, 40)
 	_ = sp.View() // with size but no shells
 	sp.SetShells([]platform.ShellInfo{{Name: "pwsh", Path: "pwsh.exe"}}, "")
-	_ = sp.View() // full setup
+	if got := sp.View(); got == "" {
+		t.Error("View() with a size and shells should render a non-empty overlay")
+	}
 }

--- a/internal/tui/handlers_test.go
+++ b/internal/tui/handlers_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jongio/dispatch/internal/data"
 	"github.com/jongio/dispatch/internal/tui/components"
+	"github.com/jongio/dispatch/internal/tui/styles"
 )
 
 var errTestOpenDir = errors.New("directory not found: /tmp/work")
@@ -169,14 +170,37 @@ func TestHandleBackgroundColor_WithAutoTheme(t *testing.T) {
 
 func TestHandleBackgroundColor_WithNamedTheme(t *testing.T) {
 	m := newTestModelWithSize(120, 30)
-	m.cfg.Theme = "dracula"
 
-	msg := tea.BackgroundColorMsg{}
-	m2, _ := m.handleBackgroundColor(msg)
+	// Establish a known baseline scheme so we can detect whether the
+	// handler wrongly re-applies the auto theme (which resets the active
+	// scheme name to "Default").
+	//
+	// Restoring via SetTheme(orig) would not work here: the process-start
+	// theme carries only colour fields, so replaying it blanks every
+	// exported style and changes rendered widths for later tests.
+	// ApplyAutoTheme rebuilds the same complete state init() does.
+	origDark := styles.CurrentTheme().IsDark
+	t.Cleanup(func() { styles.ApplyAutoTheme(origDark) })
+	styles.SetTheme(styles.DeriveTheme(styles.Campbell))
+	before := styles.CurrentTheme().SchemeName
 
-	// Named theme should not trigger auto-theme application, but
-	// hasDarkBackground is always set for other uses.
-	_ = m2.hasDarkBackground
+	m.cfg.Theme = "dracula" // a named (non-empty, non-auto) theme
+
+	msg := tea.BackgroundColorMsg{} // nil color is treated as dark
+	m2, cmd := m.handleBackgroundColor(msg)
+
+	// The dark-background flag is always set from the message.
+	if !m2.hasDarkBackground {
+		t.Error("hasDarkBackground should be true for a dark background color")
+	}
+	// A named theme must NOT trigger auto-theme application, so the active
+	// scheme name must be left untouched.
+	if got := styles.CurrentTheme().SchemeName; got != before {
+		t.Errorf("named theme re-applied auto theme: SchemeName = %q, want %q", got, before)
+	}
+	if cmd != nil {
+		t.Error("handleBackgroundColor should return nil cmd")
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -199,12 +223,18 @@ func TestHandleSessionsChanged_WithNilStore(t *testing.T) {
 
 func TestHandleSessionsChanged_WithNilDBWatchCh(t *testing.T) {
 	m := newTestModelWithSize(120, 30)
-	m.store = nil
+	m.store = openBehavioralFlowStore(t)
 	m.dbWatchCh = nil
 
-	// Should not panic even with nil channel.
-	m2, _ := m.handleSessionsChanged()
-	_ = m2
+	// With a nil watch channel, waitForDBChangeCmd returns nil, but the
+	// store is set so a load command must still be produced. tea.Batch
+	// drops the nil watch command and returns the surviving load command.
+	m2, cmd := m.handleSessionsChanged()
+
+	if cmd == nil {
+		t.Error("handleSessionsChanged should still return the load cmd with a nil watch channel")
+	}
+	_ = m2 // model passes through unchanged
 }
 
 func TestHandleSessionsChanged_LoadingIndicator(t *testing.T) {
@@ -248,12 +278,12 @@ func TestHandleAttentionTick_ReturnsCmd(t *testing.T) {
 
 	m2, cmd := m.handleAttentionTick()
 
-	// scanAttentionCmd returns nil when there are no sessions with valid cwds,
-	// or a tea.Cmd that scans attention states.
-	// The model should pass through unchanged.
-	_ = m2
-	// cmd may be nil (no sessions with state dirs) or non-nil — both valid.
-	_ = cmd
+	// scanAttentionCmd always returns a non-nil command that scans
+	// attention states, regardless of the current sessions.
+	if cmd == nil {
+		t.Error("handleAttentionTick should always return a non-nil scan cmd")
+	}
+	_ = m2 // model passes through unchanged
 }
 
 func TestHandleAttentionTick_EmptySessions(t *testing.T) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3970,9 +3970,16 @@ const maxBatchLaunch = 50
 // selection state, and returns a tea.Batch of all commands. At most
 // maxBatchLaunch sessions are launched to prevent resource exhaustion.
 func (m *Model) batchLaunchSessions(sessions []data.Session, mode string) tea.Cmd {
+	// Clear any stale status, such as the multi-select count, up front. Doing
+	// this at the end instead would wipe the messages set below and the one the
+	// caller sets afterwards, which is how the limit notice and the resume
+	// notice both became unreachable.
+	m.statusInfo = ""
+
+	limited := false
 	if len(sessions) > maxBatchLaunch {
 		sessions = sessions[:maxBatchLaunch]
-		m.statusInfo = fmt.Sprintf("Launching first %d sessions (limit)", maxBatchLaunch)
+		limited = true
 	}
 	var cmds []tea.Cmd
 	skipped := 0
@@ -3987,8 +3994,11 @@ func (m *Model) batchLaunchSessions(sessions []data.Session, mode string) tea.Cm
 		}
 	}
 
-	// Keep selections intact after launch — user can deselect with 'd'.
-	m.statusInfo = ""
+	// Selections are intentionally kept intact after launch: the user can
+	// deselect with 'd'.
+	if limited {
+		m.statusInfo = fmt.Sprintf("Launching first %d sessions (limit)", maxBatchLaunch)
+	}
 	if skipped > 0 {
 		m.statusErr = fmt.Sprintf("Skipped %d session(s): workspace folder no longer exists", skipped)
 	}
@@ -4047,10 +4057,13 @@ func (m *Model) resolveShellAndLaunch(sessionID, cwd, mode string) tea.Cmd {
 	launchStyle := launchStyleForMode(mode)
 
 	if m.cfg.DefaultShell != "" {
-		sh := m.findShellByName(m.cfg.DefaultShell)
+		sh, found := m.findShellByName(m.cfg.DefaultShell)
 		if sh.Path == "" {
 			m.statusErr = fmt.Sprintf("Cannot launch: shell %q not found", m.cfg.DefaultShell)
 			return nil
+		}
+		if !found {
+			m.statusErr = fmt.Sprintf("Shell %q not detected; launching %s instead", m.cfg.DefaultShell, sh.Name)
 		}
 		return m.launchExternal(sh, sessionID, cwd, launchStyle)
 	}
@@ -4071,15 +4084,18 @@ func (m *Model) resolveShellAndLaunch(sessionID, cwd, mode string) tea.Cmd {
 	return nil
 }
 
-// findShellByName returns the detected ShellInfo matching name, or the
-// platform default if no match is found.
-func (m *Model) findShellByName(name string) platform.ShellInfo {
+// findShellByName returns the detected ShellInfo matching name. The second
+// result reports whether an exact match was found. When it is false the caller
+// still receives the platform default so a launch can proceed, but it must tell
+// the user which shell was actually used: silently substituting a different
+// shell than the one configured leaves the user believing their setting applied.
+func (m *Model) findShellByName(name string) (platform.ShellInfo, bool) {
 	for _, sh := range m.shells {
 		if sh.Name == name {
-			return sh
+			return sh, true
 		}
 	}
-	return platform.DefaultShell()
+	return platform.DefaultShell(), false
 }
 
 // resolveShellAndLaunchDirect launches a session without showing the shell
@@ -4090,8 +4106,11 @@ func (m *Model) resolveShellAndLaunchDirect(sessionID, cwd, mode string) tea.Cmd
 	launchStyle := launchStyleForMode(mode)
 
 	var sh platform.ShellInfo
+	shellMissing := false
 	if m.cfg.DefaultShell != "" {
-		sh = m.findShellByName(m.cfg.DefaultShell)
+		var found bool
+		sh, found = m.findShellByName(m.cfg.DefaultShell)
+		shellMissing = !found
 	} else if len(m.shells) > 0 {
 		sh = m.shells[0]
 	} else {
@@ -4101,6 +4120,9 @@ func (m *Model) resolveShellAndLaunchDirect(sessionID, cwd, mode string) tea.Cmd
 	if sh.Path == "" {
 		m.statusErr = "Cannot launch: no shell detected on this system"
 		return nil
+	}
+	if shellMissing {
+		m.statusErr = fmt.Sprintf("Shell %q not detected; launching %s instead", m.cfg.DefaultShell, sh.Name)
 	}
 
 	return m.launchExternal(sh, sessionID, cwd, launchStyle)
@@ -4671,8 +4693,13 @@ func (m Model) handleResumeInterrupted() (tea.Model, tea.Cmd) {
 		mode = config.LaunchModeTab
 	}
 
-	m.statusInfo = fmt.Sprintf("Resuming %d interrupted sessions", len(sessions))
 	cmd := m.batchLaunchSessions(sessions, mode)
+	// Set this after the batch, which resets the stale selection status first.
+	// If the batch truncated the list its own limit notice is the more
+	// important message, so it wins.
+	if m.statusInfo == "" {
+		m.statusInfo = fmt.Sprintf("Resuming %d interrupted sessions", len(sessions))
+	}
 	return m, cmd
 }
 
@@ -4917,13 +4944,11 @@ func checkNerdFontCmd() tea.Cmd {
 	}
 }
 
-// openFileCmd opens a file using the platform default application. It checks
-// that the file exists before attempting to open it.
+// openFileCmd opens a file using the platform default application. Validation
+// of the path lives in platform.OpenFile so the failure message is consistent
+// with openDirCmd.
 func (m Model) openFileCmd(path string) tea.Cmd {
 	return func() tea.Msg {
-		if _, err := os.Stat(path); err != nil {
-			return fileOpenedMsg{path: path, err: fmt.Errorf("file not found: %s", path)}
-		}
 		err := platform.OpenFile(path)
 		return fileOpenedMsg{path: path, err: err}
 	}

--- a/internal/tui/model_coverage2_test.go
+++ b/internal/tui/model_coverage2_test.go
@@ -9,6 +9,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/jongio/dispatch/internal/data"
+	"github.com/jongio/dispatch/internal/tui/styles"
 )
 
 // ---------------------------------------------------------------------------
@@ -276,8 +277,16 @@ func TestDeepSearchCmdCov_NilStore(t *testing.T) {
 func TestCloseStore_NoStore(t *testing.T) {
 	m := newTestModel()
 	m.store = nil
+	m.sessionsLoading = true
 
 	m.closeStore() // should not panic
+
+	if m.sessionsLoading {
+		t.Error("closeStore should clear sessionsLoading")
+	}
+	if m.store != nil {
+		t.Error("closeStore should leave store nil")
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -330,7 +339,9 @@ func TestHandleHeaderClick_Y0_SearchBar(t *testing.T) {
 	// Click on x=80 (well past the title) on line 0 — should focus search.
 	result, _ := m.handleHeaderClick(80, 0)
 	rm := result.(Model)
-	_ = rm
+	if !rm.searchBar.Focused() {
+		t.Error("clicking the header search area should focus the search bar")
+	}
 }
 
 func TestHandleHeaderClick_Y0_TitleArea(t *testing.T) {
@@ -368,7 +379,9 @@ func TestHandleKey_QuestionMark(t *testing.T) {
 	msg := tea.KeyPressMsg{Code: '?', Text: "?"}
 	result, _ := m.Update(msg)
 	rm := result.(Model)
-	_ = rm // verify no panic; ? may open help or attention picker
+	if rm.state != stateHelpOverlay {
+		t.Errorf("pressing '?' should open the help overlay: state = %v, want %v", rm.state, stateHelpOverlay)
+	}
 }
 
 func TestHandleKey_Slash_Search(t *testing.T) {
@@ -379,7 +392,9 @@ func TestHandleKey_Slash_Search(t *testing.T) {
 	msg := tea.KeyPressMsg{Code: '/', Text: "/"}
 	result, _ := m.Update(msg)
 	rm := result.(Model)
-	_ = rm // search should be activated
+	if !rm.searchBar.Focused() {
+		t.Error("pressing '/' should focus the search bar")
+	}
 }
 
 func TestHandleKey_S_Sort(t *testing.T) {
@@ -626,9 +641,19 @@ func TestUpdateCov_ClearStatusMsg(t *testing.T) {
 func TestUpdate_FontCheckMsg(t *testing.T) {
 	m := newTestModelWithSize(120, 30)
 
+	// handleFontCheck pushes the detected state into global styles; start from
+	// the opposite value so the change is observable, and restore afterward.
+	orig := styles.NerdFontEnabled()
+	t.Cleanup(func() { styles.SetNerdFontEnabled(orig) })
+	styles.SetNerdFontEnabled(false)
+
 	result, _ := m.Update(fontCheckMsg{installed: true})
 	rm := result.(Model)
-	_ = rm // just verify no panic
+	_ = rm
+
+	if !styles.NerdFontEnabled() {
+		t.Error("fontCheckMsg{installed: true} should enable nerd-font glyphs")
+	}
 }
 
 func TestUpdate_AttentionScannedMsg(t *testing.T) {

--- a/internal/tui/model_gitstatus_test.go
+++ b/internal/tui/model_gitstatus_test.go
@@ -169,9 +169,30 @@ func TestDemoGitStatuses(t *testing.T) {
 // TestSyncPreviewGitStatus_NilDetail verifies syncing with no loaded detail is
 // safe and clears the preview's git status.
 func TestSyncPreviewGitStatus_NilDetail(t *testing.T) {
-	m := newTestModel()
+	m := newTestModelWithSize(120, 30)
+
+	// Give the preview a rendered detail and a populated git status so its
+	// git section is visible, proving there is state to clear.
+	m.preview.SetSize(80, 40)
+	m.preview.SetDetail(&data.SessionDetail{
+		Session: data.Session{ID: "sess-1", Branch: "main", Cwd: "/home/me/proj"},
+	})
+	m.preview.SetGitStatus(platform.GitStatus{
+		Exists: true, IsRepo: true, Branch: "main",
+		Upstream: "origin/main", HasUpstream: true, Ahead: 3, Behind: 2,
+	})
+	if !strings.Contains(m.preview.View(), "Push/Pull") {
+		t.Fatal("setup: preview should render a git section before clearing")
+	}
+
+	// Syncing with no loaded detail must clear the git status (and must not
+	// panic dereferencing a nil detail).
 	m.detail = nil
-	m.syncPreviewGitStatus() // must not panic
+	m.syncPreviewGitStatus()
+
+	if strings.Contains(m.preview.View(), "Push/Pull") {
+		t.Error("syncPreviewGitStatus with nil detail should clear the preview git section")
+	}
 }
 
 func TestGitStatusKeybinding(t *testing.T) {

--- a/internal/tui/model_helpers_test.go
+++ b/internal/tui/model_helpers_test.go
@@ -896,7 +896,10 @@ func TestFindShellByName_Found(t *testing.T) {
 		{Name: "bash", Path: "/bin/bash"},
 		{Name: "zsh", Path: "/bin/zsh"},
 	}
-	got := m.findShellByName("zsh")
+	got, found := m.findShellByName("zsh")
+	if !found {
+		t.Error("findShellByName(zsh) found = false, want true for a detected shell")
+	}
 	if got.Name != "zsh" || got.Path != "/bin/zsh" {
 		t.Errorf("findShellByName(zsh) = %v", got)
 	}
@@ -907,9 +910,15 @@ func TestFindShellByName_NotFound(t *testing.T) {
 	m.shells = []platform.ShellInfo{
 		{Name: "bash", Path: "/bin/bash"},
 	}
-	got := m.findShellByName("nonexistent")
+	got, found := m.findShellByName("nonexistent")
+	if found {
+		t.Error("findShellByName(nonexistent) found = true, want false so callers can report the substitution")
+	}
 	if got.Path == "" {
-		t.Error("not found → should return DefaultShell with non-empty Path")
+		t.Error("not found should still return DefaultShell with a non-empty Path")
+	}
+	if got.Name == "nonexistent" {
+		t.Error("not found should return the platform default, not echo the requested name")
 	}
 }
 

--- a/internal/tui/model_helpers_test.go
+++ b/internal/tui/model_helpers_test.go
@@ -209,36 +209,77 @@ func TestGroupOrder_DatePivot_AlwaysDescending(t *testing.T) {
 // resolveTheme
 // ---------------------------------------------------------------------------
 
+// setThemeBaseline sets a known baseline scheme (Campbell) so that resolveTheme's
+// effect (or lack of one) is observable via CurrentTheme().SchemeName. It returns
+// the baseline scheme name.
+//
+// Restoring is deliberately not SetTheme(CurrentTheme()). At process start the
+// exported style variables are assigned directly by applyLegacyDefaults, which
+// then builds a Theme carrying only colour fields, so its style fields are the
+// zero Style. Replaying that Theme through SetTheme would blank every exported
+// style, and because a zero Style has no padding the rendered widths change,
+// which silently breaks unrelated layout tests that run later in the same
+// process. ApplyAutoTheme rebuilds the complete default state through the same
+// path init() uses, so nothing leaks out of these tests.
+func setThemeBaseline(t *testing.T) string {
+	t.Helper()
+	origDark := styles.CurrentTheme().IsDark
+	t.Cleanup(func() { styles.ApplyAutoTheme(origDark) })
+	styles.SetTheme(styles.DeriveTheme(styles.Campbell))
+	return styles.CurrentTheme().SchemeName
+}
+
 func TestResolveTheme_AutoDoesNothing(t *testing.T) {
+	baseline := setThemeBaseline(t)
 	cfg := config.Default()
 	cfg.Theme = "auto"
-	// Should not panic or modify styles
 	resolveTheme(cfg)
+	if got := styles.CurrentTheme().SchemeName; got != baseline {
+		t.Errorf("auto theme should not change the active scheme: SchemeName = %q, want %q", got, baseline)
+	}
 }
 
 func TestResolveTheme_EmptyDoesNothing(t *testing.T) {
+	baseline := setThemeBaseline(t)
 	cfg := config.Default()
 	cfg.Theme = ""
 	resolveTheme(cfg)
+	if got := styles.CurrentTheme().SchemeName; got != baseline {
+		t.Errorf("empty theme should not change the active scheme: SchemeName = %q, want %q", got, baseline)
+	}
 }
 
 func TestResolveTheme_BuiltinScheme(t *testing.T) {
-	cfg := config.Default()
-	// Use a known built-in scheme name if available
+	baseline := setThemeBaseline(t)
 	names := styles.BuiltinSchemeNames()
-	if len(names) > 0 {
-		cfg.Theme = names[0]
-		resolveTheme(cfg) // should not panic
+	if len(names) == 0 {
+		t.Fatal("expected built-in schemes to be registered")
+	}
+	// Pick a built-in scheme that differs from the baseline so the change is observable.
+	want := names[0]
+	if want == baseline {
+		want = names[len(names)-1]
+	}
+	cfg := config.Default()
+	cfg.Theme = want
+	resolveTheme(cfg)
+	if got := styles.CurrentTheme().SchemeName; got != want {
+		t.Errorf("built-in scheme not applied: SchemeName = %q, want %q", got, want)
 	}
 }
 
 func TestResolveTheme_UnknownScheme(t *testing.T) {
+	baseline := setThemeBaseline(t)
 	cfg := config.Default()
 	cfg.Theme = "nonexistent-scheme-xyz"
-	resolveTheme(cfg) // should not panic, falls back to defaults
+	resolveTheme(cfg)
+	if got := styles.CurrentTheme().SchemeName; got != baseline {
+		t.Errorf("unknown scheme should fall back to defaults: SchemeName = %q, want %q", got, baseline)
+	}
 }
 
 func TestResolveTheme_UserDefinedScheme(t *testing.T) {
+	setThemeBaseline(t)
 	cfg := config.Default()
 	cfg.Theme = "MyCustomScheme"
 	cfg.Schemes = []config.ColorScheme{
@@ -252,16 +293,23 @@ func TestResolveTheme_UserDefinedScheme(t *testing.T) {
 			BrightCyan: "#61D6D6", BrightWhite: "#F2F2F2",
 		},
 	}
-	resolveTheme(cfg) // should apply the custom scheme
+	resolveTheme(cfg)
+	if got := styles.CurrentTheme().SchemeName; got != "MyCustomScheme" {
+		t.Errorf("user-defined scheme not applied: SchemeName = %q, want %q", got, "MyCustomScheme")
+	}
 }
 
 func TestResolveTheme_InvalidUserScheme(t *testing.T) {
+	baseline := setThemeBaseline(t)
 	cfg := config.Default()
 	cfg.Theme = "BadScheme"
 	cfg.Schemes = []config.ColorScheme{
 		{Name: "BadScheme"}, // empty colors → Validate() fails
 	}
-	resolveTheme(cfg) // should not panic, skips invalid scheme
+	resolveTheme(cfg)
+	if got := styles.CurrentTheme().SchemeName; got != baseline {
+		t.Errorf("invalid scheme should be skipped: SchemeName = %q, want %q", got, baseline)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/tui/model_launch_test.go
+++ b/internal/tui/model_launch_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -162,6 +163,8 @@ func TestBatchLaunchSessions_Empty(t *testing.T) {
 func TestBatchLaunchSessions_UnderLimit(t *testing.T) {
 	m := newTestModelWithSize(120, 30)
 	m.cfg = config.Default()
+	// A stale selection status must not survive the launch.
+	m.statusInfo = "2 selected"
 
 	sessions := []data.Session{
 		{ID: "s1", Cwd: "/tmp/a"},
@@ -173,7 +176,8 @@ func TestBatchLaunchSessions_UnderLimit(t *testing.T) {
 	if cmd == nil {
 		t.Error("batchLaunchSessions with valid sessions should return a non-nil command")
 	}
-	// statusInfo should be cleared
+	// Under the limit there is nothing to report, so the stale status is gone
+	// and no new one replaces it.
 	if m.statusInfo != "" {
 		t.Errorf("statusInfo should be empty, got %q", m.statusInfo)
 	}
@@ -194,7 +198,14 @@ func TestBatchLaunchSessions_ExceedsLimit(t *testing.T) {
 	if cmd == nil {
 		t.Error("batchLaunchSessions exceeding limit should still return a non-nil command")
 	}
-	// After batch launch, statusInfo is cleared (the limit message is set then cleared)
+	// The truncation notice must actually reach the user. It was previously
+	// set and then cleared before returning, so it could never be displayed.
+	if m.statusInfo == "" {
+		t.Fatal("statusInfo is empty; the batch limit notice must survive the call")
+	}
+	if !strings.Contains(m.statusInfo, strconv.Itoa(maxBatchLaunch)) {
+		t.Errorf("statusInfo = %q, want it to report the %d session limit", m.statusInfo, maxBatchLaunch)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -895,6 +906,14 @@ func TestHandleResumeInterrupted_WithInterrupted(t *testing.T) {
 	}
 	if rm.statusErr != "" {
 		t.Errorf("statusErr = %q, want empty (nothing should be skipped)", rm.statusErr)
+	}
+	// The resume notice must survive: batchLaunchSessions previously cleared
+	// statusInfo on the way out, so this message could never be displayed.
+	if rm.statusInfo == "" {
+		t.Fatal("statusInfo is empty; the resume notice must survive the batch launch")
+	}
+	if !strings.Contains(rm.statusInfo, "Resuming") {
+		t.Errorf("statusInfo = %q, want it to report the resume", rm.statusInfo)
 	}
 }
 

--- a/internal/tui/model_launch_test.go
+++ b/internal/tui/model_launch_test.go
@@ -461,8 +461,15 @@ func TestHandleReindexClick_NilCancel(t *testing.T) {
 	btnX := startX + (overlayW-len(btnLabel))/2
 
 	msg := tea.MouseReleaseMsg{X: btnX + 1, Y: btnY, Button: tea.MouseLeft}
-	// Should not panic with nil cancel handle
+	// Should not panic with nil cancel handle, and the cancel path should run.
 	m.handleReindexClick(msg)
+
+	if m.reindexing {
+		t.Error("clicking Cancel should stop reindexing even with a nil cancel handle")
+	}
+	if m.statusInfo != statusReindexCancelled {
+		t.Errorf("statusInfo = %q, want %q", m.statusInfo, statusReindexCancelled)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -824,7 +831,14 @@ func TestHandleJumpNextAttention_WithWaiting(t *testing.T) {
 
 	result, _ := m.handleJumpNextAttention()
 	rm := result.(Model)
-	_ = rm
+	// The only waiting session is s2 at index 1; the cursor should jump to it
+	// and the detail should be reloaded (detailVersion bumped).
+	if got := rm.sessionList.Cursor(); got != 1 {
+		t.Errorf("cursor = %d, want 1 (waiting session s2)", got)
+	}
+	if rm.detailVersion != m.detailVersion+1 {
+		t.Errorf("detailVersion = %d, want %d", rm.detailVersion, m.detailVersion+1)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -872,9 +886,16 @@ func TestHandleResumeInterrupted_WithInterrupted(t *testing.T) {
 		"s2": data.AttentionIdle,
 	}
 
-	result, _ := m.handleResumeInterrupted()
+	result, cmd := m.handleResumeInterrupted()
 	rm := result.(Model)
-	_ = rm
+	// s1 is interrupted and present in the loaded sessions, so a batch launch
+	// command must be produced and nothing should be reported as skipped.
+	if cmd == nil {
+		t.Error("expected a batch launch cmd for the interrupted session, got nil")
+	}
+	if rm.statusErr != "" {
+		t.Errorf("statusErr = %q, want empty (nothing should be skipped)", rm.statusErr)
+	}
 }
 
 func TestHandleResumeInterrupted_InterruptedNotInView(t *testing.T) {

--- a/internal/tui/model_update_test.go
+++ b/internal/tui/model_update_test.go
@@ -170,9 +170,16 @@ func TestUpdate_SpinnerTick(t *testing.T) {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	m.spinner = s
-	// Just verify it doesn't panic and returns a model.
-	result, _ := m.Update(s.Tick())
-	_ = result.(Model)
+	result, cmd := m.Update(s.Tick())
+	rm := result.(Model)
+	// A spinner tick must schedule the next tick so the animation continues,
+	// and advance the current frame.
+	if cmd == nil {
+		t.Error("spinner tick should return a non-nil cmd to schedule the next frame")
+	}
+	if rm.spinner.View() == m.spinner.View() {
+		t.Error("spinner tick should advance the animation frame")
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -1036,7 +1043,16 @@ func TestHandleKey_JumpHomeEnd(t *testing.T) {
 func TestCloseStore_NilStore(t *testing.T) {
 	m := newTestModel()
 	m.store = nil
+	m.sessionsLoading = true
+
 	m.closeStore() // should not panic
+
+	if m.sessionsLoading {
+		t.Error("closeStore should clear sessionsLoading")
+	}
+	if m.store != nil {
+		t.Error("closeStore should leave store nil")
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -1454,13 +1470,18 @@ func TestLaunchWithMode_NoSelection(t *testing.T) {
 
 func TestLaunchWithMode_InPlace(t *testing.T) {
 	m := newTestModel()
+	// A valid resume template makes NewResumeCmd deterministic (no real CLI needed).
+	m.cfg.ResumeSessionCommand = "echo {sessionId}"
 	m.sessionList.SetSessions([]data.Session{{ID: "s1", Cwd: "/test"}})
-	// launchInPlace may fail since there's no real copilot CLI, but
-	// we just need to verify it doesn't panic and returns a cmd or nil.
+
 	cmd := m.launchWithMode(config.LaunchModeInPlace)
-	// Could be nil if platform.NewResumeCmd fails, that's ok.
-	// The key assertion is no panic; cmd value depends on platform.
-	_ = cmd == nil // suppress unused warning while documenting the check
+
+	if cmd == nil {
+		t.Error("launchWithMode(in-place) with a valid resume template should return a non-nil cmd")
+	}
+	if m.statusErr != "" {
+		t.Errorf("statusErr = %q, want empty", m.statusErr)
+	}
 }
 
 func TestLaunchWithMode_External_SingleShell(t *testing.T) {
@@ -1665,28 +1686,52 @@ func TestHandleConfigKey_EscapeClosesPanel(t *testing.T) {
 }
 
 func TestHandleConfigKey_UpDown(t *testing.T) {
+	setupTempConfigDir(t)
 	m := newTestModel()
 	m.state = stateConfigPanel
 	m.configPanel = components.NewConfigPanel()
 	m.configPanel.SetValues(components.ConfigValues{})
 
-	// Down
-	result, _ := m.handleConfigKey(tea.KeyPressMsg{Code: tea.KeyDown})
-	_ = result.(Model)
+	// Down moves the cursor from the Yolo row (0) to the Agent row (1);
+	// pressing Enter on a text field begins editing.
+	down, _ := m.handleConfigKey(tea.KeyPressMsg{Code: tea.KeyDown})
+	dm := down.(Model)
+	edited, _ := dm.handleConfigKey(enterKeyMsg())
+	em := edited.(Model)
+	if !em.configPanel.IsEditing() {
+		t.Error("Down then Enter should begin editing the Agent text field")
+	}
 
-	// Up
-	result, _ = m.handleConfigKey(tea.KeyPressMsg{Code: tea.KeyUp})
-	_ = result.(Model)
+	// From the Agent row, Up returns to the Yolo row (0); pressing Enter there
+	// toggles the boolean instead of entering edit mode.
+	up, _ := dm.handleConfigKey(tea.KeyPressMsg{Code: tea.KeyUp})
+	um := up.(Model)
+	toggled, _ := um.handleConfigKey(enterKeyMsg())
+	ym := toggled.(Model)
+	if ym.configPanel.IsEditing() {
+		t.Error("Up to the Yolo row then Enter should not enter edit mode")
+	}
+	if !ym.configPanel.Values().YoloMode {
+		t.Error("Enter on the Yolo row should toggle YoloMode on")
+	}
 }
 
 func TestHandleConfigKey_Enter(t *testing.T) {
+	setupTempConfigDir(t)
 	m := newTestModel()
 	m.state = stateConfigPanel
 	m.configPanel = components.NewConfigPanel()
 	m.configPanel.SetValues(components.ConfigValues{})
 
+	// Cursor starts on the Yolo row; Enter toggles it on and persists to cfg.
 	result, _ := m.handleConfigKey(enterKeyMsg())
-	_ = result.(Model)
+	rm := result.(Model)
+	if !rm.configPanel.Values().YoloMode {
+		t.Error("Enter on the Yolo row should toggle YoloMode on in the panel")
+	}
+	if !rm.cfg.YoloMode {
+		t.Error("Enter on the Yolo row should persist YoloMode to cfg")
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -2778,16 +2823,36 @@ func TestHandleKey_ShellPicker_UpDown(t *testing.T) {
 		{Name: "zsh", Path: "/bin/zsh"},
 	}, "")
 
-	result, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	_ = result.(Model)
+	// Down advances the highlight from the first shell (bash) to zsh.
+	down, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	dm := down.(Model)
+	if sh, ok := dm.shellPicker.Selected(); !ok || sh.Name != "zsh" {
+		t.Errorf("after Down, selected shell = %q, want zsh", sh.Name)
+	}
 
-	result, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
-	_ = result.(Model)
+	// Up from that position returns the highlight to bash.
+	up, _ := dm.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	um := up.(Model)
+	if sh, ok := um.shellPicker.Selected(); !ok || sh.Name != "bash" {
+		t.Errorf("after Up, selected shell = %q, want bash", sh.Name)
+	}
 }
 
 // ---------------------------------------------------------------------------
 // handleKey: filter panel state
 // ---------------------------------------------------------------------------
+
+// filterPanelModel returns a model in stateFilterPanel with one parent group
+// ("/home/proj") holding two expanded children (alpha, beta). The navigation
+// items are ordered [group, alpha, beta] with the cursor on the group header.
+func filterPanelModel() Model {
+	m := newTestModel()
+	m.state = stateFilterPanel
+	m.filterPanel = components.NewFilterPanel()
+	m.filterPanel.SetSize(80, 30)
+	m.filterPanel.SetFolders([]string{"/home/proj/alpha", "/home/proj/beta"}, nil)
+	return m
+}
 
 func TestHandleKey_FilterPanel_Escape(t *testing.T) {
 	m := newTestModel()
@@ -2800,28 +2865,63 @@ func TestHandleKey_FilterPanel_Escape(t *testing.T) {
 }
 
 func TestHandleKey_FilterPanel_UpDown(t *testing.T) {
-	m := newTestModel()
-	m.state = stateFilterPanel
-	result, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
-	_ = result.(Model)
-	result, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
-	_ = result.(Model)
+	m := filterPanelModel()
+
+	// Down moves the cursor from the group header onto the first child
+	// (alpha); toggling there excludes only that directory.
+	down, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	dm := down.(Model)
+	sc, _ := dm.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+	scm := sc.(Model)
+	child := scm.filterPanel.Apply()
+	if len(child) != 1 || !strings.HasSuffix(child[0], "alpha") {
+		t.Errorf("Down then Space should exclude only alpha, got %v", child)
+	}
+
+	// From the child, Up returns to the group header; toggling there
+	// excludes every child in the group (alpha and beta).
+	up, _ := dm.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	um := up.(Model)
+	sg, _ := um.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
+	sgm := sg.(Model)
+	group := sgm.filterPanel.Apply()
+	if len(group) != 2 {
+		t.Errorf("Up to group then Space should exclude both children, got %v", group)
+	}
 }
 
 func TestHandleKey_FilterPanel_LeftRight(t *testing.T) {
-	m := newTestModel()
-	m.state = stateFilterPanel
-	result, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
-	_ = result.(Model)
-	result, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyRight})
-	_ = result.(Model)
+	m := filterPanelModel()
+	if !strings.Contains(ansi.Strip(m.filterPanel.View()), "alpha") {
+		t.Fatal("setup: expanded group should list child alpha")
+	}
+
+	// Left collapses the group under the cursor, hiding its children.
+	left, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
+	lm := left.(Model)
+	if strings.Contains(ansi.Strip(lm.filterPanel.View()), "alpha") {
+		t.Error("Left should collapse the group and hide child alpha")
+	}
+
+	// Right re-expands the collapsed group, showing its children again.
+	right, _ := lm.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	rm := right.(Model)
+	if !strings.Contains(ansi.Strip(rm.filterPanel.View()), "alpha") {
+		t.Error("Right should re-expand the group and show child alpha")
+	}
 }
 
 func TestHandleKey_FilterPanel_Space(t *testing.T) {
-	m := newTestModel()
-	m.state = stateFilterPanel
+	m := filterPanelModel()
+
+	// The cursor starts on the group header; Space toggles exclusion for
+	// the whole group, so both children become excluded.
 	result, _ := m.Update(tea.KeyPressMsg{Code: ' ', Text: " "})
-	_ = result.(Model)
+	rm := result.(Model)
+	excluded := rm.filterPanel.Apply()
+	if len(excluded) != 2 {
+		t.Errorf("Space on group header should exclude both children, got %v", excluded)
+	}
 }
 
 func TestHandleKey_FilterPanel_Enter(t *testing.T) {
@@ -2896,35 +2996,63 @@ func TestHandleKey_SearchFocused_CharKeysDoNotLeak(t *testing.T) {
 func TestHandleMouse_WheelUp(t *testing.T) {
 	m := newTestModelWithSize(120, 30)
 	m.sessionList.SetSessions([]data.Session{{ID: "s1"}, {ID: "s2"}, {ID: "s3"}})
+	before := m.detailVersion
 	msg := tea.MouseWheelMsg{Button: tea.MouseWheelUp, X: 5, Y: 10}
 	result, _ := m.Update(msg)
-	_ = result.(Model)
+	rm := result.(Model)
+	// Wheeling over the list (no preview) scrolls the list and bumps the
+	// detail version so the selected session's detail reloads.
+	if rm.detailVersion != before+1 {
+		t.Errorf("wheel up over list: detailVersion = %d, want %d", rm.detailVersion, before+1)
+	}
 }
 
 func TestHandleMouse_WheelDown(t *testing.T) {
 	m := newTestModelWithSize(120, 30)
 	m.sessionList.SetSessions([]data.Session{{ID: "s1"}, {ID: "s2"}, {ID: "s3"}})
+	before := m.detailVersion
 	msg := tea.MouseWheelMsg{Button: tea.MouseWheelDown, X: 5, Y: 10}
 	result, _ := m.Update(msg)
-	_ = result.(Model)
+	rm := result.(Model)
+	if rm.detailVersion != before+1 {
+		t.Errorf("wheel down over list: detailVersion = %d, want %d", rm.detailVersion, before+1)
+	}
 }
 
 func TestHandleMouse_WheelUp_OverPreview(t *testing.T) {
 	m := newTestModelWithSize(120, 30)
 	m.showPreview = true
 	m.recalcLayout()
+	m.preview.SetPlanContent(strings.Repeat("plan line\n", 100))
+	m.preview.ShowPlanView()
+	m.preview.ScrollDown(5)
+	before := m.preview.ScrollOffset()
+	want := before - 3
+	if want < 0 {
+		want = 0
+	}
 	msg := tea.MouseWheelMsg{Button: tea.MouseWheelUp, X: m.layout.listWidth + 5, Y: 10}
 	result, _ := m.Update(msg)
-	_ = result.(Model)
+	rm := result.(Model)
+	// Wheeling up over the preview scrolls its content up by 3 (clamped at 0).
+	if got := rm.preview.ScrollOffset(); got != want {
+		t.Errorf("wheel up over preview: ScrollOffset = %d, want %d (from %d)", got, want, before)
+	}
 }
 
 func TestHandleMouse_WheelDown_OverPreview(t *testing.T) {
 	m := newTestModelWithSize(120, 30)
 	m.showPreview = true
 	m.recalcLayout()
+	m.preview.SetPlanContent(strings.Repeat("plan line\n", 100))
+	m.preview.ShowPlanView()
 	msg := tea.MouseWheelMsg{Button: tea.MouseWheelDown, X: m.layout.listWidth + 5, Y: 10}
 	result, _ := m.Update(msg)
-	_ = result.(Model)
+	rm := result.(Model)
+	// Wheeling down over the preview scrolls its content down by 3.
+	if got := rm.preview.ScrollOffset(); got != 3 {
+		t.Errorf("wheel down over preview: ScrollOffset = %d, want 3", got)
+	}
 }
 
 func TestHandleMouse_NotSessionList(t *testing.T) {
@@ -2940,13 +3068,18 @@ func TestHandleMouse_NotSessionList(t *testing.T) {
 
 func TestHandleMouse_LeftClick_HeaderArea(t *testing.T) {
 	m := newTestModelWithSize(120, 30)
+	// Release on the header row (Y=0) to the right of the title focuses
+	// the search bar.
 	msg := tea.MouseReleaseMsg{
 		Button: tea.MouseLeft,
-		X:      5,
+		X:      100,
 		Y:      0,
 	}
 	result, _ := m.Update(msg)
-	_ = result.(Model)
+	rm := result.(Model)
+	if !rm.searchBar.Focused() {
+		t.Error("clicking the header search area should focus the search bar")
+	}
 }
 
 func TestHandleMouse_LeftClick_BelowContent(t *testing.T) {
@@ -2982,10 +3115,33 @@ func TestHandleMouse_LeftClick_NotRelease(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestHandleHeaderClick_BadgeLine(t *testing.T) {
+	setupTempConfigDir(t)
 	m := newTestModelWithSize(120, 30)
-	// Click on badge line (Y=1) at X=0 — might not hit anything.
-	result, _ := m.handleHeaderClick(0, 1)
-	_ = result.(Model)
+
+	// Find an X on the badge line (Y=1) that maps to a time-range badge
+	// other than the current selection, click it, and confirm the time
+	// range switches to that badge's label and a reload cmd is returned.
+	var clickX int
+	var wantRange string
+	for x := 0; x < 120; x++ {
+		if rest, ok := strings.CutPrefix(m.badgeClickAction(x), "time:"); ok && rest != m.timeRange {
+			clickX = x
+			wantRange = rest
+			break
+		}
+	}
+	if wantRange == "" {
+		t.Fatal("setup: no clickable time-range badge found on the badge line")
+	}
+
+	result, cmd := m.handleHeaderClick(clickX, 1)
+	rm := result.(Model)
+	if rm.timeRange != wantRange {
+		t.Errorf("clicking time badge: timeRange = %q, want %q", rm.timeRange, wantRange)
+	}
+	if cmd == nil {
+		t.Error("clicking a time badge should return a reload cmd")
+	}
 }
 
 func TestHandleHeaderClick_SeparatorLine(t *testing.T) {
@@ -3201,7 +3357,12 @@ func TestHandleMouse_DoubleClick_WithCtrl(t *testing.T) {
 		Mod:    tea.ModCtrl,
 	}
 	result2, _ := rm1.Update(msg2)
-	_ = result2.(Model)
+	rm2 := result2.(Model)
+	// The second release on the same row is a double-click, which clears
+	// the pending single-click regardless of the Ctrl modifier.
+	if rm2.click.pendingClickVersion != 0 {
+		t.Errorf("Ctrl double-click should reset pendingClickVersion, got %d", rm2.click.pendingClickVersion)
+	}
 }
 
 func TestHandleMouse_DoubleClick_WithShift(t *testing.T) {
@@ -3225,7 +3386,12 @@ func TestHandleMouse_DoubleClick_WithShift(t *testing.T) {
 		Mod:    tea.ModShift,
 	}
 	result2, _ := rm1.Update(msg2)
-	_ = result2.(Model)
+	rm2 := result2.(Model)
+	// The second release on the same row is a double-click, which clears
+	// the pending single-click regardless of the Shift modifier.
+	if rm2.click.pendingClickVersion != 0 {
+		t.Errorf("Shift double-click should reset pendingClickVersion, got %d", rm2.click.pendingClickVersion)
+	}
 }
 
 func TestHandleMouse_LeftClick_InPreviewPane(t *testing.T) {
@@ -3487,7 +3653,7 @@ func TestHandleConfigKey_EditingMode_Escape(t *testing.T) {
 	m.configPanel.MoveDown() // to agent field
 	m.configPanel.HandleEnter()
 	if !m.configPanel.IsEditing() {
-		t.Skip("could not enter editing mode")
+		t.Fatal("setup: HandleEnter did not enter editing mode")
 	}
 	result, _ := m.Update(escKeyMsg())
 	rm := result.(Model)
@@ -3497,6 +3663,7 @@ func TestHandleConfigKey_EditingMode_Escape(t *testing.T) {
 }
 
 func TestHandleConfigKey_EditingMode_Enter(t *testing.T) {
+	setupTempConfigDir(t)
 	m := newTestModelWithSize(120, 30)
 	m.state = stateConfigPanel
 	m.configPanel = components.NewConfigPanel()
@@ -3504,7 +3671,7 @@ func TestHandleConfigKey_EditingMode_Enter(t *testing.T) {
 	m.configPanel.MoveDown()
 	m.configPanel.HandleEnter()
 	if !m.configPanel.IsEditing() {
-		t.Skip("could not enter editing mode")
+		t.Fatal("setup: HandleEnter did not enter editing mode")
 	}
 	result, _ := m.Update(enterKeyMsg())
 	rm := result.(Model)
@@ -3518,14 +3685,22 @@ func TestHandleConfigKey_EditingMode_TypeChar(t *testing.T) {
 	m.state = stateConfigPanel
 	m.configPanel = components.NewConfigPanel()
 	m.configPanel.SetSize(120, 30)
-	m.configPanel.MoveDown()
+	m.configPanel.MoveDown() // to agent field (a text field)
 	m.configPanel.HandleEnter()
 	if !m.configPanel.IsEditing() {
-		t.Skip("could not enter editing mode")
+		t.Fatal("setup: HandleEnter did not enter editing mode")
 	}
-	// Type a character while in editing mode
+	// Typing a character while editing feeds the config panel's text input
+	// and stays in editing mode; the character lands in the edit buffer.
 	result, _ := m.Update(runeKeyMsg('x'))
-	_ = result.(Model)
+	rm := result.(Model)
+	if !rm.configPanel.IsEditing() {
+		t.Error("typing a character should remain in editing mode")
+	}
+	rm.configPanel.ConfirmEdit()
+	if got := rm.configPanel.Values().Agent; got != "x" {
+		t.Errorf("typed character not captured: Agent = %q, want %q", got, "x")
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -4273,17 +4448,22 @@ func TestAttentionPriority(t *testing.T) {
 // Launch validation — graceful error handling for bad config
 // ---------------------------------------------------------------------------
 
-func TestResolveShellAndLaunch_InvalidShell_SetsStatusErr(t *testing.T) {
+func TestResolveShellAndLaunch_UnknownShellName_FallsBackSilently(t *testing.T) {
 	m := newTestModel()
 	m.cfg.DefaultShell = "nonexistent-shell-999"
-	// No shells detected, so findShellByName falls back to DefaultShell()
-	// which should have a path, but if the configured name is wrong
-	// the user should get feedback.
 	m.shells = nil
+	// An unknown configured shell name does NOT set statusErr: findShellByName
+	// silently falls back to platform.DefaultShell(), which resolves to a valid
+	// shell (cmd.exe on Windows), so the launch proceeds without any warning.
+	// This is inconsistent with the empty-path case below, which does warn.
+	// This test is named for what it actually verifies, not for the warning a
+	// reader might expect.
 	cmd := m.resolveShellAndLaunch("s1", "/test", config.LaunchModeTab)
-	// On a real system DefaultShell() returns a valid path, so cmd should be non-nil.
 	if cmd == nil {
-		t.Log("resolveShellAndLaunch returned nil; DefaultShell() may have failed on this platform")
+		t.Fatal("unknown shell name should fall back to the platform default and return a launch cmd")
+	}
+	if m.statusErr != "" {
+		t.Errorf("unknown shell name should fall back silently, but statusErr = %q", m.statusErr)
 	}
 }
 
@@ -4321,11 +4501,15 @@ func TestResolveShellAndLaunchDirect_NoShells_UsesDefault(t *testing.T) {
 	m := newTestModel()
 	m.cfg.DefaultShell = ""
 	m.shells = nil
-	// DefaultShell() should succeed on any real OS, so cmd should be non-nil.
+	// With no configured or detected shells, the direct launch path uses
+	// platform.DefaultShell() (cmd.exe on Windows), which has a valid path,
+	// so it returns a launch cmd without setting an error.
 	cmd := m.resolveShellAndLaunchDirect("s1", "/test", config.LaunchModeTab)
-	// DefaultShell() should succeed on any real OS, so cmd should be non-nil.
 	if cmd == nil {
-		t.Log("resolveShellAndLaunchDirect returned nil; DefaultShell() may have failed on this platform")
+		t.Fatal("no shells should fall back to the platform default and return a launch cmd")
+	}
+	if m.statusErr != "" {
+		t.Errorf("default-shell fallback should not set statusErr, got %q", m.statusErr)
 	}
 }
 

--- a/internal/tui/model_update_test.go
+++ b/internal/tui/model_update_test.go
@@ -4448,22 +4448,22 @@ func TestAttentionPriority(t *testing.T) {
 // Launch validation — graceful error handling for bad config
 // ---------------------------------------------------------------------------
 
-func TestResolveShellAndLaunch_UnknownShellName_FallsBackSilently(t *testing.T) {
+func TestResolveShellAndLaunch_UnknownShellName_WarnsAndUsesDefault(t *testing.T) {
 	m := newTestModel()
 	m.cfg.DefaultShell = "nonexistent-shell-999"
 	m.shells = nil
-	// An unknown configured shell name does NOT set statusErr: findShellByName
-	// silently falls back to platform.DefaultShell(), which resolves to a valid
-	// shell (cmd.exe on Windows), so the launch proceeds without any warning.
-	// This is inconsistent with the empty-path case below, which does warn.
-	// This test is named for what it actually verifies, not for the warning a
-	// reader might expect.
+	// An unknown configured shell name still launches, using the platform
+	// default, but it must say so. Substituting a different shell without
+	// telling the user leaves them believing their configured shell applied.
 	cmd := m.resolveShellAndLaunch("s1", "/test", config.LaunchModeTab)
 	if cmd == nil {
 		t.Fatal("unknown shell name should fall back to the platform default and return a launch cmd")
 	}
-	if m.statusErr != "" {
-		t.Errorf("unknown shell name should fall back silently, but statusErr = %q", m.statusErr)
+	if m.statusErr == "" {
+		t.Fatal("unknown shell name should report the substitution, but statusErr was empty")
+	}
+	if !strings.Contains(m.statusErr, "nonexistent-shell-999") {
+		t.Errorf("statusErr = %q, want it to name the configured shell that was not found", m.statusErr)
 	}
 }
 

--- a/internal/tui/styles/scheme_test.go
+++ b/internal/tui/styles/scheme_test.go
@@ -373,3 +373,46 @@ func TestSetTheme_UpdatesExportedVars(t *testing.T) {
 		t.Error("TitleStyle.Render produced empty string after SetTheme")
 	}
 }
+
+// TestSetTheme_CurrentThemeRoundTrips proves that snapshotting the active theme
+// and replaying it restores the exported styles unchanged.
+//
+// applyLegacyDefaults assigns the exported style variables directly, so if the
+// Theme it builds did not also carry those styles, this round-trip would copy
+// zero Styles over every exported variable instead of restoring them. That
+// failure is silent: a zero lipgloss.Style still renders, it just loses padding
+// and colour, which changes rendered widths for anything laid out afterwards.
+// Several tests here and in internal/tui rely on exactly this save and restore.
+func TestSetTheme_CurrentThemeRoundTrips(t *testing.T) {
+	ApplyAutoTheme(true)
+	t.Cleanup(func() { ApplyAutoTheme(true) })
+
+	snapshot := CurrentTheme()
+	styleByName := func() map[string]string {
+		return map[string]string{
+			"TitleStyle":         TitleStyle.Render("x"),
+			"StatusBarStyle":     StatusBarStyle.Render("x"),
+			"PreviewBorderStyle": PreviewBorderStyle.Render("x"),
+			"BadgeStyle":         BadgeStyle.Render("x"),
+			"SelectedStyle":      SelectedStyle.Render("x"),
+			"GitDirtyStyle":      GitDirtyStyle.Render("x"),
+		}
+	}
+	want := styleByName()
+
+	// Guard the guard: if the defaults rendered as bare text, the comparison
+	// below would pass even against a blanked style and prove nothing.
+	if want["TitleStyle"] == "x" && want["StatusBarStyle"] == "x" {
+		t.Fatal("legacy default styles render as plain text, so this test cannot detect a blanked style")
+	}
+
+	// Switch away, then replay the snapshot taken before the switch.
+	SetTheme(DeriveTheme(Campbell))
+	SetTheme(snapshot)
+
+	for name, got := range styleByName() {
+		if got != want[name] {
+			t.Errorf("%s not restored by SetTheme(CurrentTheme()): got %q, want %q", name, got, want[name])
+		}
+	}
+}

--- a/internal/tui/styles/theme.go
+++ b/internal/tui/styles/theme.go
@@ -402,6 +402,12 @@ func applyLegacyDefaults(isDark bool) {
 	GitMissingStyle = lipgloss.NewStyle().Foreground(le).Bold(true)
 
 	// Build a Theme struct so CurrentTheme() is never nil.
+	//
+	// The style fields must mirror the exported variables assigned above.
+	// CurrentTheme() is the only snapshot callers can take, so if these were
+	// left zero, the round-trip SetTheme(CurrentTheme()) would blank every
+	// exported style rather than restoring it. A zero lipgloss.Style also
+	// drops padding, which silently changes rendered widths.
 	primary := "#7C6FF4"
 	text := "#E4E4E7"
 	if !isDark {
@@ -422,6 +428,69 @@ func applyLegacyDefaults(isDark bool) {
 		StatusBg:   "#18181B",
 		HeaderBg:   "#111111",
 		IsDark:     isDark,
+
+		TitleStyle:       TitleStyle,
+		SubtitleStyle:    SubtitleStyle,
+		HeaderStyle:      HeaderStyle,
+		SelectedStyle:    SelectedStyle,
+		NormalStyle:      NormalStyle,
+		DimmedStyle:      DimmedStyle,
+		HiddenStyle:      HiddenStyle,
+		FavoritedStyle:   FavoritedStyle,
+		WaitingRowStyle:  WaitingRowStyle,
+		GroupHeaderStyle: GroupHeaderStyle,
+
+		BadgeStyle:       BadgeStyle,
+		ActiveBadgeStyle: ActiveBadgeStyle,
+
+		PreviewBorder: PreviewBorderStyle,
+		PreviewTitle:  PreviewTitleStyle,
+		PreviewLabel:  PreviewLabelStyle,
+		PreviewValue:  PreviewValueStyle,
+
+		OverlayStyle: OverlayStyle,
+		OverlayTitle: OverlayTitleStyle,
+
+		StatusBar:         StatusBarStyle,
+		SearchPrompt:      SearchPromptStyle,
+		ErrorStyle:        ErrorStyle,
+		SuccessStyle:      SuccessStyle,
+		DimStyle:          DimStyle,
+		KeyStyle:          KeyStyle,
+		SpinnerStyle:      SpinnerStyle,
+		SeparatorStyle:    SeparatorStyle,
+		ConfigLabel:       ConfigLabelStyle,
+		ConfigValue:       ConfigValueStyle,
+		ConfigDimmedValue: ConfigDimmedValue,
+
+		ChatUserBubble:      ChatUserBubbleStyle,
+		ChatAssistantBubble: ChatAssistantBubbleStyle,
+		ChatUserLabel:       ChatUserLabelStyle,
+		ChatAssistantLabel:  ChatAssistantLabelStyle,
+
+		AttentionWaitingStyle:     AttentionWaitingStyle,
+		AttentionActiveStyle:      AttentionActiveStyle,
+		AttentionStaleStyle:       AttentionStaleStyle,
+		AttentionIdleStyle:        AttentionIdleStyle,
+		AttentionInterruptedStyle: AttentionInterruptedStyle,
+		AttentionWorkingStyle:     AttentionWorkingStyle,
+		AttentionThinkingStyle:    AttentionThinkingStyle,
+		AttentionCompactingStyle:  AttentionCompactingStyle,
+
+		PlanIndicatorStyle: PlanIndicatorStyle,
+		NoteIndicatorStyle: NoteIndicatorStyle,
+		TagIndicatorStyle:  TagIndicatorStyle,
+
+		WorkCompleteStyle:   WorkCompleteStyle,
+		WorkIncompleteStyle: WorkIncompleteStyle,
+		WorkAnalyzingStyle:  WorkAnalyzingStyle,
+
+		GitCleanStyle:     GitCleanStyle,
+		GitDirtyStyle:     GitDirtyStyle,
+		GitUntrackedStyle: GitUntrackedStyle,
+		GitAheadStyle:     GitAheadStyle,
+		GitBehindStyle:    GitBehindStyle,
+		GitMissingStyle:   GitMissingStyle,
 	}
 }
 

--- a/internal/update/update_coverage_test.go
+++ b/internal/update/update_coverage_test.go
@@ -852,14 +852,38 @@ func TestValidateVersion_Parallel(t *testing.T) {
 
 func TestReleaseUpdateLock_Nil(t *testing.T) {
 	t.Parallel()
-	// Should not panic.
-	releaseUpdateLock(nil)
+	// A nil lock is a no-op: it must not panic and must not touch the
+	// filesystem. Place a sentinel file and confirm it survives the call.
+	// (Removing the nil guard would panic here, failing the test.)
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, "sentinel.lock")
+	if err := os.WriteFile(sentinel, []byte("keep"), cacheFilePerm); err != nil {
+		t.Fatalf("writing sentinel: %v", err)
+	}
+
+	releaseUpdateLock(nil) // must not panic
+
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Errorf("releaseUpdateLock(nil) must not remove unrelated files: %v", err)
+	}
 }
 
 func TestReleaseUpdateLock_EmptyPath(t *testing.T) {
 	t.Parallel()
-	// Should not panic.
-	releaseUpdateLock(&updateLock{path: ""})
+	// An empty lock path is a no-op: the guard short-circuits before any
+	// os.Remove call. The primary contract is no-panic; we additionally
+	// assert an unrelated pre-existing file is left untouched.
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, "sentinel.lock")
+	if err := os.WriteFile(sentinel, []byte("keep"), cacheFilePerm); err != nil {
+		t.Fatalf("writing sentinel: %v", err)
+	}
+
+	releaseUpdateLock(&updateLock{path: ""}) // must not panic
+
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Errorf("releaseUpdateLock with empty path must not remove unrelated files: %v", err)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -1049,15 +1073,41 @@ func TestCopyFile_DstDirMissing(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestWriteCache_EmptyPath(t *testing.T) {
-	t.Parallel()
-	// When path is empty AND cachePath() can't resolve, writeCache should
-	// silently return without panic.
-	writeCache("", &updateCache{
-		CheckedAt:      time.Now(),
-		LatestVersion:  "1.0.0",
+	// When path is empty, writeCache resolves the default cache location via
+	// cachePath()/ConfigDir and writes there. Point the config dir at a temp
+	// location and assert the cache file lands at the resolved path with the
+	// data we passed. (setConfigDir uses t.Setenv, so no t.Parallel.)
+	tmpDir := t.TempDir()
+	setConfigDir(t, tmpDir)
+
+	dir, err := configDirForTest(tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantPath := filepath.Join(dir, cacheFileName)
+	if _, err := os.Stat(wantPath); err == nil {
+		t.Fatalf("cache file already exists before writeCache: %s", wantPath)
+	}
+
+	cache := &updateCache{
+		CheckedAt:      time.Now().Truncate(time.Second),
+		LatestVersion:  "1.2.3",
 		CurrentVersion: "1.0.0",
-	})
-	// No assertion — just verify no panic.
+	}
+	writeCache("", cache)
+
+	raw, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("writeCache(\"\") should write to the resolved cache path %s: %v", wantPath, err)
+	}
+	var got updateCache
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("cache file is not valid JSON: %v", err)
+	}
+	if got.LatestVersion != cache.LatestVersion || got.CurrentVersion != cache.CurrentVersion {
+		t.Errorf("cache = {latest %q, current %q}, want {latest %q, current %q}",
+			got.LatestVersion, got.CurrentVersion, cache.LatestVersion, cache.CurrentVersion)
+	}
 }
 
 func TestWriteCache_ExplicitPath(t *testing.T) {
@@ -1332,19 +1382,25 @@ func TestAcquireUpdateLock_CreatesMetadata(t *testing.T) {
 
 func TestWriteCache_UnwritableDir(t *testing.T) {
 	t.Parallel()
-	// Path in a non-existent deeply nested location.
-	// writeCache should silently fail (no panic, no error return).
-	badPath := filepath.Join(t.TempDir(), "no", "permissions", "cache.json")
-	writeCache(badPath, &updateCache{
+	// Make writeCache's os.MkdirAll fail deterministically on every OS by
+	// using a regular file as a parent directory component: MkdirAll cannot
+	// create a directory whose ancestor is a file. writeCache is best-effort,
+	// so it must not panic and must not leave a cache file behind.
+	tmpDir := t.TempDir()
+	blocker := filepath.Join(tmpDir, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), cacheFilePerm); err != nil {
+		t.Fatalf("writing blocker file: %v", err)
+	}
+	dstPath := filepath.Join(blocker, "cache.json") // parent "blocker" is a file
+
+	writeCache(dstPath, &updateCache{
 		CheckedAt:      time.Now(),
 		LatestVersion:  "1.0.0",
 		CurrentVersion: "1.0.0",
 	})
-	// Verify it was actually written (MkdirAll succeeds for nested dirs
-	// in a temp directory). This tests the success path through MkdirAll.
-	if _, err := os.Stat(badPath); err != nil {
-		// If it failed, that's OK — writeCache is best-effort.
-		t.Log("writeCache failed for nested path (expected in some environments)")
+
+	if _, err := os.Stat(dstPath); err == nil {
+		t.Error("writeCache must not create a cache file when the parent directory is unwritable")
 	}
 }
 

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,3 +1,12 @@
 # Keep dependency resolution strict so missing peer dependencies fail locally
 # and in CI instead of producing an incomplete installation.
 legacy-peer-deps=false
+
+# Refuse to resolve a release published within this many days. Compromised and
+# malicious releases are usually found and pulled within days of publication,
+# so letting a release age is cheap protection. Dependabot applies the same
+# 3 day default to its own pull requests; matching it here extends the same
+# floor to local and CI installs, which Dependabot's cooldown does not cover,
+# without holding back a bump the bot has already opened.
+# Unit is days, and the setting requires npm 11.10.0 or later.
+min-release-age=3


### PR DESCRIPTION
## What this is

A quality pass that started as a test-health audit and turned up four production bugs, all of the same shape: code that silently discards information someone needed.

## Tests that verified nothing

78 of 2,873 tests contained no assertion at all. Each would still have passed with the function under test replaced by an empty body.

- Added real assertions to 74 tests across 29 files. The 4 remaining are documented exceptions: two explicit no-panic contracts, one smoke contract, and the standard `exec` helper subprocess.
- `internal/tui/components/sessionpickerview.go` had all 7 functions at **0%**. It is now at **100%**, lifting that package to 89.8%.
- `TestSessionStatePath_UNCPath` guarded a security boundary (UNC rejection stops session state loading from an attacker-controlled network share) and discarded the result. It now asserts the contract on both platform branches.
- Five tests called `t.Skip` when their own fully deterministic setup failed, so a regression would have made them vanish rather than fail. They now call `t.Fatal`.
- Two tests had names that contradicted what they asserted. Renamed.

Total coverage 84.3% to 84.7%.

## Four production bugs

**`styles`: `SetTheme(CurrentTheme())` did not round-trip.** `applyLegacyDefaults` assigned the exported style variables directly, then built a `Theme` carrying only colour fields. The style fields were left as the zero `Style`, so the natural save-and-restore copied zero Styles over every exported variable. A zero `lipgloss.Style` still renders, it just loses padding, so this surfaced only as changed layout widths much later. Existing tests in `scheme_test.go` already used this pattern and were silently blanking global styles.

**`platform`: `OpenFile` did not validate its path.** `OpenDir` and `OpenURL` both do. The OS openers detach and report a missing path through their own UI rather than the exit status, so a bad path was indistinguishable from a successful open. Validation now lives in `OpenFile` and `openFileCmd` no longer duplicates it.

**`tui`: an unknown configured shell was silently swapped.** `findShellByName` fell back to the platform default, and the caller only errored when the resulting path was empty, which it never was. A user whose configured shell was missing got a different shell with no indication. Both launch paths now name the substitution.

**`tui`: two status messages could never be displayed.** `batchLaunchSessions` cleared `statusInfo` just before returning, wiping both its own "Launching first N sessions (limit)" notice and the "Resuming N interrupted sessions" notice set by `handleResumeInterrupted`. The stale selection status is now cleared on entry instead.

Each fix has a regression test that fails if the bug returns.

## An order-dependent flake, found and fixed

Preflight's shuffled run failed while the unshuffled runs passed. The cause was the theme round-trip bug above, reached through two new tests that saved and restored theme state. Because a blanked style drops padding, it shifted rendered widths and broke an unrelated wrapped-row alignment test hundreds of tests later.

Was 5/10 seeds failing. Now **0/12 shuffled runs** across the changed packages.

## Dependencies

- `charm.land/bubbles/v2` v2.1.1 to v2.2.0. Additive release, no breaking changes, no new transitive packages. v2.2.1 was withheld as too new; its only fix is a `textarea` freeze and this project does not import `textarea`, so it is unreachable here.
- Dependabot's open PRs (bubbletea, sqlite, astro, marked) were deliberately left alone rather than duplicated.
- Added `min-release-age=3` to `web/.npmrc`. Dependabot's cooldown only governs its own PRs, so local and CI installs previously had no age protection. Matched to Dependabot's default so it does not block a bump the bot has already opened.

## Validation

- `mage preflight` 13/13: gofmt, gofumpt, `go vet`, golangci-lint (0 issues, also `GOOS=linux`), build, tests, race detector, govulncheck, dead code, install.
- 12 shuffled-order runs across the changed packages, 0 failures.
- `osv-scanner` across 48 Go and 399 npm packages: no issues. This closes a gap from the earlier audit, where the known-malicious (`MAL-`) screen had never run.
- `npm ci` resolves the committed lockfile and the site still builds.

## Note for review

`internal/tui/model_update_test.go` accounts for most of the line count and is almost entirely added assertions. The behavioral changes worth your attention are in `internal/tui/styles/theme.go`, `internal/platform/open.go`, and the two `internal/tui/model.go` hunks.