### PR TITLE
docs: refresh CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,7 +6,9 @@ This file is auto-generated. Run `mage contributors` to update.
 
 ## Contributors
 
-- **Jon Gallant** (@jongio) -- 112 contributions
-- **Copilot** (@Copilot) -- 99 contributions
+- **Jon Gallant** (@jongio) -- 460 contributions
+- **Copilot App** (@Copilot) -- 321 contributions
+- **Jon Gallant** -- 23 contributions
+- **jongio** (@jongio) -- 3 contributions
 - **Wallace Breza** -- 2 contributions
 - **Wallace Breza** -- 1 contribution


### PR DESCRIPTION
## What

Regenerates `CONTRIBUTORS.md`, which had drifted far out of date.

```
before:  Jon Gallant 112 · Copilot 99            (4 entries)
after:   Jon Gallant 460 · Copilot App 321       (6 entries)
```

## Why

The release workflow already regenerates this file, but it publishes the result to an `auto/contributors-<tag>` branch and then tries to open a pull request. That call has been failing:

```
pull request create failed: GraphQL: GitHub Actions is not permitted
to create or approve pull requests (createPullRequest)
##[warning]Could not create contributor PR — merge the branch manually
```

The failure is swallowed by `|| echo "::warning::..."`, so the release still succeeds and nothing surfaces. Every release since v0.10.3 left an orphan branch behind and main kept the stale file. Seventeen of those branches had accumulated; they have now been cleaned up.

## How

Regenerated with the same command the workflow runs, `go run ./cmd/contributors/ --all`, rather than editing the generated file by hand. Confirmed the output is byte-identical on a second run, so this is not a file that will flap on every regeneration.

## Two follow-ups, not included here

**1. The workflow will keep creating orphan branches until a repository setting changes.** This PR fixes the stale data but not the cause. Under Settings, Actions, General, Workflow permissions, the option "Allow GitHub Actions to create and approve pull requests" needs to be enabled. I can't change repository settings, so this one needs a maintainer. The alternative is to have the workflow commit `CONTRIBUTORS.md` directly to main instead of opening a pull request.

**2. Duplicate identities could be consolidated with a `.mailmap`.** The list shows `Jon Gallant` and `Wallace Breza` twice each, because commits were authored under two email addresses per person. The generator formats with `%aN`/`%aE`, which already respect `.mailmap`, so adding one would merge these without touching the generator. There is no `.mailmap` in the repo today. Left out of this PR because it changes attribution and is a judgment call for the maintainer.

## Testing

- [x] `go build ./cmd/dispatch/` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [ ] New tests added for new functionality (not applicable, generated content only)
- [x] Existing tests still pass

`go test ./cmd/contributors/ ./internal/contributors/` passes. Documentation-only change, so the full quality pipeline was not re-run.

## Screenshots

Not applicable.