### PR TITLE
feat(export): include the session plan in exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Named views come from the `views` array in `config.json`. `dispatch views use <n
 
 ### Export
 
-Save a full session (metadata and the complete conversation) to a file with `dispatch export <id>`:
+Save a full session (metadata, the plan if one exists, and the complete conversation) to a file with `dispatch export <id>`:
 
 ```sh
 dispatch export 0a1b2c3d
@@ -324,7 +324,7 @@ dispatch export 0a1b2c3d --redact --stdout
 dispatch export 0a1b2c3d --out ./exports
 ```
 
-By default the session is written as Markdown to the exports directory. Use `--format json` for machine-readable output, `--format html` for a self-contained web page you can open in a browser, or `--format text` for plain text. Use `--stdout` to print to the terminal instead of writing a file, `--out <dir>` to choose the destination directory, and `--redact` to mask common secret patterns before writing. `--stdout` and `--out` cannot be combined.
+By default the session is written as Markdown to the exports directory. Use `--format json` for machine-readable output, `--format html` for a self-contained web page you can open in a browser, or `--format text` for plain text. Use `--stdout` to print to the terminal instead of writing a file, `--out <dir>` to choose the destination directory, and `--redact` to mask common secret patterns before writing. `--stdout` and `--out` cannot be combined. When the session has a `plan.md`, its content is included as a Plan section in every format, and as a `plan` field in JSON.
 
 #### Batch Export
 

--- a/cmd/dispatch/export.go
+++ b/cmd/dispatch/export.go
@@ -262,6 +262,11 @@ func redactedSessionDetail(detail *data.SessionDetail) *data.SessionDetail {
 	redacted.Session.Branch = platform.RedactSecrets(redacted.Session.Branch)
 	redacted.Session.Summary = platform.RedactSecrets(redacted.Session.Summary)
 
+	// The plan is copied by the struct assignment above, so it has to be
+	// redacted explicitly. A plan is prose the user wrote and is a likely
+	// place for a pasted token, so leaving it raw would defeat --redact.
+	redacted.Plan = platform.RedactSecrets(detail.Plan)
+
 	if len(detail.Turns) > 0 {
 		redacted.Turns = append([]data.Turn(nil), detail.Turns...)
 		for i := range redacted.Turns {
@@ -340,6 +345,7 @@ func writeExportFile(dir, id, format, content string) (string, error) {
 // session store. The ID may be a full session ID or a unique short prefix. It
 // returns (nil, nil) when no session matches, and an *data.AmbiguousIDPrefixError
 // when a short prefix matches more than one session.
+// When the session has a plan.md file, its content is attached to the detail.
 func defaultExportGetDetail(id string) (*data.SessionDetail, error) {
 	store, err := data.Open()
 	if err != nil {
@@ -362,6 +368,15 @@ func defaultExportGetDetail(id string) (*data.SessionDetail, error) {
 			return nil, nil
 		}
 		return nil, err
+	}
+
+	// Attach the session's plan.md when present. A missing or unreadable plan
+	// is normal (most sessions have none), so read errors are ignored and the
+	// plan is simply left out of the export.
+	if detail != nil {
+		if plan, perr := data.ReadPlanContent(detail.Session.ID); perr == nil {
+			detail.Plan = plan
+		}
 	}
 	return detail, nil
 }

--- a/cmd/dispatch/export_test.go
+++ b/cmd/dispatch/export_test.go
@@ -148,6 +148,50 @@ func TestRunExport_StdoutJSON(t *testing.T) {
 	}
 }
 
+func TestRunExport_IncludesPlan(t *testing.T) {
+	withExportDetail(t, func(string) (*data.SessionDetail, error) {
+		d := sampleDetail()
+		d.Plan = "# Goal\n\nShip the widget fix.\n"
+		return d, nil
+	})
+
+	// Markdown output carries a Plan section.
+	var md bytes.Buffer
+	if err := runExport(&md, []string{"export", "ses-001", "--stdout"}); err != nil {
+		t.Fatalf("runExport md: %v", err)
+	}
+	if !strings.Contains(md.String(), "## Plan") || !strings.Contains(md.String(), "Ship the widget fix.") {
+		t.Errorf("markdown output missing plan, got:\n%s", md.String())
+	}
+
+	// JSON output carries the plan field.
+	var js bytes.Buffer
+	if err := runExport(&js, []string{"export", "ses-001", "--stdout", "--format", "json"}); err != nil {
+		t.Fatalf("runExport json: %v", err)
+	}
+	var got data.SessionDetail
+	if err := json.Unmarshal(js.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if !strings.Contains(got.Plan, "Ship the widget fix.") {
+		t.Errorf("json plan = %q, want it to contain the plan body", got.Plan)
+	}
+}
+
+func TestRunExport_OmitsPlanWhenAbsent(t *testing.T) {
+	withExportDetail(t, func(string) (*data.SessionDetail, error) { return sampleDetail(), nil })
+
+	var js bytes.Buffer
+	if err := runExport(&js, []string{"export", "ses-001", "--stdout", "--format", "json"}); err != nil {
+		t.Fatalf("runExport json: %v", err)
+	}
+	// Plan is tagged omitempty, so an absent plan must not appear at all
+	// rather than serializing as an empty string.
+	if strings.Contains(js.String(), "\"plan\"") {
+		t.Errorf("json should omit plan when empty, got:\n%s", js.String())
+	}
+}
+
 func TestRunExport_RedactsStdout(t *testing.T) {
 	detail := sampleDetail()
 	detail.Turns = []data.Turn{
@@ -162,6 +206,28 @@ func TestRunExport_RedactsStdout(t *testing.T) {
 	out := buf.String()
 	if strings.Contains(out, "abcdefghijklmnopqrstuvwxyz123456") || strings.Contains(out, "super-secret-token") {
 		t.Fatalf("redacted export leaked a secret:\n%s", out)
+	}
+	if !strings.Contains(out, "[redacted]") {
+		t.Fatalf("redacted export missing placeholder:\n%s", out)
+	}
+}
+
+func TestRunExport_RedactsPlan(t *testing.T) {
+	// A plan is prose the user wrote and is a likely place for a pasted
+	// token, so --redact has to cover it the same way it covers turns.
+	// The env-style pattern is line-anchored, so the assignment sits at the
+	// start of its own line the way it would in a real pasted snippet.
+	detail := sampleDetail()
+	detail.Plan = "# Goal\n\nDeploy with:\n\nAPI_TOKEN=super-secret-token\n"
+	withExportDetail(t, func(string) (*data.SessionDetail, error) { return detail, nil })
+
+	var buf bytes.Buffer
+	if err := runExport(&buf, []string{"export", "ses-001", "--stdout", "--redact"}); err != nil {
+		t.Fatalf("runExport: %v", err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "super-secret-token") {
+		t.Fatalf("redacted export leaked a secret from the plan:\n%s", out)
 	}
 	if !strings.Contains(out, "[redacted]") {
 		t.Fatalf("redacted export missing placeholder:\n%s", out)

--- a/internal/data/export.go
+++ b/internal/data/export.go
@@ -67,6 +67,12 @@ func RenderMarkdown(detail *SessionDetail) string {
 	fmt.Fprintf(&b, "| Files | %d |\n", s.FileCount)
 	b.WriteString("\n")
 
+	// ── Plan ──
+	if detail.Plan != "" {
+		b.WriteString("## Plan\n\n")
+		b.WriteString(strings.TrimRight(detail.Plan, "\n") + "\n\n")
+	}
+
 	// ── Conversation ──
 	if len(detail.Turns) > 0 {
 		b.WriteString("## Conversation\n\n")
@@ -150,6 +156,12 @@ func RenderText(detail *SessionDetail) string {
 	fmt.Fprintf(&b, "Last Active: %s\n", s.LastActiveAt)
 	fmt.Fprintf(&b, "Turns: %d\n", s.TurnCount)
 	fmt.Fprintf(&b, "Files: %d\n\n", s.FileCount)
+
+	// Plan, before the conversation so it reads as context.
+	if detail.Plan != "" {
+		b.WriteString("Plan\n\n")
+		b.WriteString(strings.TrimRight(detail.Plan, "\n") + "\n\n")
+	}
 
 	if len(detail.Turns) > 0 {
 		b.WriteString("Conversation\n\n")
@@ -259,6 +271,14 @@ func RenderHTML(detail *SessionDetail) string {
 	fmt.Fprintf(&b, "<tr><td>Turns</td><td>%d</td></tr>\n", s.TurnCount)
 	fmt.Fprintf(&b, "<tr><td>Files</td><td>%d</td></tr>\n", s.FileCount)
 	b.WriteString("</table>\n")
+
+	// Plan, before the conversation so it reads as context. The body is
+	// escaped like every other user-supplied value and wrapped in <pre> so
+	// the plan's own Markdown layout survives.
+	if detail.Plan != "" {
+		b.WriteString("<h2>Plan</h2>\n")
+		fmt.Fprintf(&b, "<pre>%s</pre>\n", esc(strings.TrimRight(detail.Plan, "\n")))
+	}
 
 	// Conversation.
 	if len(detail.Turns) > 0 {

--- a/internal/data/export_test.go
+++ b/internal/data/export_test.go
@@ -293,6 +293,115 @@ func TestRenderMarkdown_MinimalDetail(t *testing.T) {
 	if strings.Contains(md, "## References") {
 		t.Error("references section should be absent with no refs")
 	}
+	if strings.Contains(md, "## Plan") {
+		t.Error("plan section should be absent when Plan is empty")
+	}
+}
+
+func TestRenderMarkdown_Plan(t *testing.T) {
+	detail := &SessionDetail{
+		Session: Session{ID: "plan-session", Summary: "Has a plan"},
+		Turns: []Turn{
+			{TurnIndex: 0, UserMessage: "start", AssistantResponse: "ok"},
+		},
+		Plan: "# Goal\n\nShip the feature.\n",
+	}
+
+	md := RenderMarkdown(detail)
+
+	if !strings.Contains(md, "## Plan") {
+		t.Fatal("missing plan section")
+	}
+	if !strings.Contains(md, "Ship the feature.") {
+		t.Error("missing plan body")
+	}
+	// The plan should render before the conversation so it reads as context.
+	if strings.Index(md, "## Plan") > strings.Index(md, "## Conversation") {
+		t.Error("plan section should appear before conversation")
+	}
+}
+
+func TestRenderText_Plan(t *testing.T) {
+	detail := &SessionDetail{
+		Session: Session{ID: "plan-session", Summary: "Has a plan"},
+		Turns: []Turn{
+			{TurnIndex: 0, UserMessage: "start", AssistantResponse: "ok"},
+		},
+		Plan: "# Goal\n\nShip the feature.\n",
+	}
+
+	txt := RenderText(detail)
+
+	if !strings.Contains(txt, "Plan") {
+		t.Fatal("missing plan section")
+	}
+	if !strings.Contains(txt, "Ship the feature.") {
+		t.Error("missing plan body")
+	}
+	if strings.Index(txt, "Plan") > strings.Index(txt, "Conversation") {
+		t.Error("plan section should appear before conversation")
+	}
+}
+
+func TestRenderText_NoPlanSectionWhenEmpty(t *testing.T) {
+	detail := &SessionDetail{
+		Session: Session{ID: "no-plan", Summary: "No plan"},
+		Turns:   []Turn{{TurnIndex: 0, UserMessage: "start"}},
+	}
+
+	if strings.Contains(RenderText(detail), "\nPlan\n") {
+		t.Error("plan section should be absent when Plan is empty")
+	}
+}
+
+func TestRenderHTML_Plan(t *testing.T) {
+	detail := &SessionDetail{
+		Session: Session{ID: "plan-session", Summary: "Has a plan"},
+		Turns: []Turn{
+			{TurnIndex: 0, UserMessage: "start", AssistantResponse: "ok"},
+		},
+		Plan: "# Goal\n\nShip the feature.\n",
+	}
+
+	out := RenderHTML(detail)
+
+	if !strings.Contains(out, "<h2>Plan</h2>") {
+		t.Fatal("missing plan heading")
+	}
+	if !strings.Contains(out, "Ship the feature.") {
+		t.Error("missing plan body")
+	}
+	if strings.Index(out, "<h2>Plan</h2>") > strings.Index(out, "<h2>Conversation</h2>") {
+		t.Error("plan section should appear before conversation")
+	}
+}
+
+func TestRenderHTML_EscapesPlan(t *testing.T) {
+	// Plan content is user-supplied, so it must be escaped like every other
+	// value rather than injected into the page as markup.
+	detail := &SessionDetail{
+		Session: Session{ID: "plan-session", Summary: "Has a plan"},
+		Plan:    "<script>alert('x')</script>",
+	}
+
+	out := RenderHTML(detail)
+
+	if strings.Contains(out, "<script>alert") {
+		t.Error("plan content was not escaped")
+	}
+	if !strings.Contains(out, "&lt;script&gt;") {
+		t.Error("expected the plan body to be HTML-escaped")
+	}
+}
+
+func TestRenderHTML_NoPlanSectionWhenEmpty(t *testing.T) {
+	detail := &SessionDetail{
+		Session: Session{ID: "no-plan", Summary: "No plan"},
+	}
+
+	if strings.Contains(RenderHTML(detail), "<h2>Plan</h2>") {
+		t.Error("plan section should be absent when Plan is empty")
+	}
 }
 
 func TestExportSession(t *testing.T) {

--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -289,4 +289,8 @@ type SessionDetail struct {
 	Checkpoints []Checkpoint  `json:"checkpoints"`
 	Files       []SessionFile `json:"files"`
 	Refs        []SessionRef  `json:"refs"`
+	// Plan holds the session's plan.md content when one exists. It is filled
+	// in on demand by the export command and stays empty otherwise, so it is
+	// omitted from JSON when absent.
+	Plan string `json:"plan,omitempty"`
 }


### PR DESCRIPTION
## What

`dispatch export` now includes the session's `plan.md` when one exists.

- `SessionDetail` gains a `Plan` field, tagged `omitempty`
- `defaultExportGetDetail` attaches `plan.md` when present
- All four formats render it: a Plan section in Markdown, text, and HTML, and a `plan` field in JSON
- `--redact` covers the plan

## Why

Export wrote metadata and the full conversation but never the plan, so the document describing what the session set out to do was the one part missing from its own export.

## How

The plan renders before the conversation in every format, so it reads as context for what follows.

A missing or unreadable `plan.md` is treated as normal rather than an error, since most sessions have none. `omitempty` keeps sessions without a plan byte-identical in JSON.

Two things worth flagging for review:

**Format parity.** This work originally covered only Markdown and JSON. `--format html` and `--format text` were added to export since then, so wiring only the original two would have left the plan invisible in half the formats. All four are wired, each with a test. The HTML body is escaped like every other user-supplied value and wrapped in `<pre>` so the plan's own Markdown layout survives.

**Redaction.** `redactedSessionDetail` builds its copy by struct assignment, so a newly added field passes through verbatim unless it is redacted explicitly. A plan is prose the user wrote and a likely place for a pasted token, so `--redact` would have masked the conversation while leaking straight out of the plan. `TestRunExport_RedactsPlan` fails when the redaction line is removed, so it cannot silently regress.

## Testing

- [x] `go build ./cmd/dispatch/` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] New tests added for new functionality
- [x] Existing tests still pass

Nine new tests: plan present and absent in each of the four formats, section ordering, HTML escaping of plan content, JSON `omitempty`, and the redaction regression.

`mage preflight` 13/13, including the race detector, `govulncheck`, `gofumpt`, `golangci-lint`, and dead-code detection.

## Screenshots

Not applicable, no UI change.