### PR TITLE
chore(deps): update bubbles to v2.2.1 and deny the esbuild install script

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/jongio/dispatch
 go 1.26.6
 
 require (
-	charm.land/bubbles/v2 v2.2.0
+	charm.land/bubbles/v2 v2.2.1
 	charm.land/bubbletea/v2 v2.0.9
 	charm.land/glamour/v2 v2.0.1
 	charm.land/lipgloss/v2 v2.0.6

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-charm.land/bubbles/v2 v2.2.0 h1:9GEMewcejrNtVIxZ9Y2wSsWJamsWNsXa8MpMLnH4yI4=
-charm.land/bubbles/v2 v2.2.0/go.mod h1:wdMgn+sje1KNXdwFizIWjbf328fIUBxqEmJ/vYPo8yc=
+charm.land/bubbles/v2 v2.2.1 h1:Fq1+qm5hV6GkvzLQDhCBpXXE5tLgvh1PRriCLwSvIQU=
+charm.land/bubbles/v2 v2.2.1/go.mod h1:wdMgn+sje1KNXdwFizIWjbf328fIUBxqEmJ/vYPo8yc=
 charm.land/bubbletea/v2 v2.0.9 h1:DpJCMWKgzQK8SJv4zbKKFHAI10ymWy/evClPFk0k0f8=
 charm.land/bubbletea/v2 v2.0.9/go.mod h1:2SkdgoTXluXJHOUwAoRlRXF/28vklb1rFl6GcgV1/ss=
 charm.land/glamour/v2 v2.0.1 h1:xl+r00A4aJWU0z8fgwKd9fQQ4rsphqGUzuEiXZP5n+c=

--- a/web/package.json
+++ b/web/package.json
@@ -26,5 +26,8 @@
   },
   "overrides": {
     "volar-service-yaml": "0.0.71"
+  },
+  "allowScripts": {
+    "esbuild": false
   }
 }


### PR DESCRIPTION
## What

Two dependency-maintenance changes.

- `charm.land/bubbles/v2` v2.2.0 to v2.2.1
- `web/package.json` records `allowScripts: { "esbuild": false }`, denying esbuild's `postinstall`

## Why

**bubbles v2.2.1** was withheld from the previous dependency pass because it was under the 3 day minimum release age. It is now past that window. The release fixes a `textarea` word-left freeze. Dispatch does not import `textarea`, so this is currency rather than a fix that reaches users here.

**esbuild** ships a `postinstall` of `node install.js`, which npm 11 reports on every install because the package is not covered by `allowScripts`. The script is not needed: `@esbuild/win32-x64` arrives through `optionalDependencies`, and the lockfile carries the linux and darwin variants the same way. The binary reports `0.28.1` and the site builds with the script blocked. Approving it would allow package-authored code to run at install time for no benefit, so it is denied instead. That records the decision, silences the warning, and keeps the script blocked.

## How

`go get charm.land/bubbles/v2@v2.2.1` followed by `go mod tidy`. Only bubbles moved in `go.sum`; no new transitive packages entered the graph.

The npm change was written by `npm install-scripts deny esbuild` rather than edited by hand, so the key matches what the installed npm reads.

`web/package-lock.json` is deliberately absent from the diff: denying a script changes install policy, not resolution.

No CHANGELOG entry: routine dependency bumps in this repo are rolled up at release time under "Toolchain and dependencies" rather than recorded individually.

## Testing

- [x] `go build ./cmd/dispatch/` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] New tests added for new functionality (not applicable, no behavior change)
- [x] Existing tests still pass

`mage preflight` 13/13 at this HEAD, including the race detector, `govulncheck`, `gofumpt`, `golangci-lint`, and dead-code detection.

Supply chain: `go mod verify` passed, `osv-scanner` found no issues across 48 Go and 392 npm packages, `npm audit` reports 0 vulnerabilities. `npm ci` reproduces the committed lockfile and the website builds with the esbuild script denied.

## Screenshots

Not applicable, no UI change.